### PR TITLE
Handle port conflicts gracefully in server and PowerLine

### DIFF
--- a/common/changes/@grackle-ai/cli/graceful-port-conflicts_2026-03-11-05-24.json
+++ b/common/changes/@grackle-ai/cli/graceful-port-conflicts_2026-03-11-05-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Handle port conflicts gracefully with controlled shutdown instead of hard exit",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/powerline/src/index.ts
+++ b/packages/powerline/src/index.ts
@@ -59,10 +59,11 @@ function main(): void {
       server.on("error", (err: NodeJS.ErrnoException) => {
         if (err.code === "EADDRINUSE") {
           logger.fatal({ port }, "Port %d is already in use. Is another PowerLine running?", port);
-          process.exit(1);
+        } else {
+          logger.fatal({ err }, "PowerLine server error");
         }
-        logger.fatal({ err }, "PowerLine server error");
-        process.exit(1);
+        process.exitCode = 1;
+        shutdown();
       });
 
       server.listen(port, () => {
@@ -73,8 +74,9 @@ function main(): void {
       // Graceful shutdown
       function shutdown(): void {
         logger.info("Shutting down PowerLine...");
-        server.close();
-        process.exit(0);
+        server.close(() => {
+          process.exit(process.exitCode || 0);
+        });
       }
 
       process.on("SIGINT", shutdown);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -136,10 +136,11 @@ function main(): void {
   grpcServer.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
       logger.fatal({ port: grpcPort }, "Port %d is already in use. Is another Grackle server running?", grpcPort);
-      process.exit(1);
+    } else {
+      logger.fatal({ err }, "gRPC server error");
     }
-    logger.fatal({ err }, "gRPC server error");
-    process.exit(1);
+    process.exitCode = 1;
+    shutdown().catch(() => { process.exit(1); });
   });
 
   grpcServer.listen(grpcPort, "127.0.0.1", () => {
@@ -155,10 +156,11 @@ function main(): void {
   webServer.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
       logger.fatal({ port: webPort }, "Port %d is already in use. Is another Grackle server running?", webPort);
-      process.exit(1);
+    } else {
+      logger.fatal({ err }, "Web server error");
     }
-    logger.fatal({ err }, "Web server error");
-    process.exit(1);
+    process.exitCode = 1;
+    shutdown().catch(() => { process.exit(1); });
   });
 
   webServer.listen(webPort, "127.0.0.1", () => {
@@ -196,7 +198,7 @@ function main(): void {
     });
 
     clearTimeout(forceExit);
-    process.exit(0);
+    process.exit(process.exitCode || 0);
   }
 
   process.on("SIGINT", shutdown);


### PR DESCRIPTION
## Summary
- Add `error` event handlers on both HTTP servers (gRPC + Web in server, HTTP/2 in PowerLine)
- Catch `EADDRINUSE` and exit with a clear message: "Port X is already in use. Is another Grackle server running?"
- Other server errors also log and exit cleanly instead of crashing with an unhandled exception

## Test plan
- [ ] Start `grackle serve`, then start a second instance — should print clear error and exit(1)
- [ ] Start PowerLine on same port twice — same behavior
- [ ] Normal startup still works