### PR TITLE
fix(e2e): stabilize flaky task-tree child creation test

### DIFF
--- a/tests/e2e-tests/tests/task-tree.spec.ts
+++ b/tests/e2e-tests/tests/task-tree.spec.ts
@@ -137,6 +137,9 @@ test.describe("Task tree hierarchy", () => {
     await page.locator('[data-testid="task-edit-title"]').fill("ac-child");
     await page.locator('[data-testid="task-edit-save"]').click();
 
+    // Wait for the edit panel to close, confirming the save round-trip completed
+    await expect(page.locator('[data-testid="task-edit-title"]')).not.toBeVisible({ timeout: 5_000 });
+
     // Navigate back to Tasks tab to see the updated tree
     await goToTasksTab(page);
 


### PR DESCRIPTION
## Summary
- Fix race condition in task-tree E2E test where navigating to the Tasks tab happened before the save round-trip completed
- Add an explicit wait for the edit panel to close (confirming the gRPC create succeeded and navigation occurred) before switching tabs

## Test plan
- [x] The fix adds a deterministic wait (`task-edit-title` not visible) between save and tab navigation
- [ ] CI: verify this test passes consistently (was 283/284 → 284/284 on retry before)

Closes #720