### PR TITLE
fix: bump uuid to 11.1.1 and @babel/plugin-transform-modules-systemjs to 7.29.4

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-deps-uuid-babel_2026-05-09-07-40.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-deps-uuid-babel_2026-05-09-07-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bump uuid to 11.1.1 (buffer bounds check fix) and override @babel/plugin-transform-modules-systemjs to 7.29.4 (arbitrary code generation fix).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -20,6 +20,7 @@
     "dompurify": "3.4.0",
     "postcss": "8.5.10",
     "ip-address": "10.1.1",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   postcss: 8.5.10
   ip-address: 10.1.1
   follow-redirects: 1.16.0
+  '@babel/plugin-transform-modules-systemjs': 7.29.4
 
 pnpmfileChecksum: sha256-La8sfCMI7irxJPTW6u4mJb4vNiyLrXeEbKaXv5G3dL0=
 
@@ -318,8 +319,8 @@ importers:
         specifier: ^2.3.0
         version: 2.4.0
       uuid:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -352,8 +353,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
       uuid:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -500,8 +501,8 @@ importers:
         specifier: ^2.3.0
         version: 2.4.0
       uuid:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -626,8 +627,8 @@ importers:
         specifier: ^10.3.1
         version: 10.3.1
       uuid:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -1854,8 +1855,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -10341,12 +10342,13 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -11360,7 +11362,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -11633,7 +11635,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -19130,7 +19132,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   methods@1.1.2: {}
 
@@ -22034,7 +22036,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uuid@8.3.2: {}
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "cron-parser": "^4.9.0",
     "pino": "^10.3.1",
     "ulid": "^2.3.0",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -39,7 +39,7 @@
     "@grackle-ai/common": "workspace:*",
     "better-sqlite3": "^11.0.0",
     "drizzle-orm": "^0.45.2",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -37,7 +37,7 @@
     "@grackle-ai/prompt": "workspace:*",
     "pino": "^10.3.1",
     "ulid": "^2.3.0",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",

--- a/packages/plugin-scheduling/package.json
+++ b/packages/plugin-scheduling/package.json
@@ -32,7 +32,7 @@
     "@grackle-ai/plugin-sdk": "workspace:*",
     "cron-parser": "^4.9.0",
     "pino": "^10.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",


### PR DESCRIPTION
## Summary

Closes 2 Dependabot alerts that appeared during the security sweep.

| Package | From | To | Severity | How |
|---|---|---|---|---|
| uuid | 11.1.0 | 11.1.1 | medium | direct bump in `packages/database`, `packages/core`, `packages/plugin-scheduling`, `packages/plugin-core` (`^11.0.0` → `^11.1.1` to force re-resolution) |
| @babel/plugin-transform-modules-systemjs | 7.29.0 | 7.29.4 | high | pnpm globalOverride (transitive only) |

Closes Dependabot alerts:
- [#91](https://github.com/nick-pape/grackle/security/dependabot/91) uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
- [#92](https://github.com/nick-pape/grackle/security/dependabot/92) @babel/plugin-transform-modules-systemjs: arbitrary code generation when compiling malicious input

## Test plan
- [x] rush update succeeds, lockfile updated
- [x] rush install succeeds (CI strictness)
- [x] rush build succeeds with no warnings
- [ ] CI green
- [ ] Dependabot alerts close after merge