### PR TITLE
Fix checkout after squash-merge in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,9 +80,12 @@ jobs:
 
           gh pr merge "$pr_url" --squash --admin --delete-branch
 
+      # After squash-merge, local main has diverged from origin/main
+      # (rush merged the temp branch locally, but the PR was squash-merged).
+      # Reset to origin/main to get the squashed result.
       - name: Checkout updated main
         if: steps.bump.outputs.has_bump == 'true'
-        run: git checkout main && git pull origin main
+        run: git fetch origin main && git checkout -B main origin/main
 
       - name: Build
         run: node common/scripts/install-run-rush.js build


### PR DESCRIPTION
## Summary

Fixes the publish workflow failing at "Checkout updated main" with `fatal: Need to specify how to reconcile divergent branches.`

After `rush version --bump` merges the temp branch into local main (2 commits), and the PR is squash-merged on origin/main (1 different commit), local and remote main diverge. `git pull` fails because it doesn't know how to reconcile them.

Fix: use `git checkout -B main origin/main` to reset local main to the squash-merged result.

## Context

Failed run: https://github.com/nick-pape/grackle/actions/runs/22814786313

## Test plan

- [ ] Merge this, delete the failed v0.0.1 release, create a new one
- [ ] Verify all steps pass through to npm publish