### PR TITLE
Extract shared build-and-test action, remove double build

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -1,0 +1,22 @@
+name: Build and Test
+description: Shared install → build → Playwright → test steps
+
+runs:
+  using: composite
+  steps:
+    - name: Rush install
+      shell: bash
+      run: node common/scripts/install-run-rush.js install
+
+    - name: Rush build
+      shell: bash
+      run: node common/scripts/install-run-rush.js build
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: npx playwright install --with-deps chromium
+      working-directory: packages/web
+
+    - name: Run tests
+      shell: bash
+      run: node common/scripts/install-run-rush.js test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 jobs:
@@ -17,25 +19,17 @@ jobs:
         with:
           node-version: 22
 
-      - name: Rush install
-        run: node common/scripts/install-run-rush.js install
-
       - name: Verify change logs
+        if: github.event_name == 'pull_request'
         run: node common/scripts/install-run-rush.js change --verify
 
       - name: Block major version bumps
+        if: github.event_name == 'pull_request'
         run: |
           if grep -r '"type": "major"' common/changes/ 2>/dev/null; then
             echo "::error::Major version bumps are blocked. Use patch or minor."
             exit 1
           fi
 
-      - name: Rush build
-        run: node common/scripts/install-run-rush.js build
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: packages/web
-
-      - name: Run tests
-        run: node common/scripts/install-run-rush.js test --verbose
+      - name: Build and test
+        uses: ./.github/actions/build-and-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Publish
 
 on:
   push:
@@ -32,18 +32,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Install
-        run: node common/scripts/install-run-rush.js install
-
-      - name: Build
-        run: node common/scripts/install-run-rush.js build
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: packages/web
-
-      - name: Run tests
-        run: node common/scripts/install-run-rush.js test --verbose
+      - name: Build and test
+        uses: ./.github/actions/build-and-test
 
       # In lockStepVersion mode, `rush version --bump` only consumes changefiles
       # for the mainProject (@grackle-ai/cli). Changefiles targeting other
@@ -165,12 +155,8 @@ jobs:
           git commit -m "chore: bump versions [skip ci]"
           git push origin main
 
-      - name: Rebuild with bumped versions
-        if: steps.bump.outputs.has_bump == 'true'
-        run: |
-          node common/scripts/install-run-rush.js install
-          node common/scripts/install-run-rush.js build
-
+      # No rebuild needed — rush publish packages the existing dist/ output
+      # with the bumped package.json version. Compiled JS is version-independent.
       - name: Publish to npm
         if: steps.bump.outputs.has_bump == 'true'
         run: node common/scripts/install-run-rush.js publish --include-all --publish --set-access-level public


### PR DESCRIPTION
## Summary
- **New composite action** `.github/actions/build-and-test/action.yml` — extracts the shared install → build → Playwright → test steps used by both CI and publish workflows
- **CI workflow** (`ci.yml`) — adds `push: main` trigger, makes changefile checks PR-only via `if`, uses the composite action
- **Publish workflow** (renamed `cd.yml` → `publish.yml`) — uses the composite action and **removes the redundant rebuild** after version bump. `rush publish` only needs the bumped `package.json` + existing `dist/` output; compiled JS is version-independent.

## Test plan
- [ ] CI runs on the PR with check name `build` (validates branch ruleset compatibility)
- [ ] Composite action runs all 4 steps (install, build, playwright, test)
- [ ] After merge: push to main triggers both CI and Publish workflows
- [ ] Publish workflow skips rebuild, publishes with single build cycle