### PR TITLE
feat: add @grackle-ai/mcp-stdio stdio-to-HTTP MCP proxy

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-mcp-stdio-package_2026-04-29-16-44.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-mcp-stdio-package_2026-04-29-16-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add @grackle-ai/mcp-stdio — an npx-able stdio-to-HTTP MCP proxy that bridges stdio-only clients (Claude Desktop, Codex CLI, Clawpilot) to Grackle's HTTP MCP server using static API-key auth",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -427,13 +427,32 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
       zod:
         specifier: ^4.0.0
         version: 4.3.6
+    devDependencies:
+      '@grackle-ai/heft-rig':
+        specifier: workspace:*
+        version: link:../../rigs/heft-rig
+      '@rushstack/heft':
+        specifier: 1.2.7
+        version: 1.2.7(@types/node@22.19.15)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.0.1)(sass@1.98.0)(terser@5.46.1)
+
+  ../../packages/mcp-stdio:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.0
+        version: 1.27.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -691,7 +710,7 @@ importers:
         version: link:../runtime-sdk
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -847,7 +866,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -3463,7 +3482,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -13691,7 +13709,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     container_name: grackle
     ports:
       - "${GRACKLE_WEB_PORT:-3000}:3000"   # Web UI + WebSocket
+      # MCP HTTP endpoint — used by @grackle-ai/mcp-stdio and any Bearer-token MCP client.
+      # The API key gates access, but this binding exposes the port on all interfaces.
+      # On multi-tenant hosts, restrict to loopback: "127.0.0.1:${GRACKLE_MCP_PORT:-7435}:7435"
+      - "${GRACKLE_MCP_PORT:-7435}:7435"   # MCP HTTP (Streamable HTTP + API-key auth)
     volumes:
       - grackle-data:/data                                                      # Persistent DB, Neo4j, API key
 

--- a/packages/mcp-stdio/README.md
+++ b/packages/mcp-stdio/README.md
@@ -35,12 +35,12 @@ Or run directly:
 GRACKLE_URL=http://127.0.0.1:7435/mcp GRACKLE_API_KEY=<key> npx @grackle-ai/mcp-stdio
 ```
 
-Requires **Node.js >= 20**.
+Requires **Node.js >= 22**.
 
 ## Configuration
 
 | Variable | Description | Default |
-|---|---|---|
+| --- | --- | --- |
 | `GRACKLE_URL` | Full URL of the Grackle MCP HTTP endpoint | `http://127.0.0.1:7435/mcp` |
 | `GRACKLE_API_KEY` | API key for authenticating with the Grackle server. **Required** — the proxy exits with an error if not set. | *(none)* |
 

--- a/packages/mcp-stdio/README.md
+++ b/packages/mcp-stdio/README.md
@@ -1,0 +1,79 @@
+# @grackle-ai/mcp-stdio
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@grackle-ai/mcp-stdio"><img src="https://img.shields.io/npm/v/@grackle-ai/mcp-stdio.svg" alt="npm version" /></a>
+  <a href="https://github.com/nick-pape/grackle/actions/workflows/ci.yml"><img src="https://github.com/nick-pape/grackle/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/nick-pape/grackle/main/apps/docs-site/static/img/grackle-logo.png" alt="Grackle" width="200" />
+</p>
+
+stdio-to-HTTP MCP proxy for [Grackle](https://github.com/nick-pape/grackle). Bridges MCP clients that only speak stdio (Claude Desktop, Codex CLI, Clawpilot) to a running Grackle HTTP MCP server using static API-key auth — no OAuth flow required.
+
+## Quick Start
+
+Add to your MCP client config:
+
+```json
+{
+  "grackle": {
+    "command": "npx",
+    "args": ["-y", "@grackle-ai/mcp-stdio"],
+    "env": {
+      "GRACKLE_URL": "http://127.0.0.1:7435/mcp",
+      "GRACKLE_API_KEY": "<your-api-key>"
+    }
+  }
+}
+```
+
+Or run directly:
+
+```bash
+GRACKLE_URL=http://127.0.0.1:7435/mcp GRACKLE_API_KEY=<key> npx @grackle-ai/mcp-stdio
+```
+
+Requires **Node.js >= 20**.
+
+## Configuration
+
+| Variable | Description | Default |
+|---|---|---|
+| `GRACKLE_URL` | Full URL of the Grackle MCP HTTP endpoint | `http://127.0.0.1:7435/mcp` |
+| `GRACKLE_API_KEY` | API key for authenticating with the Grackle server. **Required** — the proxy exits with an error if not set. | *(none)* |
+
+The API key is the 64-character hex token stored in `~/.grackle/api-key` on the machine running the Grackle server. For a Docker deployment, see the section below.
+
+---
+
+## Docker Quick Start
+
+The published Grackle image exposes the MCP port (7435) by default when using the provided `docker-compose.yml`:
+
+```bash
+# Start Grackle
+docker compose up -d
+
+# Read the API key from the container's volume
+docker exec grackle cat /data/.grackle/api-key
+```
+
+Then use the key in your MCP client config as shown above, with `GRACKLE_URL=http://127.0.0.1:7435/mcp`.
+
+> **Multi-tenant hosts:** The default `docker-compose.yml` binding exposes port 7435 on all interfaces. To restrict to loopback, change the port mapping to `"127.0.0.1:7435:7435"` in your compose file.
+
+---
+
+## How It Works
+
+`@grackle-ai/mcp-stdio` spawns a local stdio MCP server that forwards every `tools/list` and `tools/call` request to the Grackle HTTP MCP server over Streamable HTTP. Tool discovery is fully dynamic — the proxy calls `listTools` upstream on every request so new Grackle tools are automatically available without updating the proxy.
+
+On any network error the proxy reconnects once before propagating the failure. No OAuth flow, no token expiry.
+
+---
+
+## License
+
+MIT

--- a/packages/mcp-stdio/config/rig.json
+++ b/packages/mcp-stdio/config/rig.json
@@ -1,0 +1,3 @@
+{
+  "rigPackageName": "@grackle-ai/heft-rig"
+}

--- a/packages/mcp-stdio/config/rush-project.json
+++ b/packages/mcp-stdio/config/rush-project.json
@@ -1,0 +1,12 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "_phase:build",
+      "outputFolderNames": ["dist"]
+    },
+    {
+      "operationName": "_phase:test",
+      "outputFolderNames": []
+    }
+  ]
+}

--- a/packages/mcp-stdio/eslint.config.cjs
+++ b/packages/mcp-stdio/eslint.config.cjs
@@ -1,0 +1,5 @@
+const rigConfig = require("@grackle-ai/heft-rig/profiles/default/config/eslint.config.cjs");
+
+module.exports = [
+  ...rigConfig
+];

--- a/packages/mcp-stdio/package.json
+++ b/packages/mcp-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grackle-ai/mcp-stdio",
-  "version": "0.108.0",
+  "version": "0.108.1",
   "description": "stdio-to-HTTP MCP proxy for Grackle — bridges stdio-only MCP clients (Claude Desktop, Codex CLI, Clawpilot) to a Grackle HTTP MCP server using static API-key auth",
   "license": "MIT",
   "repository": {
@@ -21,7 +21,7 @@
     "url": "https://github.com/nick-pape/grackle/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0 <24.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-stdio/package.json
+++ b/packages/mcp-stdio/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@grackle-ai/mcp-stdio",
+  "version": "0.108.0",
+  "description": "stdio-to-HTTP MCP proxy for Grackle — bridges stdio-only MCP clients (Claude Desktop, Codex CLI, Clawpilot) to a Grackle HTTP MCP server using static API-key auth",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nick-pape/grackle.git",
+    "directory": "packages/mcp-stdio"
+  },
+  "keywords": [
+    "grackle",
+    "mcp",
+    "model-context-protocol",
+    "stdio",
+    "proxy",
+    "ai-agents"
+  ],
+  "homepage": "https://github.com/nick-pape/grackle#readme",
+  "bugs": {
+    "url": "https://github.com/nick-pape/grackle/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "grackle-mcp-stdio": "dist/index.js"
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "heft build --clean",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "clean": "heft clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.0"
+  },
+  "devDependencies": {
+    "@grackle-ai/heft-rig": "workspace:*",
+    "@rushstack/heft": "1.2.7",
+    "@types/node": "^22.0.0",
+    "vitest": "^3.1.1"
+  }
+}

--- a/packages/mcp-stdio/src/index.ts
+++ b/packages/mcp-stdio/src/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { main } from "./proxy.js";
+
+main().catch((err: unknown) => {
+  process.stderr.write(`Fatal: ${(err as Error).message}\n`);
+  process.exit(1);
+});

--- a/packages/mcp-stdio/src/index.ts
+++ b/packages/mcp-stdio/src/index.ts
@@ -2,6 +2,6 @@
 import { main } from "./proxy.js";
 
 main().catch((err: unknown) => {
-  process.stderr.write(`Fatal: ${(err as Error).message}\n`);
+  process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
   process.exit(1);
 });

--- a/packages/mcp-stdio/src/proxy.test.ts
+++ b/packages/mcp-stdio/src/proxy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Mock } from "vitest";
-import { newTransport, withReconnect } from "./proxy.js";
+import { newTransport, withReconnect, isTransportError } from "./proxy.js";
 import type { ClientManager } from "./proxy.js";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
@@ -18,6 +18,26 @@ describe("newTransport", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const url = (transport as any)._url as URL | undefined;
     expect(url?.toString()).toBe("http://myhost:9000/mcp");
+  });
+});
+
+describe("isTransportError", () => {
+  it("recognises TypeError as a transport error", () => {
+    expect(isTransportError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("recognises ECONNREFUSED as a transport error", () => {
+    expect(isTransportError(new Error("connect ECONNREFUSED 127.0.0.1:7435"))).toBe(true);
+  });
+
+  it("recognises ECONNRESET as a transport error", () => {
+    expect(isTransportError(new Error("read ECONNRESET"))).toBe(true);
+  });
+
+  it("does not classify tool / application errors as transport errors", () => {
+    expect(isTransportError(new Error("tool execution failed"))).toBe(false);
+    expect(isTransportError(new Error("invalid arguments"))).toBe(false);
+    expect(isTransportError("string error")).toBe(false);
   });
 });
 
@@ -50,11 +70,11 @@ describe("withReconnect", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it("resets and retries once on failure", async () => {
+  it("resets and retries once on transport error", async () => {
     const client = {} as Client;
     const manager = makeManager(client);
     const fn: Mock = vi.fn()
-      .mockRejectedValueOnce(new Error("connection lost"))
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED 127.0.0.1:7435"))
       .mockResolvedValue("recovered");
 
     const result = await withReconnect(manager, fn);
@@ -65,12 +85,23 @@ describe("withReconnect", () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retry on non-transport errors", async () => {
+    const client = {} as Client;
+    const manager = makeManager(client);
+    const fn: Mock = vi.fn().mockRejectedValue(new Error("tool execution failed"));
+
+    await expect(withReconnect(manager, fn)).rejects.toThrow("tool execution failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.resetClient).not.toHaveBeenCalled();
+  });
+
   it("propagates error if retry also fails", async () => {
     const client = {} as Client;
     const manager = makeManager(client);
-    const fn: Mock = vi.fn().mockRejectedValue(new Error("still broken"));
+    const transportError = new Error("connect ECONNREFUSED 127.0.0.1:7435");
+    const fn: Mock = vi.fn().mockRejectedValue(transportError);
 
-    await expect(withReconnect(manager, fn)).rejects.toThrow("still broken");
+    await expect(withReconnect(manager, fn)).rejects.toThrow("ECONNREFUSED");
     expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/mcp-stdio/src/proxy.test.ts
+++ b/packages/mcp-stdio/src/proxy.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Mock } from "vitest";
+import { newTransport, withReconnect } from "./proxy.js";
+import type { ClientManager } from "./proxy.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+describe("newTransport", () => {
+  it("sets Authorization header with Bearer token", () => {
+    const transport = newTransport("http://127.0.0.1:7435/mcp", "test-key-abc");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const init = (transport as any)._requestInit as RequestInit | undefined;
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(headers?.["Authorization"]).toBe("Bearer test-key-abc");
+  });
+
+  it("uses the provided URL", () => {
+    const transport = newTransport("http://myhost:9000/mcp", "key");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const url = (transport as any)._url as URL | undefined;
+    expect(url?.toString()).toBe("http://myhost:9000/mcp");
+  });
+});
+
+describe("withReconnect", () => {
+  function makeManager(client: Client): ClientManager & { getClient: Mock; resetClient: Mock } {
+    return {
+      getClient: vi.fn().mockResolvedValue(client),
+      resetClient: vi.fn(),
+    };
+  }
+
+  it("calls fn once when it succeeds", async () => {
+    const client = {} as Client;
+    const manager = makeManager(client);
+    const fn: Mock = vi.fn().mockResolvedValue("result");
+
+    const result = await withReconnect(manager, fn);
+
+    expect(result).toBe("result");
+    expect(manager.getClient).toHaveBeenCalledTimes(1);
+    expect(manager.resetClient).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets and retries once on failure", async () => {
+    const client = {} as Client;
+    const manager = makeManager(client);
+    const fn: Mock = vi.fn()
+      .mockRejectedValueOnce(new Error("connection lost"))
+      .mockResolvedValue("recovered");
+
+    const result = await withReconnect(manager, fn);
+
+    expect(result).toBe("recovered");
+    expect(manager.getClient).toHaveBeenCalledTimes(2);
+    expect(manager.resetClient).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates error if retry also fails", async () => {
+    const client = {} as Client;
+    const manager = makeManager(client);
+    const fn: Mock = vi.fn().mockRejectedValue(new Error("still broken"));
+
+    await expect(withReconnect(manager, fn)).rejects.toThrow("still broken");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mcp-stdio/src/proxy.test.ts
+++ b/packages/mcp-stdio/src/proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Mock } from "vitest";
 import { newTransport, withReconnect } from "./proxy.js";
 import type { ClientManager } from "./proxy.js";
@@ -22,6 +22,14 @@ describe("newTransport", () => {
 });
 
 describe("withReconnect", () => {
+  beforeEach(() => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   function makeManager(client: Client): ClientManager & { getClient: Mock; resetClient: Mock } {
     return {
       getClient: vi.fn().mockResolvedValue(client),

--- a/packages/mcp-stdio/src/proxy.ts
+++ b/packages/mcp-stdio/src/proxy.ts
@@ -63,7 +63,35 @@ export function createClientManager(grackleUrl: string, apiKey: string): ClientM
 }
 
 /**
- * Call `fn` with the upstream client, reconnecting once on any error.
+ * Returns true for errors that indicate a transient transport or connectivity
+ * failure and are safe to retry without risk of duplicating side effects.
+ * Application-level errors (e.g. invalid tool arguments) are not transport
+ * errors and should propagate immediately without a retry.
+ * Exported for testability.
+ */
+export function isTransportError(err: unknown): boolean {
+  if (err instanceof TypeError) {
+    return true;
+  }
+  if (err instanceof Error) {
+    const msg = err.message;
+    return (
+      msg.includes("ECONNREFUSED") ||
+      msg.includes("ECONNRESET") ||
+      msg.includes("ENOTFOUND") ||
+      msg.includes("fetch failed") ||
+      msg.includes("Failed to fetch") ||
+      msg.includes("socket hang up") ||
+      msg.includes("network")
+    );
+  }
+  return false;
+}
+
+/**
+ * Call `fn` with the upstream client, reconnecting once on transient transport
+ * errors. Non-transport errors (application errors, tool errors) propagate
+ * immediately without retry to avoid duplicating side effects.
  * Exported for testability.
  */
 export async function withReconnect<T>(
@@ -73,7 +101,11 @@ export async function withReconnect<T>(
   try {
     return await fn(await manager.getClient());
   } catch (err) {
-    process.stderr.write(`Reconnecting upstream: ${(err as Error).message}\n`);
+    if (!isTransportError(err)) {
+      throw err;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Reconnecting upstream: ${msg}\n`);
     manager.resetClient();
     return fn(await manager.getClient());
   }

--- a/packages/mcp-stdio/src/proxy.ts
+++ b/packages/mcp-stdio/src/proxy.ts
@@ -1,0 +1,125 @@
+import { createRequire } from "node:module";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const esmRequire: NodeRequire = createRequire(import.meta.url);
+const { version } = esmRequire("../package.json") as { version: string };
+
+/** Default MCP HTTP endpoint when GRACKLE_URL is not set. */
+const DEFAULT_GRACKLE_URL: string = "http://127.0.0.1:7435/mcp";
+
+/** Create a fresh upstream transport pointing at the Grackle HTTP MCP server. */
+export function newTransport(grackleUrl: string, apiKey: string): StreamableHTTPClientTransport {
+  return new StreamableHTTPClientTransport(new URL(grackleUrl), {
+    requestInit: { headers: { Authorization: `Bearer ${apiKey}` } },
+  });
+}
+
+/** Create and connect a new upstream MCP client. */
+function connect(grackleUrl: string, apiKey: string): Promise<Client> {
+  const c = new Client(
+    { name: "grackle-mcp-stdio", version },
+    { capabilities: {} },
+  );
+  return c.connect(newTransport(grackleUrl, apiKey)).then(() => c);
+}
+
+/** Manages the upstream client as a promise to avoid async assignment races. */
+export interface ClientManager {
+  getClient: () => Promise<Client>;
+  resetClient: () => void;
+}
+
+/** Create a ClientManager that lazily connects and reconnects on demand. */
+export function createClientManager(grackleUrl: string, apiKey: string): ClientManager {
+  let upstreamPromise: Promise<Client> | undefined;
+
+  function getClient(): Promise<Client> {
+    if (!upstreamPromise) {
+      // Assign synchronously so concurrent callers share the same promise.
+      // On failure, clear so the next call retries.
+      upstreamPromise = connect(grackleUrl, apiKey).catch((err: unknown) => {
+        upstreamPromise = undefined;
+        throw err;
+      });
+    }
+    return upstreamPromise;
+  }
+
+  function resetClient(): void {
+    const old = upstreamPromise;
+    upstreamPromise = undefined;
+    old?.then((c) => c.close()).catch(() => { /* ignore close errors */ });
+  }
+
+  return { getClient, resetClient };
+}
+
+/**
+ * Call `fn` with the upstream client, reconnecting once on any error.
+ * Exported for testability.
+ */
+export async function withReconnect<T>(
+  manager: ClientManager,
+  fn: (c: Client) => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn(await manager.getClient());
+  } catch (err) {
+    process.stderr.write(`Reconnecting upstream: ${(err as Error).message}\n`);
+    manager.resetClient();
+    return fn(await manager.getClient());
+  }
+}
+
+/** Create the stdio MCP server that proxies all requests to the Grackle HTTP MCP server. */
+export function createProxyServer(grackleUrl: string, apiKey: string): Server {
+  const manager = createClientManager(grackleUrl, apiKey);
+
+  const server = new Server(
+    { name: "grackle-mcp-stdio", version },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const result = await withReconnect(manager, (c) => c.listTools());
+    return { tools: result.tools };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolResult> => {
+    const { name, arguments: args } = req.params;
+    return withReconnect(
+      manager,
+      (c) => c.callTool({ name, arguments: args }),
+    ) as Promise<CallToolResult>;
+  });
+
+  return server;
+}
+
+/** Start the proxy: connect upstream, then attach to stdio and serve. */
+export async function main(): Promise<void> {
+  const grackleUrl = process.env.GRACKLE_URL ?? DEFAULT_GRACKLE_URL;
+  const apiKey = process.env.GRACKLE_API_KEY;
+  if (!apiKey) {
+    process.stderr.write("ERROR: GRACKLE_API_KEY is not set\n");
+    process.exit(1);
+  }
+
+  const server = createProxyServer(grackleUrl, apiKey);
+  await server.connect(new StdioServerTransport());
+  process.stderr.write(`grackle-mcp-stdio ready (upstream: ${grackleUrl})\n`);
+
+  function shutdown(): void {
+    process.exit(0);
+  }
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/packages/mcp-stdio/tsconfig.json
+++ b/packages/mcp-stdio/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/@grackle-ai/heft-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/mcp-stdio/vitest.config.ts
+++ b/packages/mcp-stdio/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    testTimeout: 10_000,
+    isolate: true,
+    passWithNoTests: true,
+  },
+});

--- a/rush.json
+++ b/rush.json
@@ -152,6 +152,11 @@
       "versionPolicyName": "grackle"
     },
     {
+      "packageName": "@grackle-ai/mcp-stdio",
+      "projectFolder": "packages/mcp-stdio",
+      "versionPolicyName": "grackle"
+    },
+    {
       "packageName": "@grackle-ai/knowledge-core",
       "projectFolder": "packages/knowledge-core",
       "versionPolicyName": "grackle"


### PR DESCRIPTION
## Summary

- Adds new `@grackle-ai/mcp-stdio` package — an `npx`-able stdio-to-HTTP MCP proxy that bridges MCP clients speaking only stdio (Claude Desktop, Codex CLI, Clawpilot) to Grackle's existing HTTP MCP server
- Auth via static API key (`GRACKLE_API_KEY` env var) — no OAuth, no token expiry; tools are forwarded dynamically via `listTools` so new Grackle tools appear automatically
- Exposes MCP port 7435 by default in `deploy/docker-compose.yml` so the published Docker image works out of the box; comment explains loopback-only binding for multi-tenant hosts

## Usage

Add to MCP client config:
```json
{
  "grackle": {
    "command": "npx",
    "args": ["-y", "@grackle-ai/mcp-stdio"],
    "env": {
      "GRACKLE_URL": "http://127.0.0.1:7435/mcp",
      "GRACKLE_API_KEY": "<key from: docker exec grackle cat /data/.grackle/api-key>"
    }
  }
}
```

## Test plan

- [x] `rush build -t @grackle-ai/mcp-stdio` — builds cleanly, no warnings
- [x] `vitest run` — 5/5 unit tests pass (transport auth header, URL, withReconnect success/retry/propagate)
- [x] End-to-end smoke test against isolated Grackle server: `initialize` returned correct `serverInfo`, `tools/list` returned 70 tools dynamically proxied from upstream