### PR TITLE
fix: resolve environment from workspace linkedEnvironmentIds in startTask (#1205)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1205-task-env-resolution_2026-04-25-08-01.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1205-task-env-resolution_2026-04-25-08-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix startTask to resolve environment from workspace linkedEnvironmentIds when no explicit environment or ancestor environment is specified; surface startTask errors as toasts instead of silently swallowing them",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/plugin-core/src/task-handlers.test.ts
+++ b/packages/plugin-core/src/task-handlers.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ConnectError, Code } from "@connectrpc/connect";
+import type { ConnectRouter } from "@connectrpc/connect";
+
+// ── Mock @grackle-ai/database ────────────────────────────────────────
+
+vi.mock("@grackle-ai/database", async () => {
+  const { createDatabaseMock } = await import("./test-utils/mock-database.js");
+  return createDatabaseMock();
+});
+
+// ── Mock @grackle-ai/core ────────────────────────────────────────────
+
+vi.mock("@grackle-ai/core", async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    emit: vi.fn(),
+    streamHub: {
+      publish: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+      createGlobalStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+    },
+    streamRegistry: { register: vi.fn() },
+    tokenPush: { refreshTokensForTask: vi.fn().mockResolvedValue(undefined) },
+    adapterManager: { getConnection: vi.fn(() => ({ id: "mock-conn" })) },
+    personasStore: {
+      getPersona: vi.fn(() => ({
+        id: "system",
+        name: "System",
+        model: "claude-sonnet-4-5",
+        prompt: "",
+        systemPrompt: "",
+        mcpServers: [],
+      })),
+    },
+    cleanupLifecycleStream: vi.fn(),
+    ensureLifecycleStream: vi.fn(),
+    processEventStream: vi.fn(),
+    processorRegistry: { get: vi.fn(() => undefined), lateBind: vi.fn() },
+  };
+});
+
+// ── Mock local modules ───────────────────────────────────────────────
+
+vi.mock("./grpc-shared.js", () => ({
+  validatePipeInputs: vi.fn(),
+  toDialableHost: vi.fn((host: string) => host),
+  resolveAncestorEnvironmentId: vi.fn(() => ""),
+}));
+
+vi.mock("./lifecycle.js", () => ({
+  cleanupLifecycleStream: vi.fn(),
+  ensureLifecycleStream: vi.fn(),
+}));
+
+vi.mock("./signals/orphan-reparent.js", () => ({
+  transferAllPipeSubscriptions: vi.fn(),
+}));
+
+vi.mock("./grpc-proto-converters.js", () => ({
+  taskRowToProto: vi.fn(),
+  sessionRowToProto: vi.fn(),
+}));
+
+vi.mock("@grackle-ai/prompt", () => ({
+  buildTaskPrompt: vi.fn((title: string) => `Prompt for ${title}`),
+  buildOrchestratorContext: vi.fn(() => ({})),
+  buildOrchestratorContextInput: vi.fn(() => ({})),
+}));
+
+vi.mock("node:path", async () => {
+  const actual = await vi.importActual("node:path") as Record<string, unknown>;
+  return { ...actual, join: (...parts: string[]) => parts.join("/") };
+});
+
+// ── Import AFTER mocks ───────────────────────────────────────────────
+
+import { registerGrackleRoutes } from "./grpc-service.js";
+import {
+  taskStore,
+  sessionStore,
+  workspaceStore,
+  workspaceEnvironmentLinkStore,
+} from "@grackle-ai/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getHandlers(): Record<string, (...args: any[]) => any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handlers: Record<string, (...args: any[]) => any> = {};
+  const fakeRouter = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service(_def: unknown, impl: Record<string, (...args: any[]) => any>) {
+      handlers = { ...handlers, ...impl };
+    },
+  } as unknown as ConnectRouter;
+  registerGrackleRoutes(fakeRouter);
+  return handlers;
+}
+
+function makeTaskRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "task-1",
+    workspaceId: "ws-1",
+    title: "Test Task",
+    description: "",
+    status: "not_started",
+    branch: "",
+    dependsOn: "[]",
+    startedAt: null,
+    completedAt: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    sortOrder: 0,
+    parentTaskId: "",
+    depth: 0,
+    canDecompose: false,
+    defaultPersonaId: "",
+    workpad: "",
+    scheduleId: "",
+    ...overrides,
+  };
+}
+
+function makeWorkspaceRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "ws-1",
+    name: "Test Workspace",
+    description: "",
+    repoUrl: "",
+    status: "active",
+    useWorktrees: true,
+    workingDirectory: "",
+    defaultPersonaId: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("startTask environment resolution", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handlers: Record<string, (...args: any[]) => any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = getHandlers();
+
+    vi.mocked(taskStore.getTask).mockReturnValue(makeTaskRow() as never);
+    vi.mocked(taskStore.areDependenciesMet).mockReturnValue(true);
+    vi.mocked(sessionStore.listSessionsForTask).mockReturnValue([]);
+    vi.mocked(workspaceStore.getWorkspace).mockReturnValue(makeWorkspaceRow() as never);
+    vi.mocked(workspaceEnvironmentLinkStore.getLinkedEnvironmentIds).mockReturnValue(["env-linked-1"]);
+  });
+
+  it("throws FailedPrecondition when workspace has no linked envs", async () => {
+    vi.mocked(workspaceEnvironmentLinkStore.getLinkedEnvironmentIds).mockReturnValue([]);
+
+    const err = await handlers.startTask({
+      taskId: "task-1",
+      personaId: "",
+      environmentId: "",
+      notes: "",
+    }).catch((e: unknown) => e) as ConnectError;
+
+    expect(err).toBeInstanceOf(ConnectError);
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.message).toContain("No environment specified");
+  });
+
+  it("throws FailedPrecondition when task has no workspace and no env passed", async () => {
+    vi.mocked(taskStore.getTask).mockReturnValue(
+      makeTaskRow({ workspaceId: null }) as never,
+    );
+    vi.mocked(workspaceEnvironmentLinkStore.getLinkedEnvironmentIds).mockReturnValue([]);
+
+    const err = await handlers.startTask({
+      taskId: "task-1",
+      personaId: "",
+      environmentId: "",
+      notes: "",
+    }).catch((e: unknown) => e) as ConnectError;
+
+    expect(err).toBeInstanceOf(ConnectError);
+    expect(err.code).toBe(Code.FailedPrecondition);
+  });
+});

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -17,7 +17,7 @@ import {
   fuzzySearch,
   type FuzzyKey,
 } from "@grackle-ai/common";
-import { envRegistry, sessionStore, taskStore, workspaceStore, personaStore, settingsStore, dispatchQueueStore, grackleHome, slugify, safeParseJsonArray } from "@grackle-ai/database";
+import { envRegistry, sessionStore, taskStore, workspaceStore, personaStore, settingsStore, dispatchQueueStore, grackleHome, slugify, safeParseJsonArray, workspaceEnvironmentLinkStore } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
 import { adapterManager } from "@grackle-ai/core";
@@ -309,6 +309,7 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
 
   const environmentId = req.environmentId
     || resolveAncestorEnvironmentId(task.parentTaskId)
+    || (task.workspaceId ? workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(task.workspaceId)[0] : "")
     || "";
   if (!environmentId) {
     throw new ConnectError("No environment specified for task, ancestor, or workspace", Code.FailedPrecondition);

--- a/packages/web/src/hooks/useTasks.test.ts
+++ b/packages/web/src/hooks/useTasks.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { ConnectError, Code } from "@connectrpc/connect";
 import { useTasks } from "./useTasks.js";
 
 // ---------------------------------------------------------------------------
@@ -9,6 +10,7 @@ import { useTasks } from "./useTasks.js";
 
 const mockClient = vi.hoisted(() => ({
   listTasks: vi.fn(),
+  startTask: vi.fn(),
 }));
 
 vi.mock("./useGrackleClient.js", () => ({
@@ -71,5 +73,65 @@ describe("useTasks loading state", () => {
     await waitFor(() => {
       expect(result.current.tasksLoading).toBe(false);
     });
+  });
+});
+
+describe("useTasks startTask", () => {
+  it("sets startingId and re-throws non-ResourceExhausted errors", async () => {
+    const connectErr = new ConnectError("No environment specified", Code.FailedPrecondition);
+    mockClient.startTask.mockRejectedValue(connectErr);
+
+    const { result } = setup();
+
+    let caught: unknown;
+    act(() => {
+      caught = result.current.startTask("task-1").catch((e: unknown) => e);
+    });
+
+    expect(result.current.taskStartingId).toBe("task-1");
+
+    await waitFor(() => {
+      expect(result.current.taskStartingId).toBe(undefined);
+    });
+
+    expect(caught).toBe(connectErr);
+  });
+
+  it("does NOT re-throw ResourceExhausted (task queued)", async () => {
+    const resourceErr = new ConnectError("Environment at capacity", Code.ResourceExhausted);
+    mockClient.startTask.mockRejectedValue(resourceErr);
+
+    const { result } = setup();
+
+    let caught: unknown;
+    act(() => {
+      caught = result.current.startTask("task-1");
+    });
+
+    // StartingId should remain set (task is queued)
+    expect(result.current.taskStartingId).toBe("task-1");
+
+    // Should not throw
+    expect(caught).toBe(undefined);
+  });
+
+  it("clears startingId and re-throws on generic error", async () => {
+    const genericErr = new Error("Something went wrong");
+    mockClient.startTask.mockRejectedValue(genericErr);
+
+    const { result } = setup();
+
+    let caught: unknown;
+    act(() => {
+      caught = result.current.startTask("task-1").catch((e: unknown) => e);
+    });
+
+    expect(result.current.taskStartingId).toBe("task-1");
+
+    await waitFor(() => {
+      expect(result.current.taskStartingId).toBe(undefined);
+    });
+
+    expect(caught).toBe(genericErr);
   });
 });

--- a/packages/web/src/hooks/useTasks.test.ts
+++ b/packages/web/src/hooks/useTasks.test.ts
@@ -84,16 +84,15 @@ describe("useTasks startTask", () => {
     const { result } = setup();
 
     let caught: unknown;
-    act(() => {
-      caught = result.current.startTask("task-1").catch((e: unknown) => e);
+    await act(async () => {
+      try {
+        await result.current.startTask("task-1");
+      } catch (e) {
+        caught = e;
+      }
     });
 
-    expect(result.current.taskStartingId).toBe("task-1");
-
-    await waitFor(() => {
-      expect(result.current.taskStartingId).toBe(undefined);
-    });
-
+    expect(result.current.taskStartingId).toBe(undefined);
     expect(caught).toBe(connectErr);
   });
 
@@ -103,16 +102,20 @@ describe("useTasks startTask", () => {
 
     const { result } = setup();
 
-    let caught: unknown;
-    act(() => {
-      caught = result.current.startTask("task-1");
+    let threw = false;
+    await act(async () => {
+      try {
+        await result.current.startTask("task-1");
+      } catch {
+        threw = true;
+      }
     });
 
     // StartingId should remain set (task is queued)
     expect(result.current.taskStartingId).toBe("task-1");
 
-    // Should not throw
-    expect(caught).toBe(undefined);
+    // Should not have thrown
+    expect(threw).toBe(false);
   });
 
   it("clears startingId and re-throws on generic error", async () => {
@@ -122,16 +125,15 @@ describe("useTasks startTask", () => {
     const { result } = setup();
 
     let caught: unknown;
-    act(() => {
-      caught = result.current.startTask("task-1").catch((e: unknown) => e);
+    await act(async () => {
+      try {
+        await result.current.startTask("task-1");
+      } catch (e) {
+        caught = e;
+      }
     });
 
-    expect(result.current.taskStartingId).toBe("task-1");
-
-    await waitFor(() => {
-      expect(result.current.taskStartingId).toBe(undefined);
-    });
-
+    expect(result.current.taskStartingId).toBe(undefined);
     expect(caught).toBe(genericErr);
   });
 });

--- a/packages/web/src/hooks/useTasks.ts
+++ b/packages/web/src/hooks/useTasks.ts
@@ -208,6 +208,7 @@ export function useTasks(): UseTasksResult {
           return;
         }
         setTaskStartingId(undefined);
+        throw err;
       }
     },
     [],

--- a/packages/web/src/pages/TaskPage.tsx
+++ b/packages/web/src/pages/TaskPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useParams, useLocation } from "react-router";
+import { ConnectError } from "@connectrpc/connect";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
   Breadcrumbs, ChatInput, ConfirmDialog, EventStream, FindingsPanel,
@@ -246,7 +247,12 @@ export function TaskPage(): JSX.Element {
             task={task}
             sessionId={sessionId}
             isBlocked={isTaskBlocked}
-            onStart={() => { startTask(task.id, undefined, selectedEnvId).catch(() => {}); }}
+            onStart={() => {
+              startTask(task.id, undefined, selectedEnvId).catch((err) => {
+                const message = err instanceof ConnectError ? err.message : "Failed to start task";
+                showToast(message, "error");
+              });
+            }}
             onResume={() => { resumeTask(task.id).catch(() => {}); }}
             onStop={() => { stopTask(task.id).catch(() => {}); }}
             onPause={() => { if (sessionId) { kill(sessionId).catch(() => {}); } }}
@@ -323,7 +329,12 @@ export function TaskPage(): JSX.Element {
                     </div>
                   ) : (
                     <div className={styles.emptyCta}>
-                      <button data-testid="stream-start-cta" className={styles.ctaButton} onClick={() => { startTask(task.id, undefined, selectedEnvId).catch(() => {}); }}>Start Task</button>
+                      <button data-testid="stream-start-cta" className={styles.ctaButton} onClick={() => {
+                          startTask(task.id, undefined, selectedEnvId).catch((err) => {
+                            const message = err instanceof ConnectError ? err.message : "Failed to start task";
+                            showToast(message, "error");
+                          });
+                        }}>Start Task</button>
                       <div className={styles.ctaDescription}>Click to begin agent execution</div>
                     </div>
                   )

--- a/tests/e2e-tests/tests/fixtures.ts
+++ b/tests/e2e-tests/tests/fixtures.ts
@@ -163,7 +163,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
             }
             const body = JSON.parse(bodyStr);
             body.personaId = "stub";
-            if (!body.environmentId) {
+            if (body.environmentId == null) {
               body.environmentId = envId;
             }
             const newBodyStr = JSON.stringify(body);

--- a/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
+++ b/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
@@ -11,16 +11,18 @@ test.describe("Task start with workspace-linked environment resolution", { tag: 
   test("starts task when workspace has linked env and no env passed explicitly", async ({ stubTask }) => {
     const { page } = stubTask;
 
-    // Create a task — the workspace is linked to "test-local" by the fixture,
-    // but the stub runtime patch injects the envId. We verify the task starts
-    // successfully, confirming the server-side resolution chain works.
+    // Create a task in a workspace that is linked to "test-local" by the fixture.
+    // The stub fetch patch injects personaId="stub" but does NOT inject environmentId
+    // (only injects when environmentId is null/undefined, not when it is "").
+    // So the StartTask request reaches the server with environmentId="" and the
+    // server resolves it via the workspace's linkedEnvironmentIds fallback.
     await stubTask.createAndNavigate("linked-env-start", stubScenario(
       emitText("Working on linked env task..."),
       onInputMatch({ fail: "fail", "*": "next" }),
       idle(),
     ));
 
-    // Click Start — the server should resolve environment from workspace's linked envs
+    // Click Start — server resolves environment from workspace's linked envs
     await page.getByTestId("task-header-start").click();
 
     // Wait for stub to reach waiting_input
@@ -40,19 +42,19 @@ test.describe("Task start with workspace-linked environment resolution", { tag: 
   test("shows error toast when startTask fails", async ({ stubTask }) => {
     const { page, client } = stubTask;
 
-    // Create a task via RPC (no scenario, just a plain task)
     const task = await stubTask.createTask("error-toast-test");
     await navigateToTask(page, "error-toast-test");
 
-    // Click Start — this will fail because there's no connected environment
-    // (the stub runtime patch injects envId but no persona is configured for normal tasks)
-    // The error should be surfaced as a toast, not silently swallowed.
+    // Stop the environment so StartTask fails with "Environment not connected".
+    // The server resolves environmentId via the workspace fallback ("test-local")
+    // but it is now disconnected → FailedPrecondition error.
+    // That error must surface as a toast rather than being silently swallowed.
+    await client.core.stopEnvironment({ id: "test-local" });
+
     await page.getByTestId("task-header-start").click();
 
-    // Give the toast time to appear — the error message from the server
-    // should be displayed as a toast notification
-    await expect(page.getByText(/Failed to start task|No environment|failed/i), {
-      timeout: 10_000,
-    }).toBeVisible();
+    await expect(
+      page.getByText(/not connected|Failed to start task/i),
+    ).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
+++ b/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "./fixtures.js";
+import {
+  stubScenario,
+  emitText,
+  idle,
+  onInputMatch,
+  navigateToTask,
+} from "./helpers.js";
+
+test.describe("Task start with workspace-linked environment resolution", { tag: ["@task"] }, () => {
+  test("starts task when workspace has linked env and no env passed explicitly", async ({ stubTask }) => {
+    const { page } = stubTask;
+
+    // Create a task — the workspace is linked to "test-local" by the fixture,
+    // but the stub runtime patch injects the envId. We verify the task starts
+    // successfully, confirming the server-side resolution chain works.
+    await stubTask.createAndNavigate("linked-env-start", stubScenario(
+      emitText("Working on linked env task..."),
+      onInputMatch({ fail: "fail", "*": "next" }),
+      idle(),
+    ));
+
+    // Click Start — the server should resolve environment from workspace's linked envs
+    await page.getByTestId("task-header-start").click();
+
+    // Wait for stub to reach waiting_input
+    const inputField = page.locator('input[placeholder="Type a message..."]');
+    await expect(inputField).toBeVisible({ timeout: 15_000 });
+
+    // Send input to advance the stub
+    await inputField.fill("continue");
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+
+    // Task should transition to paused (review) state
+    await expect(page.getByRole("button", { name: "Resume", exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("shows error toast when startTask fails", async ({ stubTask }) => {
+    const { page, client } = stubTask;
+
+    // Create a task via RPC (no scenario, just a plain task)
+    const task = await stubTask.createTask("error-toast-test");
+    await navigateToTask(page, "error-toast-test");
+
+    // Click Start — this will fail because there's no connected environment
+    // (the stub runtime patch injects envId but no persona is configured for normal tasks)
+    // The error should be surfaced as a toast, not silently swallowed.
+    await page.getByTestId("task-header-start").click();
+
+    // Give the toast time to appear — the error message from the server
+    // should be displayed as a toast notification
+    await expect(page.getByText(/Failed to start task|No environment|failed/i), {
+      timeout: 10_000,
+    }).toBeVisible();
+  });
+});

--- a/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
+++ b/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
@@ -42,7 +42,7 @@ test.describe("Task start with workspace-linked environment resolution", { tag: 
   test("shows error toast when startTask fails", async ({ stubTask }) => {
     const { page, client } = stubTask;
 
-    const task = await stubTask.createTask("error-toast-test");
+    await stubTask.createTask("error-toast-test");
     await navigateToTask(page, "error-toast-test");
 
     // Stop the environment so StartTask fails with "Environment not connected".


### PR DESCRIPTION
## Summary

- **Server**: Add `workspaceEnvironmentLinkStore.getLinkedEnvironmentIds()` fallback in `task-handlers.ts` startTask handler, after ancestor env resolution
- **Client**: Re-throw non-`ResourceExhausted` errors from `useTasks.startTask` hook so callers can surface them as toasts
- **Client**: Add error toast handling in `TaskPage.tsx` Start Task buttons
- **Tests**: Add server-side unit tests for environment resolution cascade
- **Tests**: Add client-side unit tests for error propagation in `useTasks`

## Problem

`startTask` gRPC handler's environment resolution chain was:

```
req.environmentId → ancestor env → ""
```

Missing `workspace.linkedEnvironmentIds[0]` — so tasks on workspaces with linked environments would fail with `FailedPrecondition` if no explicit env was passed, even though the workspace had a default.

## Solution

The resolution cascade is now:

```
req.environmentId → ancestor env → workspace linkedEnvironmentIds[0] → ""
```

Client-side, errors are now re-thrown (except `ResourceExhausted` for queued dispatch) and surfaced as toasts in the UI.

## Tests

- **Server unit tests** (`task-handlers.test.ts`): 2 tests verifying `FailedPrecondition` when no env available
- **Client unit tests** (`useTasks.test.ts`): 3 tests for startTask error propagation
- **E2E test** (`task-start-env-resolution.spec.ts`): integration test for workspace-linked env auto-selection

## Files Changed

| File | Type |
|------|------|
| `packages/plugin-core/src/task-handlers.ts` | Server fix |
| `packages/web/src/hooks/useTasks.ts` | Client fix |
| `packages/web/src/pages/TaskPage.tsx` | Client fix |
| `packages/plugin-core/src/task-handlers.test.ts` | New unit test |
| `packages/web/src/hooks/useTasks.test.ts` | New unit tests |
| `tests/e2e-tests/tests/task-start-env-resolution.spec.ts` | New E2E test |