### PR TITLE
ci: publish nightly Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -2,8 +2,12 @@ name: Docker Nightly
 
 on:
   schedule:
-    - cron: '0 11 * * *'  # 5 AM Central (11:00 UTC)
+    - cron: '0 11 * * *'  # 11:00 UTC (05:00 CST / 06:00 CDT)
   workflow_dispatch:        # Manual trigger
+
+concurrency:
+  group: docker-nightly
+  cancel-in-progress: false
 
 jobs:
   build-and-push:
@@ -39,3 +43,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           no-cache: true  # Always pull fresh @latest npm packages
+          pull: true       # Always pull fresh base images


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build and push the server Docker image to `ghcr.io/nick-pape/grackle` nightly at 5 AM CT (11:00 UTC)
- Tags each build as `latest` + `nightly-YYYYMMDD` for pinning/rollback
- Uses `no-cache: true` to ensure fresh `@latest` npm packages on every build
- Supports `workflow_dispatch` for manual triggers

## Test plan

- [ ] Merge and trigger manually via Actions tab or `gh workflow run docker-nightly.yml`
- [ ] Verify image appears at `ghcr.io/nick-pape/grackle:latest`
- [ ] `docker pull ghcr.io/nick-pape/grackle:latest && docker run -d -p 3000:3000 -v test:/data ghcr.io/nick-pape/grackle:latest`
- [ ] Verify both Neo4j and Grackle start, web UI accessible

Closes #792