### PR TITLE
fix: enable e2e tests on main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,4 @@ jobs:
       - name: Build and test
         uses: ./.github/actions/build-and-test
         with:
-          skip-e2e: ${{ github.event_name == 'push' && 'true' || 'false' }}
           e2e-tags: ${{ steps.e2e-scope.outputs.tags }}


### PR DESCRIPTION
## Summary
- CI on `main` was skipping e2e tests (`skip-e2e: true`), which also skipped Playwright browser installation
- Storybook interaction tests (run during `rush test`) need Playwright's Chromium, causing consistent failures on main
- Removed the `skip-e2e` override so main and publish CI both run the full test suite (unit + storybook + e2e) with no tag filtering

## Test plan
- [ ] CI passes on this PR (e2e tests run successfully)
- [ ] After merge, CI on main should pass (no more storybook Playwright failures)