### PR TITLE
Polish README: post-v1.0 legend and diagram cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,7 @@ Multiple agents working in parallel on a shared project, coordinating through fi
 graph TD
     P["📁 Project"]
     P --> A1["🤖 Agent A"] & A2["🤖 Agent B"] & A3["🤖 Agent C"]
-    A1 -.-> F["💬 Shared Findings"]
-    A2 -.-> F
-    A3 -.-> F
-    F -.-> A1
-    F -.-> A2
-    F -.-> A3
+    A1 & A2 & A3 <-.-> F["💬 Shared Findings"]
 ```
 
 #### 🐝 Swarm [⭐#38](https://github.com/nick-pape/grackle/issues/38)


### PR DESCRIPTION
## Summary
- Replace ✴️ coming-soon markers with ⭐ and add footer legend: "Planned post v1.0"
- Distinguish roadmap tiers: Copilot is planned for v1.0 (no marker), Codex/Goose/SSH are ⭐ post-v1.0
- Mark Team and Auditable Artifacts sections as ⭐ (basic form today, full vision post-v1.0)
- Fix Team diagram: agents now produce separate finding boxes instead of all converging on one
- Simplify Architecture diagram: remove Local and Copilot nodes, drop "spawns" labels
- Update SSH environment status to ⭐ Post v1.0

## Test plan
- [ ] Verify mermaid diagrams render correctly on GitHub
- [ ] Check ⭐ markers match v1.0.0 milestone scope