### PR TITLE
ci: cache Playwright browsers, skip E2E on push-to-main

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -1,6 +1,12 @@
 name: Build and Test
 description: Shared install → build → Playwright → test steps
 
+inputs:
+  skip-e2e:
+    description: Skip E2E tests (Playwright install + rush e2e)
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -28,9 +34,24 @@ runs:
       shell: bash
       run: node common/scripts/install-run-rush.js build
 
+    - name: Cache Playwright browsers
+      if: inputs.skip-e2e != 'true'
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
+
     - name: Install Playwright browsers
+      if: inputs.skip-e2e != 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npx playwright install --with-deps chromium
+      working-directory: tests/e2e-tests
+
+    - name: Install Playwright system deps
+      if: inputs.skip-e2e != 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: npx playwright install-deps chromium
       working-directory: tests/e2e-tests
 
     - name: Run unit tests
@@ -38,5 +59,6 @@ runs:
       run: node common/scripts/install-run-rush.js test --verbose
 
     - name: Run E2E tests
+      if: inputs.skip-e2e != 'true'
       shell: bash
       run: node common/scripts/install-run-rush.js e2e --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
 
       - name: Build and test
         uses: ./.github/actions/build-and-test
+        with:
+          skip-e2e: ${{ github.event_name == 'push' && 'true' || 'false' }}


### PR DESCRIPTION
## Summary

Two CI efficiency improvements:

**1. Cache Playwright browsers (~21s saved per warm run)**
- Caches `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml` hash (changes when Playwright version bumps)
- On cache hit: skips `playwright install` (browser download) and only runs `playwright install-deps` (fast OS library install that can't be cached)
- On cache miss: full `playwright install --with-deps chromium` as before

**2. Skip E2E on push-to-main (~345s saved per merge)**
- New `skip-e2e` input on the `build-and-test` composite action
- Set to `true` on `push` events (main branch merges)
- PRs still get full E2E — the push-to-main run is redundant since the PR already passed E2E before merge
- Unit tests still run on push-to-main (build + test, just no E2E)

**Net impact:** ~6min saved per merge to main, ~21s saved on PR runs once Playwright cache is warm.

## Test plan

- [ ] PR CI passes (first run will be cache-miss for Playwright, so timing similar to before)
- [ ] Verify Playwright cache is saved (check "Post Cache Playwright browsers" step)
- [ ] After merge, verify push-to-main CI skips E2E steps