### PR TITLE
Fix: Retry button on failed task does not work

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-257-retry-failed-task_2026-03-12-06-30.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-257-retry-failed-task_2026-03-12-06-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Allow retrying failed tasks by adding 'failed' to allowed start statuses",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/powerline/src/runtimes/stub.ts
+++ b/packages/powerline/src/runtimes/stub.ts
@@ -50,6 +50,13 @@ class StubSession implements AgentSession {
     const input = await this.waitForInput();
     if (this.killed) return;
 
+    // Simulate failure when input is "fail"
+    if (input === "fail") {
+      this.status = "failed";
+      yield { type: "status", timestamp: ts(), content: "failed" };
+      return;
+    }
+
     this.status = "running";
     yield { type: "status", timestamp: ts(), content: "running" };
     yield { type: "text", timestamp: ts(), content: `You said: ${input}` };

--- a/packages/server/src/grpc-service.ts
+++ b/packages/server/src/grpc-service.ts
@@ -498,7 +498,7 @@ export function registerGrackleRoutes(router: ConnectRouter): void {
     async startTask(req: grackle.StartTaskRequest) {
       const task = taskStore.getTask(req.taskId);
       if (!task) throw new Error(`Task not found: ${req.taskId}`);
-      if (!["pending", "assigned"].includes(task.status)) {
+      if (!["pending", "assigned", "failed"].includes(task.status)) {
         throw new Error(`Task ${req.taskId} cannot be started (status: ${task.status})`);
       }
       if (!taskStore.areDependenciesMet(req.taskId)) {

--- a/packages/server/src/task-store.test.ts
+++ b/packages/server/src/task-store.test.ts
@@ -267,4 +267,21 @@ describe("task-store tree operations", () => {
       expect(child!.canDecompose).toBe(false);
     });
   });
+
+  describe("markTaskStarted on failed task", () => {
+    it("transitions a failed task to in_progress", () => {
+      taskStore.createTask("t1", "test-proj", "Retry Task", "desc", "", [], "proj");
+      taskStore.markTaskStarted("t1");
+      taskStore.markTaskCompleted("t1", "failed");
+
+      const failed = taskStore.getTask("t1");
+      expect(failed!.status).toBe("failed");
+
+      taskStore.markTaskStarted("t1");
+
+      const retried = taskStore.getTask("t1");
+      expect(retried!.status).toBe("in_progress");
+      expect(retried!.startedAt).toBeDefined();
+    });
+  });
 });

--- a/packages/server/src/ws-bridge.ts
+++ b/packages/server/src/ws-bridge.ts
@@ -543,7 +543,7 @@ async function handleMessage(
         sendWs(ws, { type: "error", payload: { message: `Task not found: ${taskId}` } });
         return;
       }
-      if (!["pending", "assigned"].includes(task.status)) {
+      if (!["pending", "assigned", "failed"].includes(task.status)) {
         sendWs(ws, { type: "error", payload: { message: `Task cannot be started (status: ${task.status})` } });
         return;
       }

--- a/packages/web/tests/task-retry.spec.ts
+++ b/packages/web/tests/task-retry.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "./fixtures.js";
+import {
+  createProject,
+  createTask,
+  navigateToTask,
+  patchWsForStubRuntime,
+} from "./helpers.js";
+
+test.describe("Task Retry (failed → in_progress)", () => {
+  test("retry button restarts a failed task", async ({ appPage }) => {
+    const page = appPage;
+
+    // --- Setup: create project and task ---
+    await createProject(page, "retry-proj");
+    await page.getByText("retry-proj").click();
+    await createTask(page, "retry-proj", "retry task", "test-local");
+    await navigateToTask(page, "retry task");
+    await patchWsForStubRuntime(page);
+
+    // --- Start the task ---
+    await page.locator("button", { hasText: "Start Task" }).click();
+
+    // Wait for stub to reach waiting_input
+    const inputField = page.locator('input[placeholder="Type a message..."]');
+    await expect(inputField).toBeVisible({ timeout: 15_000 });
+
+    // --- Send "fail" to trigger stub failure ---
+    await inputField.fill("fail");
+    await page.locator("button", { hasText: "Send" }).click();
+
+    // --- Verify task is in failed state ---
+    await expect(page.getByText("Task failed")).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator("button", { hasText: "Retry" })).toBeVisible();
+
+    // --- Click Retry ---
+    await page.locator("button", { hasText: "Retry" }).click();
+
+    // --- Verify task restarts: stub runtime events appear again ---
+    // The stub emits "Stub runtime initialized" on each start
+    await expect(page.locator("text=in_progress")).toBeVisible({ timeout: 15_000 });
+
+    // Wait for waiting_input and send normal input to complete
+    await expect(inputField).toBeVisible({ timeout: 15_000 });
+    await inputField.fill("continue");
+    await page.locator("button", { hasText: "Send" }).click();
+
+    // --- Verify task reaches review ---
+    await expect(page.locator("button", { hasText: "Approve" })).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #257

- Add `"failed"` to the allowed-status list in both the WS bridge (`ws-bridge.ts:546`) and gRPC handler (`grpc-service.ts:501`) so that clicking **Retry** on a failed task actually restarts it
- Add a `"fail"` input mode to the stub runtime so E2E tests can trigger task failure scenarios
- Add unit test verifying `markTaskStarted` works on a failed task
- Add Playwright E2E test for the full retry flow: start → fail → retry → complete

## Root Cause
The status validation in `start_task` only allowed `"pending"` and `"assigned"` — not `"failed"`. The downstream flow (markTaskStarted, setTaskSession, buildTaskSystemContext, broadcast) already handled retry correctly.

## Test plan
- [x] Unit test: `markTaskStarted` transitions a failed task to `in_progress`
- [x] E2E test: stub task fails via "fail" input, Retry button restarts it, task completes to review
- [ ] CI: `rush build` + `rush test` pass