### PR TITLE
chore: trigger publish to include web-components on npm

### DIFF
--- a/common/changes/@grackle-ai/cli/publish-web-components_2026-04-01-14-59.json
+++ b/common/changes/@grackle-ai/cli/publish-web-components_2026-04-01-14-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@grackle-ai/cli",
+      "comment": "Add @grackle-ai/web-components to version policy so it is published to npm",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@grackle-ai/cli"
+}


### PR DESCRIPTION
Adds a patch changefile to trigger a publish cycle. PR #1175 added web-components to the version policy, but without a changefile the publish workflow had nothing to do. Once this merges, the publish workflow will bump all packages and publish web-components to npm for the first time, unblocking the Docker nightly build.