### PR TITLE
fix: bump drizzle-orm 0.38 -> 0.45.2 for SQL injection patch

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-deps-drizzle-orm_2026-05-09-06-33.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-deps-drizzle-orm_2026-05-09-06-33.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Bump drizzle-orm 0.38 -> 0.45.2 to patch SQL injection (high, alerts #49 #50).",
-      "type": "none",
+      "type": "patch",
       "packageName": "@grackle-ai/cli"
     }
   ],

--- a/common/changes/@grackle-ai/cli/nick-pape-deps-drizzle-orm_2026-05-09-06-33.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-deps-drizzle-orm_2026-05-09-06-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bump drizzle-orm 0.38 -> 0.45.2 to patch SQL injection (high, alerts #49 #50).",
+      "type": "none",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -349,8 +349,8 @@ importers:
         specifier: ^11.0.0
         version: 11.10.0
       drizzle-orm:
-        specifier: ^0.38.0
-        version: 0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
       uuid:
         specifier: ^11.0.0
         version: 11.1.0
@@ -6042,8 +6042,8 @@ packages:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
     engines: {node: '>=10'}
 
-  drizzle-orm@0.38.4:
-    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -6053,25 +6053,25 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -6101,9 +6101,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -6114,6 +6114,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -6126,8 +6128,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -16682,12 +16682,10 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  drizzle-orm@0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4):
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
-      '@types/react': 19.2.14
       better-sqlite3: 11.10.0
-      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -38,7 +38,7 @@
     "@bufbuild/protobuf": "^2.5.0",
     "@grackle-ai/common": "workspace:*",
     "better-sqlite3": "^11.0.0",
-    "drizzle-orm": "^0.38.0",
+    "drizzle-orm": "^0.45.2",
     "uuid": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `drizzle-orm` direct dep in `packages/database` from `^0.38.0` to `^0.45.2` to patch [Dependabot alert #49](https://github.com/nick-pape/grackle/security/dependabot/49) (direct) and [#50](https://github.com/nick-pape/grackle/security/dependabot/50) (transitive copy in lockfile): SQL injection via improperly escaped SQL identifiers (high severity).

The 7-minor jump (0.38 → 0.45.2) was needed because the patch only landed in 0.45.x. Drizzle is still in pre-1.0 (0.x) so each minor can ship breaking changes — but for the surface our `packages/database/src/*-store.ts` files use (builder methods, schema definitions, `eq`/`and`/`or` operators), the bump was API-compatible: full `rush build` succeeded with no warnings, and database tests pass.

## Test plan
- [x] rush update succeeds
- [x] rush install succeeds (CI strictness)
- [x] rush build -t @grackle-ai/database succeeds
- [x] rush build (full repo) succeeds with no warnings
- [x] rush test --to @grackle-ai/database passes
- [ ] CI green
- [ ] Dependabot alerts #49 and #50 close automatically after merge