### PR TITLE
feat: Skeleton/shimmer loading primitives

### DIFF
--- a/packages/web-components/src/components/display/Skeleton.module.scss
+++ b/packages/web-components/src/components/display/Skeleton.module.scss
@@ -1,0 +1,58 @@
+// =============================================================================
+// Skeleton — shimmer loading placeholders
+// =============================================================================
+
+@use '../../styles/mixins' as *;
+
+// ─── Base shimmer block ──────────────────────────────────────────────────────
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    var(--bg-inset) 25%,
+    var(--bg-surface) 50%,
+    var(--bg-inset) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+.circular {
+  border-radius: 50%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+// ─── SkeletonText ────────────────────────────────────────────────────────────
+
+.textContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+// ─── SkeletonCard ────────────────────────────────────────────────────────────
+
+.card {
+  @include surface-card;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+}

--- a/packages/web-components/src/components/display/Skeleton.stories.tsx
+++ b/packages/web-components/src/components/display/Skeleton.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "@storybook/test";
+import { Skeleton, SkeletonText, SkeletonCard } from "./Skeleton.js";
+
+// ─── Skeleton (base) ─────────────────────────────────────────────────────────
+
+const skeletonMeta: Meta<typeof Skeleton> = {
+  component: Skeleton,
+  title: "Primitives/Display/Skeleton",
+  tags: ["autodocs"],
+};
+export default skeletonMeta;
+type Story = StoryObj<typeof skeletonMeta>;
+
+/** Default full-width skeleton block. */
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    const el = canvas.getByTestId("skeleton");
+    await expect(el).toBeInTheDocument();
+    await expect(el).toHaveAttribute("aria-hidden", "true");
+    await expect(el.className).toContain("skeleton");
+  },
+};
+
+/** Circular skeleton (avatar placeholder). */
+export const Circular: Story = {
+  args: { variant: "circular", width: "48px", height: "48px" },
+  play: async ({ canvas }) => {
+    const el = canvas.getByTestId("skeleton");
+    await expect(el.className).toContain("circular");
+  },
+};
+
+/** Custom width and height. */
+export const CustomSize: Story = {
+  args: { width: "200px", height: "2rem" },
+  play: async ({ canvas }) => {
+    const el = canvas.getByTestId("skeleton");
+    await expect(el.style.width).toBe("200px");
+    await expect(el.style.height).toBe("2rem");
+  },
+};
+
+// ─── SkeletonText ────────────────────────────────────────────────────────────
+
+/** Multi-line text placeholder (3 lines, last line shorter). */
+export const Text: Story = {
+  render: (args) => <SkeletonText {...args} />,
+  play: async ({ canvas }) => {
+    const container = canvas.getByTestId("skeleton-text");
+    await expect(container).toBeInTheDocument();
+    const lines = container.querySelectorAll("[data-testid='skeleton']");
+    await expect(lines.length).toBe(3);
+  },
+};
+
+/** Single-line text placeholder. */
+export const TextSingleLine: Story = {
+  render: () => <SkeletonText lines={1} />,
+  play: async ({ canvas }) => {
+    const container = canvas.getByTestId("skeleton-text");
+    const lines = container.querySelectorAll("[data-testid='skeleton']");
+    await expect(lines.length).toBe(1);
+  },
+};
+
+// ─── SkeletonCard ────────────────────────────────────────────────────────────
+
+/** Card-shaped skeleton with title and body text. */
+export const Card: Story = {
+  render: (args) => <SkeletonCard {...args} />,
+  play: async ({ canvas }) => {
+    const card = canvas.getByTestId("skeleton-card");
+    await expect(card).toBeInTheDocument();
+    // Title skeleton + text container with 2 lines = 3 skeleton elements total
+    const skeletons = card.querySelectorAll("[data-testid='skeleton']");
+    await expect(skeletons.length).toBe(3);
+  },
+};
+
+/** Grid of skeleton cards (composition demo). */
+export const CardGrid: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "var(--space-lg)" }}>
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const cards = canvas.getAllByTestId("skeleton-card");
+    await expect(cards.length).toBe(3);
+  },
+};

--- a/packages/web-components/src/components/display/Skeleton.tsx
+++ b/packages/web-components/src/components/display/Skeleton.tsx
@@ -1,0 +1,127 @@
+import type { JSX } from "react";
+import styles from "./Skeleton.module.scss";
+
+// ─── Skeleton (base shimmer block) ───────────────────────────────────────────
+
+/** Shape variant for the Skeleton component. */
+type SkeletonVariant = "rectangular" | "circular";
+
+/** Props for the {@link Skeleton} component. */
+interface SkeletonProps {
+  /** CSS width. Defaults to `"100%"`. */
+  width?: string;
+  /** CSS height. Defaults to `"1rem"`. */
+  height?: string;
+  /** CSS border-radius override. Ignored when `variant` is `"circular"`. */
+  borderRadius?: string;
+  /** Shape variant. `"circular"` forces 50% border-radius. Defaults to `"rectangular"`. */
+  variant?: SkeletonVariant;
+  /** Additional CSS class name. */
+  className?: string;
+}
+
+/**
+ * Animated shimmer placeholder that indicates loading content.
+ * Renders a decorative `<div>` with a gradient sweep animation.
+ */
+export function Skeleton({
+  width = "100%",
+  height = "1rem",
+  borderRadius,
+  variant = "rectangular",
+  className,
+}: SkeletonProps): JSX.Element {
+  const classNames = [
+    styles.skeleton,
+    variant === "circular" ? styles.circular : "",
+    className ?? "",
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={classNames}
+      style={{
+        width,
+        height,
+        ...(borderRadius && variant !== "circular" ? { borderRadius } : {}),
+      }}
+      aria-hidden="true"
+      data-testid="skeleton"
+    />
+  );
+}
+
+// ─── SkeletonText (multi-line text placeholder) ──────────────────────────────
+
+/** Props for the {@link SkeletonText} component. */
+interface SkeletonTextProps {
+  /** Number of text lines. Defaults to `3`. */
+  lines?: number;
+  /** Width of the last line. Defaults to `"60%"`. */
+  lastLineWidth?: string;
+  /** Height of each line. Defaults to `"0.75rem"`. */
+  lineHeight?: string;
+  /** Gap between lines. Defaults to `"var(--space-sm)"`. */
+  gap?: string;
+  /** Additional CSS class name. */
+  className?: string;
+}
+
+/**
+ * Multi-line skeleton text placeholder. Renders `lines` shimmer blocks
+ * with the last line at a shorter width to simulate trailing text.
+ */
+export function SkeletonText({
+  lines = 3,
+  lastLineWidth = "60%",
+  lineHeight = "0.75rem",
+  gap = "var(--space-sm)",
+  className,
+}: SkeletonTextProps): JSX.Element {
+  return (
+    <div
+      className={`${styles.textContainer} ${className ?? ""}`}
+      style={{ gap }}
+      aria-hidden="true"
+      data-testid="skeleton-text"
+    >
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton
+          key={i}
+          width={i === lines - 1 && lines > 1 ? lastLineWidth : "100%"}
+          height={lineHeight}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ─── SkeletonCard (card-shaped placeholder) ──────────────────────────────────
+
+/** Props for the {@link SkeletonCard} component. */
+interface SkeletonCardProps {
+  /** Number of body text lines inside the card. Defaults to `2`. */
+  lines?: number;
+  /** Additional CSS class name. */
+  className?: string;
+}
+
+/**
+ * Card-shaped skeleton placeholder matching the standard card layout.
+ * Contains a title-width shimmer block and body text lines.
+ */
+export function SkeletonCard({
+  lines = 2,
+  className,
+}: SkeletonCardProps): JSX.Element {
+  return (
+    <div
+      className={`${styles.card} ${className ?? ""}`}
+      aria-hidden="true"
+      data-testid="skeleton-card"
+    >
+      <Skeleton width="40%" height="1.25rem" />
+      <SkeletonText lines={lines} />
+    </div>
+  );
+}

--- a/packages/web-components/src/components/display/index.ts
+++ b/packages/web-components/src/components/display/index.ts
@@ -9,6 +9,7 @@ export { DemoBanner } from "./DemoBanner.js";
 export { SplitButton } from "./SplitButton.js";
 export { EventRenderer } from "./EventRenderer.js";
 export { ConfirmDialog } from "./ConfirmDialog.js";
+export { Skeleton, SkeletonText, SkeletonCard } from "./Skeleton.js";
 export { Spinner } from "./Spinner.js";
 export { SplashScreen } from "./SplashScreen.js";
 

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -18,7 +18,8 @@ export { useDagLayout } from "./components/dag/useDagLayout.js";
 // Display primitives
 export {
   Breadcrumbs, Button, CopyButton, DemoBanner, SplitButton,
-  EventRenderer, ConfirmDialog, Spinner, SplashScreen,
+  EventRenderer, ConfirmDialog, Skeleton, SkeletonText, SkeletonCard,
+  Spinner, SplashScreen,
 } from "./components/display/index.js";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/display/index.js";
 export { EventStream } from "./components/display/EventStream.js";


### PR DESCRIPTION
## Summary
- Add `Skeleton`, `SkeletonText`, and `SkeletonCard` components to `@grackle-ai/web-components`
- CSS shimmer animation with `prefers-reduced-motion` support
- Storybook stories with interaction tests (7 stories: Default, Circular, CustomSize, Text, TextSingleLine, Card, CardGrid)
- Exported from package root for use by `@grackle-ai/web` pages

## Test plan
- [x] `rush build -t @grackle-ai/web-components` — clean build
- [ ] Storybook interaction tests pass via CI (`rush test`)
- [ ] Visual verification in Storybook (shimmer animation renders correctly)

Closes #1093