### PR TITLE
Skip build in publish workflow when nothing to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,15 +32,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build and test
-        uses: ./.github/actions/build-and-test
-
-      # In lockStepVersion mode, `rush version --bump` only consumes changefiles
-      # for the mainProject (@grackle-ai/cli). Changefiles targeting other
-      # lockstep packages (e.g. @grackle-ai/powerline) survive indefinitely,
-      # forcing every bump to match their type. Fix: consolidate all changefiles
-      # into the mainProject directory before bumping, and sync nextBump to the
-      # highest requested type.
+      # Check for publishable changefiles BEFORE building. CI already
+      # validates the build on push to main, so there's no point running
+      # a full build+test cycle here if there's nothing to publish.
       - name: Consolidate changefiles and sync nextBump
         id: changefile_check
         run: |
@@ -58,7 +52,7 @@ jobs:
 
           mapfile -t changefiles < <(find common/changes/ -name '*.json' 2>/dev/null)
           if [ ${#changefiles[@]} -eq 0 ]; then
-            echo "No changefiles found, skipping version bump"
+            echo "No changefiles found, nothing to publish"
             echo "has_changefiles=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -79,7 +73,7 @@ jobs:
           fi
           # All changefiles are "none" — nothing to publish
           if [ "$highest" = "none" ]; then
-            echo "All changefiles are type \"none\", skipping version bump"
+            echo "All changefiles are type \"none\", nothing to publish"
             echo "has_changefiles=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -126,6 +120,12 @@ jobs:
             fs.writeFileSync(p, JSON.stringify(v, null, 2) + '\n');
           "
           echo "Set nextBump to $highest"
+
+      # Only build if we have something to publish. CI on main already
+      # validates the build, so this is purely to produce dist/ for publishing.
+      - name: Build and test
+        if: steps.changefile_check.outputs.has_changefiles == 'true'
+        uses: ./.github/actions/build-and-test
 
       # Run rush version --bump WITHOUT --target-branch so it only modifies
       # files on disk (no branch creation, no commits, no push). We handle


### PR DESCRIPTION
## Summary
- Move changefile check **before** the build step in the publish workflow
- Gate build+test on `has_changefiles == 'true'` — if no publishable changefiles exist, the workflow exits early after ~5s instead of doing a full ~3min build+test cycle
- CI already validates the build on `push: main`, so the publish workflow only needs to build when it's actually going to publish

## Test plan
- [ ] CI passes on this PR (the CI workflow itself is unchanged)
- [ ] After merge: push to main without changefiles → publish workflow should skip build and exit early
- [ ] Push to main with a changefile → publish workflow builds, bumps, publishes as before