### PR TITLE
fix: restore clean build after Stop hook verification test

### DIFF
--- a/packages/powerline/src/runtimes/claude-code.ts
+++ b/packages/powerline/src/runtimes/claude-code.ts
@@ -261,4 +261,3 @@ export class ClaudeCodeRuntime extends BaseAgentRuntime {
     return new ClaudeCodeSession(id, prompt, model, maxTurns, resumeSessionId, branch, worktreeBasePath, systemContext, mcpServers, hooks);
   }
 }
-const x: number = "not a number";


### PR DESCRIPTION
## Summary

- Removes the deliberately broken TypeScript line (`const x: number = "not a number"`) that was added to verify Stop hook blocking behavior
- Confirms that normal `task_start` flow works correctly: build passes, all 131 tests pass

## Test plan

- [x] `rush build -t @grackle-ai/powerline` completes successfully
- [x] All 131 powerline unit tests pass (`vitest run`)
- [x] Merged with `origin/main`, rebuild still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)