### PR TITLE
revert: undo failed publish version bump

### DIFF
--- a/common/changes/@grackle-ai/cli/consolidated-unpublished_2026-03-15.json
+++ b/common/changes/@grackle-ai/cli/consolidated-unpublished_2026-03-15.json
@@ -1,0 +1,61 @@
+{
+  "changes": [
+    {
+      "comment": "Simplify task/session lifecycle: 5 task statuses, 6 session statuses, replace approve/reject with complete/resume RPCs",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "User-friendly codespace error messages, manual name fallback, optional machine type",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Add per-project worktree base path configuration",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Add user-friendly error message for Node.js ABI version mismatch in better-sqlite3",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Add --host CLI flag to PowerLine, bind to 0.0.0.0 in Docker containers",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Add 11 new ESLint rules to shared heft-rig configs and fix all violations across all packages",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Show active tab in settings breadcrumbs",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Broadcast environment status changes from gRPC/heartbeat to WebSocket clients",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Add URL routing with react-router v7",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Escalate typedef and explicit-member-accessibility lint rules to error in common",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    },
+    {
+      "comment": "Grackle brand theme and system toggle",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,8 +2,8 @@
   {
     "policyName": "grackle",
     "definitionName": "lockStepVersion",
-    "version": "0.27.0",
-    "nextBump": "minor",
+    "version": "0.26.0",
+    "nextBump": "patch",
     "mainProject": "@grackle-ai/cli"
   }
 ]

--- a/packages/cli/CHANGELOG.json
+++ b/packages/cli/CHANGELOG.json
@@ -2,50 +2,6 @@
   "name": "@grackle-ai/cli",
   "entries": [
     {
-      "version": "0.27.0",
-      "tag": "@grackle-ai/cli_v0.27.0",
-      "date": "Sun, 15 Mar 2026 19:38:05 GMT",
-      "comments": {
-        "minor": [
-          {
-            "comment": "Simplify task/session lifecycle: 5 task statuses, 6 session statuses, replace approve/reject with complete/resume RPCs"
-          },
-          {
-            "comment": "Add per-project worktree base path configuration"
-          }
-        ],
-        "patch": [
-          {
-            "comment": "User-friendly codespace error messages, manual name fallback, optional machine type"
-          },
-          {
-            "comment": "Add user-friendly error message for Node.js ABI version mismatch in better-sqlite3"
-          },
-          {
-            "comment": "Add --host CLI flag to PowerLine, bind to 0.0.0.0 in Docker containers"
-          },
-          {
-            "comment": "Add 11 new ESLint rules to shared heft-rig configs and fix all violations across all packages"
-          },
-          {
-            "comment": "Show active tab in settings breadcrumbs"
-          },
-          {
-            "comment": "Broadcast environment status changes from gRPC/heartbeat to WebSocket clients"
-          },
-          {
-            "comment": "Add URL routing with react-router v7"
-          },
-          {
-            "comment": "Escalate typedef and explicit-member-accessibility lint rules to error in common"
-          },
-          {
-            "comment": "Grackle brand theme and system toggle"
-          }
-        ]
-      }
-    },
-    {
       "version": "0.26.0",
       "tag": "@grackle-ai/cli_v0.26.0",
       "date": "Sun, 15 Mar 2026 04:23:26 GMT",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,26 +1,6 @@
 # Change Log - @grackle-ai/cli
 
-This log was last generated on Sun, 15 Mar 2026 19:38:05 GMT and should not be manually modified.
-
-## 0.27.0
-Sun, 15 Mar 2026 19:38:05 GMT
-
-### Minor changes
-
-- Simplify task/session lifecycle: 5 task statuses, 6 session statuses, replace approve/reject with complete/resume RPCs
-- Add per-project worktree base path configuration
-
-### Patches
-
-- User-friendly codespace error messages, manual name fallback, optional machine type
-- Add user-friendly error message for Node.js ABI version mismatch in better-sqlite3
-- Add --host CLI flag to PowerLine, bind to 0.0.0.0 in Docker containers
-- Add 11 new ESLint rules to shared heft-rig configs and fix all violations across all packages
-- Show active tab in settings breadcrumbs
-- Broadcast environment status changes from gRPC/heartbeat to WebSocket clients
-- Add URL routing with react-router v7
-- Escalate typedef and explicit-member-accessibility lint rules to error in common
-- Grackle brand theme and system toggle
+This log was last generated on Sun, 15 Mar 2026 04:23:26 GMT and should not be manually modified.
 
 ## 0.26.0
 Sun, 15 Mar 2026 04:23:26 GMT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/cli",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "Command-line interface for managing Grackle environments and agents",
   "license": "MIT",
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/common",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "Proto definitions, generated code, and shared types for Grackle",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/mcp",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "MCP (Model Context Protocol) server for Grackle — translates MCP tool calls to ConnectRPC",
   "license": "MIT",
   "repository": {

--- a/packages/powerline/package.json
+++ b/packages/powerline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/powerline",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "gRPC PowerLine server for Grackle AI agent integration",
   "license": "MIT",
   "repository": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/server",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "Central gRPC server with SQLite storage and WebSocket bridge for Grackle",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/web",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "React web UI for the Grackle multi-agent coordination platform",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Reverts `a6b21f1` — the publish pipeline bumped to 0.27.0 but NPM publish failed (token missing scope). This restores versions to 0.26.0 and brings back the consolidated change file so the next publish succeeds.

## Test plan
- [x] Revert is clean, no conflicts