### PR TITLE
feat: add write-spec and open-ticket skills

### DIFF
--- a/.claude/skills/open-ticket/SKILL.md
+++ b/.claude/skills/open-ticket/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: open-ticket
+description: Create a new GitHub issue with proper labels and epic assignment, then write a requirements spec for it. Run with /open-ticket "<title>" or interactively.
+---
+
+# Open Ticket — Issue Creation with Spec
+
+This skill creates a new GitHub issue with proper labels and epic assignment, then automatically runs the `/write-spec` skill to post a requirements specification as a comment.
+
+## Step 0: Gather Information
+
+If a title was provided as an argument, use it. Otherwise, ask the user for:
+- **Title**: Short, descriptive issue title
+- **Description**: What is this feature/bug/refactor? (can be brief — the spec will expand it)
+
+```
+REPO="nick-pape/grackle"
+```
+
+## Step 1: Fetch Available Labels
+
+Fetch the repository's labels to select the right ones:
+
+```bash
+gh label list -R $REPO --limit 100 --json name --jq '.[].name'
+```
+
+## Step 2: Fetch Open Epics
+
+Fetch the current epic issues to find the right parent:
+
+```bash
+gh issue list -R $REPO --state open --search "Epic:" --json number,title --jq '.[] | "\(.number): \(.title)"'
+```
+
+Key epics to know:
+- **#270** — Epic: Orchestration (multi-agent coordination, swarming, reconciliation, escalation)
+- **#272** — Epic: Web UI features (all frontend/UX work)
+- **#271** — Epic: Code quality and refactoring
+- **#273** — Epic: Rushstack tooling adoption (build infra)
+
+## Step 3: Classify the Issue
+
+Based on the title and description, determine:
+
+### Labels (select all that apply):
+- **Type**: `feature`, `bug`, `refactor`, `infra`
+- **Packages**: `web`, `server`, `cli`, `powerline`, `common` (based on which packages are affected)
+- **Domain**: `orchestration` (if related to multi-agent, swarming, task lifecycle, reconciliation, escalation)
+- **Priority**: `priority:critical`, `priority:high`, `priority:low` (if the user specifies, otherwise omit)
+
+### Parent Epic:
+- Web/UX features → #272
+- Orchestration/multi-agent → #270
+- Refactoring/code quality → #271
+- Build/tooling → #273
+- If unclear, ask the user
+
+## Step 4: Create the Issue
+
+```bash
+gh issue create -R $REPO \
+  --title "<TITLE>" \
+  --label "<LABELS>" \
+  --body "$(cat <<'EOF'
+Parent: #<EPIC_NUMBER>
+
+## Summary
+<User's description, expanded into 2-3 sentences explaining what and why>
+
+## Related
+<List any related issues discovered during classification>
+EOF
+)"
+```
+
+Capture the created issue number from the output URL.
+
+## Step 5: Run /write-spec
+
+Now invoke the `/write-spec` skill on the newly created issue to research and post a detailed requirements specification:
+
+Use the Skill tool to invoke `write-spec` with the new issue number as the argument.
+
+## Step 6: Report
+
+Summarize:
+- Issue number and URL
+- Labels applied
+- Parent epic
+- Confirm that the requirements spec was posted

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: write-spec
+description: Research a GitHub issue and write a detailed requirements specification as a comment. Run with /write-spec <ISSUE_NUMBER>.
+---
+
+# Write Spec — Requirements Specification Writer
+
+This skill researches a GitHub issue in depth and posts a detailed requirements specification as a comment on the issue.
+
+## Step 0: Parse Arguments
+
+The issue number must be provided as an argument. If not provided, ask the user for the issue number and stop.
+
+```
+ISSUE_NUMBER=<provided argument>
+REPO="nick-pape/grackle"
+```
+
+## Step 1: Read the Issue
+
+```bash
+gh issue view $ISSUE_NUMBER -R $REPO
+```
+
+Capture the title, body, labels, and any referenced issues (parent epics, related issues, sibling tickets).
+
+## Step 2: Read Related Issues
+
+For every issue referenced in the body (parent epics, sibling sub-tasks, related features), read them:
+
+```bash
+gh issue view <RELATED_NUMBER> -R $REPO
+```
+
+This provides context on how this issue fits into the larger feature.
+
+## Step 3: Read Relevant Specs and RFCs
+
+Check these spec files in the repo for relevant sections:
+
+- `specs/task-orchestration.md` — Orchestration RFC (task lifecycle, decomposition, reconciliation, escalation)
+- `specs/GRACKLE-DEEP-DIVE.md` — Full architecture deep dive (all subsystems)
+- `specs/v0.md` — Original design spec (UI mockups, interaction patterns)
+- `specs/default-personas.md` — Persona roster definitions
+- `spec/ux-audit.md` — UX audit findings and recommendations
+
+Read the files that are relevant based on the issue's domain (server, web, CLI, powerline, etc.). Use the issue labels to guide which specs to prioritize.
+
+## Step 4: Read Relevant Source Code
+
+Based on the issue's domain, explore the codebase to understand the current state:
+
+- **Server issues**: `packages/server/src/` — stores, gRPC service, event processor, adapters
+- **Web/UX issues**: `packages/web/src/` — components, hooks, routing, existing UI patterns
+- **CLI issues**: `packages/cli/src/` — commands, formatters
+- **PowerLine issues**: `packages/powerline/src/` — MCP tools, runtimes, adapters
+- **Proto issues**: `packages/common/src/proto/` — existing messages, RPCs, enums
+- **Common/types**: `packages/common/src/types.ts` — shared type definitions
+
+Use Grep, Glob, and Read to find relevant code. Focus on:
+- How the feature's domain currently works
+- What data models and APIs already exist
+- What's missing vs what's already partially implemented
+- Existing test patterns in the affected package
+
+## Step 5: Write the Requirements Specification
+
+Write a comprehensive spec covering these sections. Adapt the sections to the issue type (feature vs bug vs refactor):
+
+### For Features:
+- **Overview**: What is this feature and why does it matter? (2-3 sentences)
+- **Functional Requirements**: Numbered FR-1, FR-2, etc. Be specific and testable. Describe WHAT, not HOW.
+- **Non-Functional Requirements**: Performance, accessibility, reliability, backwards compatibility constraints
+- **Integration Points**: How does this interact with existing systems? Reference specific files/modules.
+- **Acceptance Criteria — Unit Tests**: What should unit tests verify? Number them UT-1, UT-2, etc.
+- **Acceptance Criteria — Integration Tests**: What should integration/E2E tests verify? Number them IT-1, IT-2, etc.
+- **Acceptance Criteria — Manual Testing**: Step-by-step procedures a human can follow. Number them MT-1, MT-2, etc.
+- **Out of Scope**: What is explicitly NOT part of this ticket? Reference related issues where appropriate.
+- **Open Questions**: Unresolved decisions or ambiguities discovered during research. **These are blockers — all open questions must be resolved before implementation begins.** Be specific: state the question, explain why it matters, and suggest options where possible. Number them OQ-1, OQ-2, etc.
+
+### For Bugs:
+- **Overview**: What is the bug and what's the user impact?
+- **Current Behavior**: Describe exactly what happens now. Reference specific code paths.
+- **Expected Behavior**: What should happen instead?
+- **Functional Requirements**: Numbered FR-1, FR-2, etc. What must the fix accomplish?
+- (Then the same NFR, Integration Points, Acceptance Criteria, Out of Scope, Open Questions sections as above — including the blocker requirement on Open Questions)
+
+### Important Guidelines:
+- This is a **REQUIREMENTS** doc, not an implementation plan. Describe WHAT, not HOW.
+- Don't prescribe specific classes, file structures, or code patterns — let the implementer decide.
+- You CAN reference existing code to describe the current state and integration points.
+- For bugs, reference the specific code paths that exhibit the problem.
+- Keep it thorough but readable. Use markdown formatting with headers and numbered lists.
+
+## Step 6: Post the Spec as a Comment
+
+Post the spec as a comment on the issue. Use a heredoc to preserve formatting:
+
+```bash
+gh issue comment $ISSUE_NUMBER -R $REPO --body "$(cat <<'SPECEOF'
+## Requirements Specification
+
+<your spec content here>
+
+SPECEOF
+)"
+```
+
+## Step 7: Review the Issue Description
+
+Check if the current issue description is thin or missing important context. If so, update it to supplement (not overwrite) the existing content. If the description is already adequate, leave it as-is — the spec comment provides the detail.
+
+## Step 8: Report
+
+Summarize what was done:
+- How many functional requirements were defined
+- Key findings from the code review (e.g., missing APIs, partially implemented features, existing patterns to leverage)
+- Any open questions that need team input


### PR DESCRIPTION
## Summary
- **`/write-spec <number>`**: Researches a GitHub issue (ticket, related issues, specs, source code) and posts a detailed requirements specification as a comment. Covers functional requirements, NFRs, acceptance criteria (unit/integration/manual), out of scope, and open questions (marked as blockers).
- **`/open-ticket "<title>"`**: Creates a new GitHub issue with proper labels and epic assignment, then chains into `/write-spec` to auto-generate a BRD.

## Test plan
- [x] `/write-spec` tested on 21 issues in this session — all specs posted successfully
- [x] `/open-ticket` pattern validated manually (issues #381-389 created with proper labels/epics)
- [ ] No code changes to publishable packages — skills are `.claude/` config only