### PR TITLE
chore: use latest Grackle CLI in Docker image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ When you encounter unexpected issues, workarounds, or non-obvious behavior (CI q
 
 ```bash
 # Install dependencies and build all packages
-rush update && rush build
+rush install && rush build
+# Only run `rush update` if `rush install` fails and tells you to (e.g. after changing package.json)
 
 # Build a single package
 rush build -t @grackle-ai/<package>

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -33,8 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gosu \
 
 # ── Grackle CLI + agent runtimes (pinned via lockfile) ────────────
 COPY docker/server/package.json /opt/grackle/package.json
-COPY docker/server/package-lock.json /opt/grackle/package-lock.json
-RUN npm ci --prefix /opt/grackle --omit=dev
+RUN npm install --prefix /opt/grackle --omit=dev
 ENV PATH="/opt/grackle/node_modules/.bin:$PATH"
 
 # ── Remove build toolchain (only needed for native addon compilation) ──

--- a/docker/server/package.json
+++ b/docker/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Pinned agent runtime dependencies for the Grackle server Docker image",
   "dependencies": {
-    "@grackle-ai/cli": "0.38.0",
+    "@grackle-ai/cli": "latest",
     "@anthropic-ai/claude-code": "2.1.78",
     "@openai/codex": "0.115.0",
     "@github/copilot": "1.0.7",


### PR DESCRIPTION
## Summary
- Docker image now installs `@grackle-ai/cli@latest` instead of pinned `0.38.0`
- Switched from `npm ci` (lockfile) to `npm install` for flexibility
- CLAUDE.md: recommend `rush install` over `rush update`

## Test plan
- [x] Built Docker image and verified `grackle --version` shows v0.43.0
- [x] Container starts and serves correctly on all ports