### PR TITLE
Rewrite CD: push version bump directly to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -137,75 +137,33 @@ jobs:
           "
           echo "Set nextBump to $highest"
 
-      # rush version --bump creates a temp branch, pushes it, then tries to
-      # fast-forward main directly. The direct push fails due to branch
-      # protection, so we let it fail and merge via PR instead.
+      # Run rush version --bump WITHOUT --target-branch so it only modifies
+      # files on disk (no branch creation, no commits, no push). We handle
+      # the git operations ourselves to avoid Rush's [skip ci] commits and
+      # temp branch workflow that conflicts with branch protection rulesets.
       - name: Bump versions
         id: bump
         if: steps.changefile_check.outputs.has_changefiles == 'true'
         run: |
-          set +e
-          output=$(node common/scripts/install-run-rush.js version --bump --target-branch main 2>&1)
-          status=$?
-          set -e
+          node common/scripts/install-run-rush.js version --bump
 
-          echo "$output"
-
-          if [ "$status" -ne 0 ]; then
-            if echo "$output" | grep -q 'GH013'; then
-              echo "rush version failed due to protected branch; proceeding with PR-based merge."
-            else
-              echo "rush version failed with status $status"
-              exit "$status"
-            fi
-          fi
-
-          branch=$(echo "$output" | grep -oE 'version/bump-[0-9]+' | head -1)
-          if [ -n "$branch" ]; then
-            echo "branch=$branch" >> "$GITHUB_OUTPUT"
-            echo "has_bump=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No version bump needed"
+          # Check if rush actually changed anything
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No version changes detected"
             echo "has_bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_bump=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Rush's bump commits contain [skip ci] which prevents the required
-      # 'build' check from running on the PR. Push an empty commit without
-      # [skip ci] so CI triggers, then wait for it before merging.
-      - name: Trigger CI on bump branch
+      # Commit and push the version bump directly to main. The GH_PAT from
+      # checkout belongs to an admin who can bypass the branch ruleset.
+      # [skip ci] prevents an infinite CD trigger loop.
+      - name: Push version bump
         if: steps.bump.outputs.has_bump == 'true'
         run: |
-          git fetch origin "${{ steps.bump.outputs.branch }}"
-          git checkout "${{ steps.bump.outputs.branch }}"
-          git commit --allow-empty -m "chore: trigger CI for version bump"
-          git push origin "${{ steps.bump.outputs.branch }}"
-
-      - name: Create and merge version bump PR
-        if: steps.bump.outputs.has_bump == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          branch="${{ steps.bump.outputs.branch }}"
-
-          pr_url=$(gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "chore: bump versions" \
-            --body "Automated version bump from publish workflow.")
-
-          pr_number=$(gh pr view "$pr_url" --json number --jq '.number')
-          echo "Waiting for CI on bump PR #${pr_number}..."
-          timeout 1800 gh pr checks "$pr_number" --watch --fail-fast
-
-          gh pr merge "$pr_url" --squash --admin --delete-branch \
-            --subject "chore: bump versions [skip ci]"
-
-      # After squash-merge, local main has diverged from origin/main
-      # (rush merged the temp branch locally, but the PR was squash-merged).
-      # Reset to origin/main to get the squashed result.
-      - name: Checkout updated main
-        if: steps.bump.outputs.has_bump == 'true'
-        run: git fetch origin main && git checkout -B main origin/main
+          git add -A
+          git commit -m "chore: bump versions [skip ci]"
+          git push origin main
 
       - name: Rebuild with bumped versions
         if: steps.bump.outputs.has_bump == 'true'


### PR DESCRIPTION
## Summary
- Rewrites the CD version bump flow to eliminate the temp branch + PR + CI wait dance that caused **10 consecutive publish failures** since v0.13.0
- Runs `rush version --bump` WITHOUT `--target-branch` so it only modifies files on disk (no branch creation, no commits, no push by Rush)
- Commits and pushes the version bump directly to main using `GH_PAT` (admin bypass on the branch ruleset)
- Adds `workflow_dispatch` trigger so the CD pipeline can be manually retriggered

## What was wrong

`rush version --bump --target-branch main` creates a temp branch with `[skip ci]` in commit messages, pushes it, then tries to fast-forward merge to main. With branch protection rulesets, this triggered a cascade of failures:

1. Fast-forward push blocked by ruleset (GH013) — fell through to PR-based merge
2. `[skip ci]` in Rush's commits prevented CI from running on the bump PR
3. Required "build" status check never appeared — `--admin` can't bypass **missing** checks
4. `git checkout` failed because Rush's branch only existed on the remote
5. Concurrent CD runs hit merge conflicts on stale `version/bump-*` branches

## What changed

| Before | After |
|---|---|
| `rush version --bump --target-branch main` | `rush version --bump` (local-only) |
| Rush creates temp branch + [skip ci] commits | No branch, no Rush commits |
| GH013 error handling + PR fallback | Direct `git push origin main` |
| Empty commit to trigger CI on bump branch | Not needed |
| `gh pr checks --watch` (30 min timeout) | Not needed |
| `gh pr merge --admin` (fails on missing checks) | Not needed |
| Fetch + checkout updated main after squash merge | Not needed |
| 232 lines | 170 lines |

## Test plan
- [ ] Merge this PR — the merge commit triggers CD
- [ ] If no publishable changefiles exist, CD skips bump/publish (existing behavior, no risk)
- [ ] Next merge with publishable changefiles exercises the full new flow
- [ ] If `git push origin main` fails due to ruleset bypass, add GitHub Actions as a bypass actor in the ruleset