### PR TITLE
fix: patch 5 high-severity Dependabot alerts (protobufjs, @github/copilot)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-deps-high-vulns_2026-05-21-03-59.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-deps-high-vulns_2026-05-21-03-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Patch high-severity vulnerabilities: bump protobufjs transitive override to 7.5.6 and raise the @github/copilot runtime floor to ^1.0.43 (Docker image pinned to 1.0.51). No behavior change.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -11,7 +11,7 @@
     "brace-expansion@>=2.0.0 <3.0.0": "2.0.3",
     "brace-expansion@>=1.0.0 <2.0.0": "1.1.13",
     "lodash-es": "4.18.1",
-    "protobufjs": "7.5.5",
+    "protobufjs": "7.5.6",
     "axios": "1.15.2",
     "lodash": "4.18.1",
     "fast-uri": "3.1.2",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   brace-expansion@>=2.0.0 <3.0.0: 2.0.3
   brace-expansion@>=1.0.0 <2.0.0: 1.1.13
   lodash-es: 4.18.1
-  protobufjs: 7.5.5
+  protobufjs: 7.5.6
   axios: 1.15.2
   lodash: 4.18.1
   fast-uri: 3.1.2
@@ -438,7 +438,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -463,7 +463,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -721,7 +721,7 @@ importers:
         version: link:../runtime-sdk
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -877,7 +877,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -3493,6 +3493,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3662,8 +3663,8 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
@@ -3674,8 +3675,8 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -3683,8 +3684,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -9114,8 +9115,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -13722,7 +13723,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
@@ -13936,24 +13937,24 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -19741,7 +19742,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   open@10.2.0:
     dependencies:
@@ -20539,18 +20540,18 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/codegen': 2.0.5
       '@protobufjs/eventemitter': 1.1.0
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.15
       long: 5.3.2
 

--- a/docker/server/package.json
+++ b/docker/server/package.json
@@ -10,7 +10,7 @@
     "@grackle-ai/cli": "latest",
     "@anthropic-ai/claude-code": "2.1.84",
     "@openai/codex": "0.115.0",
-    "@github/copilot": "1.0.7",
+    "@github/copilot": "1.0.51",
     "@github/copilot-sdk": "0.1.32"
   }
 }

--- a/packages/common/src/runtime-manifest.ts
+++ b/packages/common/src/runtime-manifest.ts
@@ -22,7 +22,7 @@ export const RUNTIME_MANIFESTS: Readonly<Record<string, RuntimePackageManifest>>
     packages: { "@anthropic-ai/claude-agent-sdk": "^0.2.50" },
   },
   "copilot": {
-    packages: { "@github/copilot-sdk": "^0.1.29", "@github/copilot": "^1.0.7" },
+    packages: { "@github/copilot-sdk": "^0.1.29", "@github/copilot": "^1.0.43" },
     needsJsonRpcHook: true,
   },
   "codex": {
@@ -35,7 +35,7 @@ export const RUNTIME_MANIFESTS: Readonly<Record<string, RuntimePackageManifest>>
     packages: { "@agentclientprotocol/sdk": "^0.16.1", "@zed-industries/codex-acp": "^0.10.0" },
   },
   "copilot-acp": {
-    packages: { "@agentclientprotocol/sdk": "^0.16.1", "@github/copilot": "^1.0.7" },
+    packages: { "@agentclientprotocol/sdk": "^0.16.1", "@github/copilot": "^1.0.43" },
   },
   "claude-code-acp": {
     packages: { "@agentclientprotocol/sdk": "^0.16.1", "@zed-industries/claude-agent-acp": "^0.22.0" },


### PR DESCRIPTION
## Summary
Resolves all **5 high-severity Dependabot alerts** on `main`. Two clusters:

**`@github/copilot` — GHSA-9ccr-r5hg-74gf (CVSS 8.5, REAL exposure)** — alert #93
- A nested bare git repo can execute arbitrary commands via `core.fsmonitor`/`core.hookspath` when the Copilot CLI runs git operations on it. Grackle runs the Copilot CLI as an agent on cloned/user-specified repos, so this is genuinely exploitable.
- `docker/server/package.json`: `@github/copilot` `1.0.7` → **`1.0.51`** (latest patched; ≥ 1.0.43).
- `packages/common/src/runtime-manifest.ts`: raise the lazy-install floor `^1.0.7` → **`^1.0.43`** for the `copilot` and `copilot-acp` runtimes.

**`protobufjs` ≤ 7.5.5 → 7.5.6 (4 GHSAs, theoretical exposure)** — alerts #100, #101, #104, #105
- DoS x2 + code-injection x2. Only reaches us transitively via `knowledge-core → @huggingface/transformers → onnxruntime-web` (prebuilt ML model loading). Grackle's own protobuf is `@bufbuild/protobuf`; we never parse untrusted protobuf through this path — but the override was force-pinning the *vulnerable* `7.5.5`, so this is a defensive bump.
- `common/config/rush/pnpm-config.json`: `globalOverrides.protobufjs` `7.5.5` → **`7.5.6`**, lockfile regenerated via `rush update`.

No functional/code behavior change beyond patched dependency versions.

## Test plan
- [x] `rush update` regenerates the lockfile cleanly (unqualified override → no shrinkwrap churn)
- [x] Lockfile contains only `protobufjs@7.5.6` (no 7.5.5)
- [x] Full `rush build` passes with no warnings
- [x] `rush change --verify` passes (patch change file included)
- [ ] CI green
- [ ] Post-merge: Dependabot re-scan auto-closes #93, #100, #101, #104, #105

## Notes
- Scope is **high-severity only**; the 12 moderate alerts are a planned follow-up PR (mirrors the prior #1212 high / #1213 moderate split).
- `@github/copilot-sdk` is not flagged and is left as-is.
- Copilot runtime smoke test skipped locally (needs a GitHub token); change is a version bump and the runtime build passes.