### PR TITLE
fix: Copilot/Codex MCP broker + Codex streaming + credential push at spawn

### DIFF
--- a/packages/powerline/src/runtimes/runtime-utils.ts
+++ b/packages/powerline/src/runtimes/runtime-utils.ts
@@ -278,6 +278,9 @@ export function resolveMcpServers(
         type: "http",
         url: brokerConfig.url,
         headers: { Authorization: `Bearer ${brokerConfig.token}` },
+        // tools: ["*"] is required by Copilot SDK (MCPServerConfigBase.tools is mandatory).
+        // Claude Agent SDK ignores unknown fields, Codex CLI flattens to --config.
+        tools: ["*"],
       };
     } else if (existsSync(GRACKLE_MCP_SCRIPT)) {
       // Legacy fallback: stdio stub (will be removed once broker is always available)


### PR DESCRIPTION
## Summary

- **Copilot MCP**: Add `tools: ["*"]` to the HTTP MCP broker config — required by the Copilot SDK's `MCPServerConfigBase`
- **Codex MCP**: Transform generic MCP config into Codex-native format (`mcp_servers` snake_case key, `http_headers` instead of `headers`, remove `type` field)
- **Codex streaming**: Fix all field name mismatches in `consumeStream()` to match `@openai/codex-sdk@0.111.0` types
- **Codex trust**: Add `skipGitRepoCheck: true` to thread options so Codex works in non-trusted directories
- **Credential push at spawn**: `spawnAgent()` now calls `refreshTokensForTask()` before spawning, ensuring fresh credentials are pushed — previously credentials were only pushed in the task-start path

Fixes #536. Fixes #508.

## Changes

### Codex MCP config (`packages/powerline/src/runtimes/codex.ts`)
- `mcpServers` → `mcp_servers` (Codex CLI uses snake_case)
- `headers` → `http_headers` for HTTP MCP servers
- Remove `type` field (Codex infers transport from `url` presence)
- Remove `tools` field (Codex doesn't use it)
- Stdio MCP servers pass through unchanged

### Codex streaming field names (`consumeStream`)
| Event | Old (broken) | New (correct) |
|---|---|---|
| `agent_message` completed | `item.content` | `item.text` |
| `command_execution` completed | `item.output` | `item.aggregated_output` |
| `command_execution` completed | `item.exitCode` | `item.exit_code` |
| `mcp_tool_call` started/completed | `item.serverName` | `item.server` |
| `mcp_tool_call` started/completed | `item.toolName` | `item.tool` |
| `mcp_tool_call` completed | `item.result` (string) | `item.result.content` (object) |
| `mcp_tool_call` completed | `item.error` (string) | `item.error.message` (object) |
| `file_change` started/completed | `item.file` | `item.changes[].path` |
| `reasoning` completed | `item.summary ?? item.text` | `item.text` |

### Codex trust directory (`packages/powerline/src/runtimes/codex.ts`)
- Add `skipGitRepoCheck: true` to thread options

### Credential push at spawn (`packages/server/src/grpc-service.ts`)
- `spawnAgent()` now calls `refreshTokensForTask()` before spawning
- Previously, only the task-start path pushed credentials; direct `grackle spawn` skipped this step

### Copilot MCP (prior commit)
- Add `tools: ["*"]` to the HTTP MCP broker server config

## Test plan

- [x] `rush build` — clean build, no warnings
- [x] 141 powerline tests pass (including 9 new streaming field extraction tests)
- [x] 299 server tests pass
- [x] **E2E Codex**: Full round-trip on codespace — agent_message text, command_execution output/exit_code all correctly extracted and displayed
- [x] **Credential push**: Verified fresh `~/.codex/auth.json` pushed at spawn time (previously stale tokens persisted)
- [x] **`skipGitRepoCheck`**: Codex no longer fails with "not inside a trusted directory"
- [ ] E2E Copilot: Session creates successfully but auth fails — `useLoggedInUser` path requires Copilot CLI logged-in state on the remote (separate issue)
