### PR TITLE
fix: bump @anthropic-ai/claude-code 2.1.78 -> 2.1.84

### DIFF
--- a/docker/server/package.json
+++ b/docker/server/package.json
@@ -8,7 +8,7 @@
   "description": "Pinned agent runtime dependencies for the Grackle server Docker image",
   "dependencies": {
     "@grackle-ai/cli": "latest",
-    "@anthropic-ai/claude-code": "2.1.78",
+    "@anthropic-ai/claude-code": "2.1.84",
     "@openai/codex": "0.115.0",
     "@github/copilot": "1.0.7",
     "@github/copilot-sdk": "0.1.32"


### PR DESCRIPTION
## Summary

Bumps `@anthropic-ai/claude-code` in `docker/server/package.json` from 2.1.78 to 2.1.84 to patch [Dependabot alert #68](https://github.com/nick-pape/grackle/security/dependabot/68): Trust Dialog Bypass via Git Worktree Spoofing (high severity, allows arbitrary code execution).

This is the only direct dep bump in the Dependabot backlog — the package isn't in the Rush workspace; `docker/server/package.json` is a standalone manifest used by the Docker image build for pinning agent runtimes.

## Test plan
- [x] Version specifier updated
- [ ] CI green
- [ ] Dependabot alert #68 closes automatically after merge