### PR TITLE
fix: allow better-sqlite3 install script in pnpm v8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ npx @grackle-ai/cli serve
 npx @grackle-ai/cli env add my-env --docker
 ```
 
+> **pnpm users**: pnpm v8+ blocks package install scripts by default. If `grackle serve` crashes with a `Could not locate the bindings file` error, run `pnpm approve-builds` after installing and then reinstall, or add the following to your `package.json` before installing:
+>
+> ```json
+> { "pnpm": { "onlyBuiltDependencies": ["better-sqlite3"] } }
+> ```
+
 <details>
 <summary>Building from source</summary>
 

--- a/common/changes/@grackle-ai/cli/grackle-github-backlog-410-better-sqlite3-postinstall-blocked-b_2026-03-13-22-53.json
+++ b/common/changes/@grackle-ai/cli/grackle-github-backlog-410-better-sqlite3-postinstall-blocked-b_2026-03-13-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add pnpm.onlyBuiltDependencies to allow better-sqlite3 install script in pnpm v8+",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,5 +38,8 @@
     "@rushstack/heft": "1.2.4",
     "@types/node": "^22.0.0",
     "vitest": "^3.1.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"]
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,5 +40,8 @@
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.0.0",
     "vitest": "^3.1.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"]
   }
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -9,7 +9,38 @@ import * as schema from "./schema.js";
 mkdirSync(grackleHome, { recursive: true });
 
 const dbPath: string = join(grackleHome, DB_FILENAME);
-const sqlite: InstanceType<typeof Database> = new Database(dbPath);
+
+let sqlite: InstanceType<typeof Database>;
+try {
+  sqlite = new Database(dbPath);
+} catch (err) {
+  if (err instanceof Error && err.message.includes("Could not locate the bindings file")) {
+    process.stderr.write(
+      [
+        "",
+        "ERROR: better-sqlite3 native binding not found.",
+        "",
+        "The install script for better-sqlite3 was skipped, so the required native",
+        "module was never built. This commonly happens with pnpm v8+, which blocks",
+        "package install scripts by default.",
+        "",
+        "To fix this, run one of the following:",
+        "",
+        "  Option 1 — approve builds interactively:",
+        "    pnpm approve-builds",
+        "",
+        "  Option 2 — add to your project's package.json, then reinstall:",
+        '    { "pnpm": { "onlyBuiltDependencies": ["better-sqlite3"] } }',
+        "    pnpm install",
+        "",
+        "After fixing, restart grackle.",
+        "",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+  throw err;
+}
 
 // Enable WAL mode for better concurrent read performance
 sqlite.pragma("journal_mode = WAL");

--- a/packages/server/src/pnpm-policy.test.ts
+++ b/packages/server/src/pnpm-policy.test.ts
@@ -1,0 +1,50 @@
+/**
+ * UT-1 / UT-2: Verify that both @grackle-ai/server and @grackle-ai/cli
+ * publish a `pnpm.onlyBuiltDependencies` field that includes "better-sqlite3",
+ * so pnpm v8+ users get the native binding built automatically on install.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readPackageJson(packageDir: string): Record<string, unknown> {
+  const pkgPath = resolve(__dirname, packageDir, "package.json");
+  return JSON.parse(readFileSync(pkgPath, "utf8")) as Record<string, unknown>;
+}
+
+describe("pnpm onlyBuiltDependencies policy", () => {
+  it("UT-1: @grackle-ai/server/package.json includes better-sqlite3 in pnpm.onlyBuiltDependencies", () => {
+    // __dirname is packages/server/src — one level up reaches packages/server
+    const pkg = readPackageJson("..");
+    expect(pkg.name).toBe("@grackle-ai/server");
+
+    const pnpmConfig = pkg.pnpm as Record<string, unknown> | undefined;
+    expect(pnpmConfig, "pnpm section must exist in package.json").toBeDefined();
+
+    const onlyBuilt = pnpmConfig?.onlyBuiltDependencies as string[] | undefined;
+    expect(
+      Array.isArray(onlyBuilt),
+      "pnpm.onlyBuiltDependencies must be an array",
+    ).toBe(true);
+    expect(onlyBuilt).toContain("better-sqlite3");
+  });
+
+  it("UT-2: @grackle-ai/cli/package.json includes better-sqlite3 in pnpm.onlyBuiltDependencies", () => {
+    // __dirname is packages/server/src — two levels up reaches packages/, then into cli
+    const pkg = readPackageJson("../../cli");
+    expect(pkg.name).toBe("@grackle-ai/cli");
+
+    const pnpmConfig = pkg.pnpm as Record<string, unknown> | undefined;
+    expect(pnpmConfig, "pnpm section must exist in package.json").toBeDefined();
+
+    const onlyBuilt = pnpmConfig?.onlyBuiltDependencies as string[] | undefined;
+    expect(
+      Array.isArray(onlyBuilt),
+      "pnpm.onlyBuiltDependencies must be an array",
+    ).toBe(true);
+    expect(onlyBuilt).toContain("better-sqlite3");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `pnpm.onlyBuiltDependencies: ["better-sqlite3"]` to `@grackle-ai/server` and `@grackle-ai/cli` `package.json` so pnpm v8+ automatically runs the `better-sqlite3` native binding install script on install (FR-1, FR-2)
- Add startup diagnostic in `db.ts` that detects a missing native binding and emits a clear, actionable error explaining the pnpm cause and fix — `pnpm approve-builds` or `onlyBuiltDependencies` config (FR-4, NFR-3)
- Add pnpm-specific note to README Quick Start for users on older pnpm versions or edge cases where propagation doesn't work (FR-3)
- Add unit tests (UT-1, UT-2) verifying both `package.json` files carry the `onlyBuiltDependencies` allowlist

## Test plan

- [x] `packages/server/src/pnpm-policy.test.ts` — UT-1 & UT-2: asserts `pnpm.onlyBuiltDependencies` contains `"better-sqlite3"` in both server and cli `package.json`
- [x] All 133 existing server tests continue to pass
- [x] `rush build -t @grackle-ai/server` passes cleanly
- [ ] IT-1 (integration): install from local tarball with pnpm v10 in a clean dir — verifies `better_sqlite3.node` exists after install (manual, out of CI scope)
- [ ] MT-2 (manual): delete `better-sqlite3/build/` and confirm startup diagnostic message is clear and actionable

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)