### PR TITLE
Update @playwright/mcp to @latest

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@0.0.23"]
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `@playwright/mcp` from pinned `0.0.23` to `@latest` (currently `0.0.68`)

## Test plan
- Reconnect MCP server and verify it connects successfully