### PR TITLE
Add changefile to trigger CD publish

### DIFF
--- a/common/changes/@grackle-ai/cli/fix-cd-publish-trigger_2026-03-12-01-55.json
+++ b/common/changes/@grackle-ai/cli/fix-cd-publish-trigger_2026-03-12-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix CD pipeline: rewrite version bump to push directly to main instead of creating temp branches and PRs",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}


### PR DESCRIPTION
Adds a patch changefile so the new CD pipeline can exercise the full bump+publish flow. Main is at 0.14.0, npm is at 0.13.0 — this will bump to 0.14.1 and publish.