### PR TITLE
fix: stop deleted-codespace retry storm from wiping System session

### DIFF
--- a/common/api/adapter-codespace.public.api.md
+++ b/common/api/adapter-codespace.public.api.md
@@ -7,6 +7,7 @@
 import type { AdapterDependencies } from '@grackle-ai/adapter-sdk';
 import type { BaseEnvironmentConfig } from '@grackle-ai/adapter-sdk';
 import type { EnvironmentAdapter } from '@grackle-ai/adapter-sdk';
+import { FatalAdapterError } from '@grackle-ai/adapter-sdk';
 import type { PowerLineConnection } from '@grackle-ai/adapter-sdk';
 import type { ProvisionEvent } from '@grackle-ai/adapter-sdk';
 
@@ -30,6 +31,11 @@ export interface CodespaceEnvironmentConfig extends BaseEnvironmentConfig {
     env?: Record<string, string>;
     githubAccountId?: string;
     localPort?: number;
+}
+
+// @public
+export class CodespaceNotFoundError extends FatalAdapterError {
+    constructor(codespaceName: string);
 }
 
 // (No @packageDocumentation comment for this package)

--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -147,6 +147,11 @@ export interface ExecResult {
 }
 
 // @public
+export class FatalAdapterError extends Error {
+    constructor(message: string);
+}
+
+// @public
 const file_grackle_powerline_powerline: GenFile;
 
 // @public

--- a/common/changes/@grackle-ai/cli/nick-pape-codespace-fatal-error_2026-04-28-21-20.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-codespace-fatal-error_2026-04-28-21-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix deleted-codespace retry storm: add FatalAdapterError to stop auto-reconnect on permanent adapter failures; suppress intermediate-transition toasts; preserve ChatInput text across session-state flips",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "nickpape@outlook.com"
+}

--- a/packages/adapter-codespace/src/codespace.test.ts
+++ b/packages/adapter-codespace/src/codespace.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ProvisionEvent } from "@grackle-ai/adapter-sdk";
+import { FatalAdapterError } from "@grackle-ai/adapter-sdk";
+import { CodespaceNotFoundError } from "./codespace.js";
 
 // ── Mock adapter-sdk (tunnel/process functions that can't be DI'd) ──
 const mocks = vi.hoisted(() => ({
@@ -118,5 +120,70 @@ describe("CodespaceAdapter.reconnect()", () => {
   it("throws if codespaceName is missing", async () => {
     await expect(collectEvents(adapter.reconnect!(envId, {} as Record<string, unknown>, token)))
       .rejects.toThrow("codespaceName");
+  });
+
+});
+
+// ── CodespaceNotFoundError detection ────────────────────────
+// These tests go through provision() because that calls executor.exec() directly
+// (startRemotePowerLine is mocked in reconnect() tests above, bypassing the executor).
+
+describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()", () => {
+  let adapter: CodespaceAdapter;
+  const config = { codespaceName: "test-cs" };
+  const token = "test-token";
+  const envId = "env-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new CodespaceAdapter({ exec: mockExec, sleep: mockSleep });
+  });
+
+  it("throws CodespaceNotFoundError (FatalAdapterError) when gh stderr contains 'Not Found'", async () => {
+    const ghErr = Object.assign(new Error("Command failed: gh codespace ssh"), {
+      stderr: "error getting codespace: Not Found",
+    });
+    mockExec.mockRejectedValueOnce(ghErr);
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(CodespaceNotFoundError);
+    expect(err).toBeInstanceOf(FatalAdapterError);
+    expect((err as Error).message).toContain("test-cs");
+  });
+
+  it("throws CodespaceNotFoundError when gh message contains 'not found'", async () => {
+    mockExec.mockRejectedValueOnce(new Error("Codespace test-cs not found"));
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(CodespaceNotFoundError);
+  });
+
+  it("throws CodespaceNotFoundError when gh reports 'does not exist'", async () => {
+    const ghErr = Object.assign(new Error("Command failed"), {
+      stderr: "The codespace 'test-cs' does not exist",
+    });
+    mockExec.mockRejectedValueOnce(ghErr);
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(CodespaceNotFoundError);
+  });
+
+  it("does NOT throw CodespaceNotFoundError for generic SSH failures", async () => {
+    const sshErr = Object.assign(new Error("Command failed: gh codespace ssh"), {
+      stderr: "ssh: connect to host 127.0.0.1 port 22: Connection refused",
+    });
+    mockExec.mockRejectedValueOnce(sshErr);
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).not.toBeInstanceOf(CodespaceNotFoundError);
+    expect(err).not.toBeInstanceOf(FatalAdapterError);
   });
 });

--- a/packages/adapter-codespace/src/codespace.test.ts
+++ b/packages/adapter-codespace/src/codespace.test.ts
@@ -190,6 +190,21 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
     expect(err).toBeInstanceOf(CodespaceNotFoundError);
   });
 
+  it("throws CodespaceNotFoundError for real gh HTTP 404 response (getting full codespace details)", async () => {
+    // This is the actual error gh codespace ssh emits when the codespace doesn't exist:
+    // "getting full codespace details: HTTP 404: Not Found"
+    const ghErr = Object.assign(new Error("Command failed: gh codespace ssh"), {
+      stderr: "getting full codespace details: HTTP 404: Not Found (https://api.github.com/user/codespaces/fake-cs)",
+    });
+    mockExec.mockRejectedValueOnce(ghErr);
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(CodespaceNotFoundError);
+    expect(err).toBeInstanceOf(FatalAdapterError);
+  });
+
   it("does NOT throw CodespaceNotFoundError for generic SSH failures", async () => {
     const sshErr = Object.assign(new Error("Command failed: gh codespace ssh"), {
       stderr: "ssh: connect to host 127.0.0.1 port 22: Connection refused",

--- a/packages/adapter-codespace/src/codespace.test.ts
+++ b/packages/adapter-codespace/src/codespace.test.ts
@@ -153,13 +153,29 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
     expect((err as Error).message).toContain("test-cs");
   });
 
-  it("throws CodespaceNotFoundError when gh message contains 'not found'", async () => {
-    mockExec.mockRejectedValueOnce(new Error("Codespace test-cs not found"));
+  it("throws CodespaceNotFoundError when gh stderr matches 'no such codespace'", async () => {
+    const ghErr = Object.assign(new Error("Command failed"), {
+      stderr: "no such codespace: test-cs",
+    });
+    mockExec.mockRejectedValueOnce(ghErr);
 
     const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(CodespaceNotFoundError);
+  });
+
+  it("does NOT throw CodespaceNotFoundError for 'command not found' (false-positive guard)", async () => {
+    const bashErr = Object.assign(new Error("Command failed"), {
+      stderr: "bash: somebin: command not found",
+    });
+    mockExec.mockRejectedValueOnce(bashErr);
+
+    const err = await collectEvents(adapter.provision(envId, config as Record<string, unknown>, token))
+      .catch((e: unknown) => e);
+
+    expect(err).not.toBeInstanceOf(CodespaceNotFoundError);
+    expect(err).not.toBeInstanceOf(FatalAdapterError);
   });
 
   it("throws CodespaceNotFoundError when gh reports 'does not exist'", async () => {

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -40,7 +40,7 @@ export class CodespaceNotFoundError extends FatalAdapterError {
 }
 
 /** Patterns in gh CLI stderr/message that specifically indicate the codespace no longer exists. */
-const CODESPACE_NOT_FOUND_PATTERNS: RegExp = /error getting codespace|codespace.*does not exist|no such codespace/i;
+const CODESPACE_NOT_FOUND_PATTERNS: RegExp = /error getting codespace|codespace.*does not exist|no such codespace|getting full codespace details/i;
 
 // ─── Config ─────────────────────────────────────────────────
 

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentAdapter, BaseEnvironmentConfig, PowerLineConnection, ProvisionEvent, AdapterDependencies, ExecFunction } from "@grackle-ai/adapter-sdk";
+import { FatalAdapterError } from "@grackle-ai/adapter-sdk";
 import { DEFAULT_POWERLINE_PORT, DEFAULT_MCP_PORT } from "@grackle-ai/common";
 import {
   type RemoteExecutor,
@@ -25,6 +26,21 @@ const REMOTE_COPY_TIMEOUT_MS: number = 120_000;
 
 /** Delay for reverse tunnels to wait for SSH to establish. */
 const REVERSE_TUNNEL_SETTLE_MS: number = 3_000;
+
+/**
+ * Thrown when the codespace no longer exists on GitHub.
+ * Extends `FatalAdapterError` so the auto-reconnect loop stops immediately
+ * and marks the environment as `error` rather than continuing to retry.
+ */
+export class CodespaceNotFoundError extends FatalAdapterError {
+  public constructor(codespaceName: string) {
+    super(`Codespace '${codespaceName}' not found — it may have been deleted`);
+    this.name = "CodespaceNotFoundError";
+  }
+}
+
+/** Patterns in gh CLI stderr that indicate the codespace no longer exists. */
+const CODESPACE_NOT_FOUND_PATTERNS: RegExp = /not found|does not exist|no such codespace/i;
 
 // ─── Config ─────────────────────────────────────────────────
 
@@ -61,11 +77,16 @@ class CodespaceExecutor implements RemoteExecutor {
   /** Execute a shell command inside the codespace and return trimmed stdout. */
   public async exec(command: string, opts?: { timeout?: number }): Promise<string> {
     const args = ["codespace", "ssh", "-c", this.codespaceName, "--", command];
-    const result = await this.execFn("gh", args, {
-      timeout: opts?.timeout ?? REMOTE_EXEC_DEFAULT_TIMEOUT_MS,
-      env: this.ghEnv,
-    });
-    return result.stdout;
+    try {
+      const result = await this.execFn("gh", args, {
+        timeout: opts?.timeout ?? REMOTE_EXEC_DEFAULT_TIMEOUT_MS,
+        env: this.ghEnv,
+      });
+      return result.stdout;
+    } catch (err) {
+      this.rethrowIfNotFound(err);
+      throw err;
+    }
   }
 
   /** Copy a local file or directory into the codespace via `gh codespace cp`. */
@@ -82,7 +103,21 @@ class CodespaceExecutor implements RemoteExecutor {
       localPath,
       `remote:${resolvedPath}`,
     ];
-    await this.execFn("gh", args, { timeout: REMOTE_COPY_TIMEOUT_MS, env: this.ghEnv });
+    try {
+      await this.execFn("gh", args, { timeout: REMOTE_COPY_TIMEOUT_MS, env: this.ghEnv });
+    } catch (err) {
+      this.rethrowIfNotFound(err);
+      throw err;
+    }
+  }
+
+  /** Throw {@link CodespaceNotFoundError} if the error indicates the codespace was deleted. */
+  private rethrowIfNotFound(err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    const stderr = (err as { stderr?: string }).stderr ?? "";
+    if (CODESPACE_NOT_FOUND_PATTERNS.test(message) || CODESPACE_NOT_FOUND_PATTERNS.test(stderr)) {
+      throw new CodespaceNotFoundError(this.codespaceName);
+    }
   }
 }
 
@@ -205,6 +240,9 @@ export class CodespaceAdapter implements EnvironmentAdapter {
     try {
       await executor.exec("echo ok", { timeout: SSH_CONNECTIVITY_TIMEOUT_MS });
     } catch (err) {
+      if (err instanceof FatalAdapterError) {
+        throw err;
+      }
       throw new Error(`Cannot reach codespace '${cfg.codespaceName}' via gh CLI: ${err instanceof Error ? err.message : String(err)}`);
     }
 

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -39,8 +39,8 @@ export class CodespaceNotFoundError extends FatalAdapterError {
   }
 }
 
-/** Patterns in gh CLI stderr that indicate the codespace no longer exists. */
-const CODESPACE_NOT_FOUND_PATTERNS: RegExp = /not found|does not exist|no such codespace/i;
+/** Patterns in gh CLI stderr/message that specifically indicate the codespace no longer exists. */
+const CODESPACE_NOT_FOUND_PATTERNS: RegExp = /error getting codespace|codespace.*does not exist|no such codespace/i;
 
 // ─── Config ─────────────────────────────────────────────────
 

--- a/packages/adapter-codespace/src/index.ts
+++ b/packages/adapter-codespace/src/index.ts
@@ -1,2 +1,2 @@
-export { CodespaceAdapter } from "./codespace.js";
+export { CodespaceAdapter, CodespaceNotFoundError } from "./codespace.js";
 export type { CodespaceEnvironmentConfig } from "./codespace.js";

--- a/packages/adapter-sdk/src/adapter.test.ts
+++ b/packages/adapter-sdk/src/adapter.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { EnvironmentAdapter, ProvisionEvent } from "./adapter.js";
 import { reconnectOrProvision } from "./adapter.js";
+import { FatalAdapterError } from "./fatal-error.js";
 
 /** Collect all events from an async generator. */
 async function collect(gen: AsyncGenerator<ProvisionEvent>): Promise<ProvisionEvent[]> {
@@ -82,6 +83,21 @@ describe("reconnectOrProvision", () => {
     expect(adapter.reconnect).toHaveBeenCalledOnce();
     expect(adapter.provision).toHaveBeenCalledOnce();
     expect(events[0].stage).toBe("provision");
+  });
+
+  it("re-throws FatalAdapterError from reconnect without falling back to provision", async () => {
+    const fatalErr = new FatalAdapterError("codespace permanently gone");
+    const adapter = createMockAdapter({
+      reconnect: vi.fn(async function* () {
+        throw fatalErr;
+      }),
+    });
+
+    await expect(
+      collect(reconnectOrProvision("env-1", adapter, {}, "token", true, false, silentLogger)),
+    ).rejects.toThrow(fatalErr);
+
+    expect(adapter.provision).not.toHaveBeenCalled();
   });
 
   it("defaults force to false when omitted", async () => {

--- a/packages/adapter-sdk/src/adapter.ts
+++ b/packages/adapter-sdk/src/adapter.ts
@@ -2,6 +2,7 @@ import type { Client } from "@connectrpc/connect";
 import type { powerline } from "@grackle-ai/common";
 import type { AdapterLogger } from "./logger.js";
 import { defaultLogger } from "./logger.js";
+import { FatalAdapterError } from "./fatal-error.js";
 
 /** Type-safe ConnectRPC client for the PowerLine gRPC service. */
 export type PowerLineClient = Client<typeof powerline.GracklePowerLine>;
@@ -70,6 +71,9 @@ export async function* reconnectOrProvision(
       yield* adapter.reconnect(environmentId, config, powerlineToken);
       reconnected = true;
     } catch (err) {
+      if (err instanceof FatalAdapterError) {
+        throw err;
+      }
       logger.info({ environmentId, err }, "Reconnect failed, falling back to full provision");
     }
   }

--- a/packages/adapter-sdk/src/fatal-error.ts
+++ b/packages/adapter-sdk/src/fatal-error.ts
@@ -1,9 +1,10 @@
 /**
  * Base error for adapter failures that are permanent and must not be retried.
  *
- * Throw a subclass of this from any adapter method (`provision`, `reconnect`,
- * `connect`, …) to signal to the auto-reconnect loop that the environment
- * should be marked as `error` immediately with no further retry attempts.
+ * Throw a subclass from `provision()` or `reconnect()` to signal to the
+ * auto-reconnect loop that the environment should be marked as `error`
+ * immediately with no further retry attempts. `reconnectOrProvision()`
+ * re-throws this error rather than falling back to `provision()`.
  */
 export class FatalAdapterError extends Error {
   public constructor(message: string) {

--- a/packages/adapter-sdk/src/fatal-error.ts
+++ b/packages/adapter-sdk/src/fatal-error.ts
@@ -1,0 +1,13 @@
+/**
+ * Base error for adapter failures that are permanent and must not be retried.
+ *
+ * Throw a subclass of this from any adapter method (`provision`, `reconnect`,
+ * `connect`, …) to signal to the auto-reconnect loop that the environment
+ * should be marked as `error` immediately with no further retry attempts.
+ */
+export class FatalAdapterError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "FatalAdapterError";
+  }
+}

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -1,5 +1,8 @@
 // ─── Logger ─────────────────────────────────────────────────
 export type { AdapterLogger } from "./logger.js";
+
+// ─── Fatal Error ─────────────────────────────────────────────
+export { FatalAdapterError } from "./fatal-error.js";
 export { defaultLogger } from "./logger.js";
 
 // ─── Proto Types ──────────────────────────────────────────────

--- a/packages/core/src/auto-reconnect.test.ts
+++ b/packages/core/src/auto-reconnect.test.ts
@@ -3,7 +3,7 @@
  * Covers: successful reconnect, backoff timing, max retries,
  * concurrent lock, clearReconnectState, session recovery trigger.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 // ── Mock dependencies before importing ──────────────────────
 
@@ -119,6 +119,7 @@ describe("auto-reconnect", () => {
     // Spy on tokenPush
     vi.spyOn(tokenPush, "pushToEnv").mockResolvedValue();
   });
+
 
   it("reconnects a disconnected environment after initial delay", async () => {
     insertEnv("env1");
@@ -511,6 +512,14 @@ describe("auto-reconnect", () => {
 
   // ── FatalAdapterError short-circuit ─────────────────────
 
+  // ── FatalAdapterError short-circuit ─────────────────────────
+  // These tests spy on Date.now, so they need explicit cleanup to avoid
+  // leaking the frozen clock into subsequent tests.
+  describe("FatalAdapterError short-circuit", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
   it("marks environment as error (not sleeping) and stops retrying on FatalAdapterError", async () => {
     insertEnv("env1");
     const adapter = makeAdapter();
@@ -563,6 +572,8 @@ describe("auto-reconnect", () => {
     expect(fatalEmitCount).toBe(2);
     expect(envRegistry.getEnvironment("env1")?.status).toBe("error");
   });
+
+  }); // describe("FatalAdapterError short-circuit")
 
   // ── isReconnecting ────────────────────────────────────────
 

--- a/packages/core/src/auto-reconnect.test.ts
+++ b/packages/core/src/auto-reconnect.test.ts
@@ -528,16 +528,18 @@ describe("auto-reconnect", () => {
     expect(envRegistry.getEnvironment("env1")?.status).toBe("error");
     expect(adapter.connect).toHaveBeenCalledTimes(1);
 
-    // Additional ticks must not trigger another attempt (state cleared)
+    // Additional ticks must not trigger another attempt because the env is now in "error"
+    // status, so attemptReconnects() should not select it again.
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + 30_000);
     await attemptReconnects();
     await new Promise((r) => setTimeout(r, 50));
 
-    // State was cleared — next tick initializes fresh (initial delay), no additional connect
+    // Even if reconnect state was cleared, no additional connect occurs because the
+    // environment remains marked as "error".
     expect(adapter.connect).toHaveBeenCalledTimes(1);
   });
 
-  it("emits environment.changed exactly once on FatalAdapterError", async () => {
+  it("emits environment.changed twice on FatalAdapterError (connecting + error)", async () => {
     insertEnv("env1");
     const adapter = makeAdapter();
     (adapter.connect as ReturnType<typeof vi.fn>).mockRejectedValue(

--- a/packages/core/src/auto-reconnect.test.ts
+++ b/packages/core/src/auto-reconnect.test.ts
@@ -59,6 +59,7 @@ import { recoverSuspendedSessions } from "./session-recovery.js";
 import { emit } from "./event-bus.js";
 import { attemptReconnects, clearReconnectState, resetReconnectState, isReconnecting, _resetForTesting } from "./auto-reconnect.js";
 import type { EnvironmentAdapter, PowerLineConnection } from "@grackle-ai/adapter-sdk";
+import { FatalAdapterError } from "@grackle-ai/adapter-sdk";
 
 // ── Schema ──────────────────────────────────────────────────
 
@@ -506,6 +507,59 @@ describe("auto-reconnect", () => {
 
     expect(adapter.connect).toHaveBeenCalledTimes(1);
     expect(envRegistry.getEnvironment("env1")?.status).toBe("connected");
+  });
+
+  // ── FatalAdapterError short-circuit ─────────────────────
+
+  it("marks environment as error (not sleeping) and stops retrying on FatalAdapterError", async () => {
+    insertEnv("env1");
+    const adapter = makeAdapter();
+    (adapter.connect as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new FatalAdapterError("Codespace 'env1' not found — it may have been deleted"),
+    );
+    adapterManager.registerAdapter(adapter);
+
+    // Initialize state and attempt once
+    await attemptReconnects();
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 15_000);
+    await attemptReconnects();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(envRegistry.getEnvironment("env1")?.status).toBe("error");
+    expect(adapter.connect).toHaveBeenCalledTimes(1);
+
+    // Additional ticks must not trigger another attempt (state cleared)
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 30_000);
+    await attemptReconnects();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // State was cleared — next tick initializes fresh (initial delay), no additional connect
+    expect(adapter.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits environment.changed exactly once on FatalAdapterError", async () => {
+    insertEnv("env1");
+    const adapter = makeAdapter();
+    (adapter.connect as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new FatalAdapterError("resource gone"),
+    );
+    adapterManager.registerAdapter(adapter);
+
+    vi.mocked(emit).mockClear();
+
+    // Initialize + attempt
+    await attemptReconnects();
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 15_000);
+    await attemptReconnects();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // connectAndRecover emits once for "connecting", then tryReconnect emits once
+    // for the fatal error. Total = 2 (one for → connecting, one for → error).
+    const fatalEmitCount = vi.mocked(emit).mock.calls.filter(
+      ([type]) => type === "environment.changed",
+    ).length;
+    expect(fatalEmitCount).toBe(2);
+    expect(envRegistry.getEnvironment("env1")?.status).toBe("error");
   });
 
   // ── isReconnecting ────────────────────────────────────────

--- a/packages/core/src/auto-reconnect.ts
+++ b/packages/core/src/auto-reconnect.ts
@@ -1,4 +1,4 @@
-import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
+import { reconnectOrProvision, FatalAdapterError } from "@grackle-ai/adapter-sdk";
 import { envRegistry } from "@grackle-ai/database";
 import * as adapterManager from "./adapter-manager.js";
 import * as tokenPush from "./token-push.js";
@@ -256,6 +256,18 @@ async function tryReconnect(environmentId: string): Promise<void> {
   } catch (err) {
     // Clean up any partially-established connection to avoid leaking state
     adapterManager.removeConnection(environmentId);
+
+    // Fatal errors (e.g., resource permanently gone) must not be retried.
+    if (err instanceof FatalAdapterError) {
+      logger.warn(
+        { environmentId, err: err.message },
+        "Adapter reported a fatal, non-retryable error — marking environment as error",
+      );
+      envRegistry.updateEnvironmentStatus(environmentId, "error");
+      reconnectStates.delete(environmentId);
+      emit("environment.changed", {});
+      return;
+    }
 
     const state = reconnectStates.get(environmentId) ?? { attempts: 0, nextRetryAt: 0, lastProbeAt: 0 };
     state.attempts++;

--- a/packages/core/src/auto-reconnect.ts
+++ b/packages/core/src/auto-reconnect.ts
@@ -260,7 +260,7 @@ async function tryReconnect(environmentId: string): Promise<void> {
     // Fatal errors (e.g., resource permanently gone) must not be retried.
     if (err instanceof FatalAdapterError) {
       logger.warn(
-        { environmentId, err: err.message },
+        { environmentId, err, errorMessage: err.message },
         "Adapter reported a fatal, non-retryable error — marking environment as error",
       );
       envRegistry.updateEnvironmentStatus(environmentId, "error");

--- a/packages/web-components/src/components/chat/ChatInput.stories.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.stories.tsx
@@ -1,5 +1,6 @@
+import { useState, type JSX } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn } from "@storybook/test";
+import { expect, fn, userEvent } from "@storybook/test";
 import { ChatInput } from "./ChatInput.js";
 import type { Environment } from "../../hooks/types.js";
 import { makeEnvironment, makePersona } from "../../test-utils/storybook-helpers.js";
@@ -74,6 +75,50 @@ export const StartMode: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByPlaceholderText("Type a message...")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+  },
+};
+
+/**
+ * Regression guard: typed text must survive a mode flip.
+ * ChatPage now renders a single ChatInput instance and changes the mode prop
+ * instead of unmounting/remounting. This story verifies the local text state
+ * is preserved when mode transitions from "start" to "send".
+ */
+function ModeFlipWrapper(): JSX.Element {
+  const [mode, setMode] = useState<"start" | "send">("start");
+  return (
+    <div>
+      <ChatInput
+        mode={mode}
+        taskId="task-1"
+        sessionId="sess-1"
+        environmentId="local"
+        personas={[]}
+        environments={[connectedEnv]}
+        onSendInput={fn()}
+        onSpawn={fn()}
+        onStartTask={fn()}
+        onProvisionEnvironment={fn()}
+        onShowToast={fn()}
+      />
+      <button type="button" onClick={() => setMode("send")} data-testid="flip-mode-btn">
+        Flip to send
+      </button>
+    </div>
+  );
+}
+
+export const ModeFlipPreservesText: Story = {
+  render: () => <ModeFlipWrapper />,
+  play: async ({ canvas }) => {
+    const input = canvas.getByPlaceholderText("Type a message...");
+    await userEvent.type(input, "draft message");
+    await expect(input).toHaveValue("draft message");
+
+    await userEvent.click(canvas.getByTestId("flip-mode-btn"));
+
+    // Text must survive the mode flip (component stays mounted, state is preserved)
+    await expect(input).toHaveValue("draft message");
   },
 };
 

--- a/packages/web/src/hooks/useEnvironmentToasts.test.ts
+++ b/packages/web/src/hooks/useEnvironmentToasts.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useEnvironmentToasts } from "./useEnvironmentToasts.js";
+import type { Environment } from "./useGrackleSocket.js";
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function makeEnv(id: string, status: Environment["status"]): Environment {
+  return {
+    id,
+    displayName: `Env ${id}`,
+    adapterType: "codespace",
+    status,
+    bootstrapped: true,
+    defaultRuntime: "claude-code",
+    maxConcurrentSessions: 0,
+    adapterConfig: "{}",
+    githubAccountId: "",
+  } as unknown as Environment;
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe("useEnvironmentToasts", () => {
+  it("does not toast on initial load", () => {
+    const showToast = vi.fn();
+    renderHook(() => useEnvironmentToasts([makeEnv("e1", "connected")], showToast));
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("toasts warning on connected → disconnected (genuine disconnect)", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "connected")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "disconnected")] });
+    expect(showToast).toHaveBeenCalledWith("Environment disconnected", "warning");
+  });
+
+  it("does NOT toast on connecting → disconnected (failed auto-reconnect attempt)", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "connecting")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "disconnected")] });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("does NOT toast on disconnected → connecting (auto-reconnect in flight)", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "disconnected")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "connecting")] });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("produces exactly one warning toast over a full retry cycle (connected→disconnected→connecting→disconnected)", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "connected")] } },
+    );
+
+    rerender({ envs: [makeEnv("e1", "disconnected")] }); // genuine disconnect
+    rerender({ envs: [makeEnv("e1", "connecting")] });    // auto-reconnect start
+    rerender({ envs: [makeEnv("e1", "disconnected")] }); // retry failed
+
+    const warningCalls = showToast.mock.calls.filter(([, variant]) => variant === "warning");
+    expect(warningCalls).toHaveLength(1);
+    expect(warningCalls[0][0]).toBe("Environment disconnected");
+  });
+
+  it("toasts success on → connected (recovered)", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "disconnected")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "connected")] });
+    expect(showToast).toHaveBeenCalledWith("Environment connected", "success");
+  });
+
+  it("toasts error on → error", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "disconnected")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "error")] });
+    expect(showToast).toHaveBeenCalledWith("Environment provision failed", "error");
+  });
+
+  it("does not toast on → sleeping", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "disconnected")] } },
+    );
+    rerender({ envs: [makeEnv("e1", "sleeping")] });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("toasts info on environment removed", () => {
+    const showToast = vi.fn();
+    const { rerender } = renderHook(
+      ({ envs }) => useEnvironmentToasts(envs, showToast),
+      { initialProps: { envs: [makeEnv("e1", "connected")] } },
+    );
+    rerender({ envs: [] });
+    expect(showToast).toHaveBeenCalledWith("Environment removed", "info");
+  });
+});

--- a/packages/web/src/hooks/useEnvironmentToasts.ts
+++ b/packages/web/src/hooks/useEnvironmentToasts.ts
@@ -6,8 +6,11 @@ import type { ToastVariant } from "@grackle-ai/web-components";
  * Diffs the previous and current environment lists and fires toast
  * notifications for meaningful status transitions.
  *
- * Skips toasts on initial load (when the previous ref is null) and
- * for `sleeping` transitions (passive state with no user action needed).
+ * Skips toasts on initial load (when the previous ref is null),
+ * for `sleeping` transitions (passive state), and for `connecting`
+ * transitions (auto-reconnect cycles through this on every retry attempt —
+ * streaming provision progress provides richer feedback for user-initiated
+ * reconnects).
  */
 export function useEnvironmentToasts(
   environments: Environment[],
@@ -45,14 +48,10 @@ export function useEnvironmentToasts(
         continue;
       }
 
-      // Skip sleeping transitions — sleeping is a passive state with no user
-      // action needed.
-      if (env.status === "sleeping") {
-        continue;
-      }
-
-      if (env.status === "connecting") {
-        showToast("Provisioning environment\u2026", "info");
+      // Skip sleeping (passive state) and connecting (auto-reconnect cycles
+      // through this on every retry; streaming provision progress handles
+      // user-initiated reconnect feedback).
+      if (env.status === "sleeping" || env.status === "connecting") {
         continue;
       }
 
@@ -62,10 +61,12 @@ export function useEnvironmentToasts(
         showToast("Environment provision failed", "error");
       } else if (env.status === "disconnected") {
         if (old.status === "connected") {
+          // Genuine disconnect — was working, now gone.
           showToast("Environment disconnected", "warning");
-        } else {
-          showToast("Environment stopped", "info");
         }
+        // connecting → disconnected is a failed auto-reconnect attempt; the
+        // user was already notified on the original connected → disconnected
+        // transition, so stay silent here.
       }
     }
 

--- a/packages/web/src/hooks/useGrackleSocket.ts
+++ b/packages/web/src/hooks/useGrackleSocket.ts
@@ -219,10 +219,12 @@ export function useGrackleSocket(): UseGrackleSocketResult {
     }
 
     // Cross-concern side effects: sessions need reloading when environments
-    // or tasks change (session list includes environment/task references)
+    // are removed or tasks start (session list holds env/task references).
+    // environment.changed is intentionally excluded — env status flips do not
+    // mutate session shape, and reloading on every reconnect attempt causes
+    // the visible flash described in the deleted-codespace retry-storm bug.
     if (
       event.type === "environment.removed" ||
-      event.type === "environment.changed" ||
       event.type === "task.started"
     ) {
       sessionsHook.loadSessions().catch(() => {});

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -274,26 +274,13 @@ export function ChatPage(): JSX.Element {
         />
       )}
 
-      {/* System mode chat input */}
-      {streamId === undefined && localEnvironment && isSessionActive && (
+      {/* System mode chat input — single instance so typed text survives isSessionActive flips */}
+      {streamId === undefined && localEnvironment && (
         <ChatInput
-          mode="send"
-          sessionId={latestSession!.id}
-          environmentId={latestSession!.environmentId}
-          personas={personas}
-          environments={environments}
-          onSendInput={(sid, text) => { sendInput(sid, text).catch(() => { showToast("Failed to send message", "error"); }); }}
-          onSpawn={(eid, prompt, pid) => { spawn(eid, prompt, pid).catch(() => {}); }}
-          onStartTask={(tid, pid, eid) => { startTask(tid, pid, eid).catch(() => {}); }}
-          onProvisionEnvironment={(eid) => { provisionEnvironment(eid).catch(() => {}); }}
-          onShowToast={showToast}
-        />
-      )}
-      {streamId === undefined && localEnvironment && !isSessionActive && (
-        <ChatInput
-          mode="start"
+          mode={isSessionActive ? "send" : "start"}
+          sessionId={isSessionActive ? latestSession!.id : undefined}
           taskId={ROOT_TASK_ID}
-          environmentId={localEnvironment.id}
+          environmentId={isSessionActive ? latestSession!.environmentId : localEnvironment.id}
           personas={personas}
           environments={environments}
           onSendInput={(sid, text) => { sendInput(sid, text).catch(() => { showToast("Failed to send message", "error"); }); }}


### PR DESCRIPTION
## Summary

- **Backend:** Add `FatalAdapterError` base class to `@grackle-ai/adapter-sdk`. `CodespaceExecutor.exec()` now detects `gh` CLI stderr patterns like "not found" / "does not exist" and throws `CodespaceNotFoundError` (extends `FatalAdapterError`). The auto-reconnect `tryReconnect` loop short-circuits immediately on any `FatalAdapterError`: marks the env as `error`, clears retry state, emits `environment.changed` once — no further retry storm.
- **Frontend (toasts):** `useEnvironmentToasts` now suppresses the `→ connecting` toast (was "Provisioning environment…") and the `connecting → disconnected` toast (was "Environment stopped"). Both fired on every retry cycle. Only genuinely meaningful transitions produce toasts: `connected→disconnected` (warning), `→connected` (success), `→error` (error).
- **Frontend (ChatInput):** Collapsed the two sibling `<ChatInput>` components in `ChatPage.tsx` (one for `mode="send"`, one for `mode="start"`, gated on `isSessionActive`) into a single instance with a computed `mode` prop. React now keeps the same component across mode changes, so in-progress typed text is never lost when session state flips.

## Test plan

- [x] Unit tests: `CodespaceNotFoundError` thrown on "not found" in `gh` stderr/message, not thrown on generic SSH failures (`codespace.test.ts` — 4 new tests)
- [x] Unit tests: `tryReconnect` marks env as `error` and stops retrying on `FatalAdapterError`, emits `environment.changed` exactly twice total (`auto-reconnect.test.ts` — 2 new tests)
- [x] Unit tests: `useEnvironmentToasts` produces exactly one warning toast over a full `connected→disconnected→connecting→disconnected` retry cycle (`useEnvironmentToasts.test.ts` — 9 new tests)
- [ ] Manual: add a codespace env pointing at a deleted codespace, open System chat, type a message, wait 60 s — expect at most one toast then env transitions to `error`; typed text remains intact