### PR TITLE
Fix CI check name for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [22]
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install


### PR DESCRIPTION
## Summary

The CI workflow used a `strategy.matrix` with a single Node version `[22]`, which caused GitHub to name the status check `build (22)` instead of `build`. This made it impossible to add as a required check in branch protection rules.

Removes the unnecessary matrix so the check shows up as just `build`.

## Test plan

- [ ] After this PR's CI runs, verify the check appears as `build` (not `build (22)`)
- [ ] Add `build` as a required status check in repo Settings > Rules