### PR TITLE
MCP Apps host: widget render component (Storybook)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1236-mcp-apps-host_2026-05-22-13-01.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1236-mcp-apps-host_2026-05-22-13-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add MCP Apps (SEP-1865) host widget render component to @grackle-ai/web-components (McpAppWidget + cross-origin sandbox proxy + host theming).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -442,7 +442,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -467,7 +467,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -725,7 +725,7 @@ importers:
         version: link:../runtime-sdk
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -881,7 +881,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -1092,6 +1092,12 @@ importers:
       '@grackle-ai/common':
         specifier: workspace:*
         version: link:../common
+      '@modelcontextprotocol/ext-apps':
+        specifier: 1.7.2
+        version: 1.7.2(@modelcontextprotocol/sdk@1.27.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.0
+        version: 1.27.1
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3480,12 +3486,25 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@modelcontextprotocol/ext-apps@1.7.2':
+    resolution: {integrity: sha512-OOWKDxdAjYDcgHkmzVzccyyag3FK+jBWPaWu4WvTxFsU4R/cgOX4eep66zPRA5n4v6WfxUNibPyvX4iJ7egYTg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -13666,7 +13685,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.27.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1
+      '@standard-schema/spec': 1.1.0
+      zod: 4.3.6
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@modelcontextprotocol/sdk@1.27.1':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -442,7 +442,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -467,7 +467,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -725,7 +725,7 @@ importers:
         version: link:../runtime-sdk
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -881,7 +881,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.0
-        version: 1.27.1
+        version: 1.27.1(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -1094,10 +1094,10 @@ importers:
         version: link:../common
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.2
-        version: 1.7.2(@modelcontextprotocol/sdk@1.27.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.0
-        version: 1.27.1
+        specifier: ^1.29.0
+        version: 1.29.0
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3502,6 +3502,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -13685,16 +13695,38 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.27.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.29.0
       '@standard-schema/spec': 1.1.0
       zod: 4.3.6
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@modelcontextprotocol/sdk@1.27.1':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.18)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0

--- a/packages/web-components/mcp-app-sandbox/sample-widget.js
+++ b/packages/web-components/mcp-app-sandbox/sample-widget.js
@@ -1,0 +1,74 @@
+// Sample MCP App (app-side) for the McpAppWidget Storybook story.
+//
+// Uses the REAL @modelcontextprotocol/ext-apps `App` class — bundled with its
+// dependencies inlined in app-with-deps.js (served by serve.mjs from the sandbox
+// origin) — so the ui/initialize -> initialized -> tool-input/tool-result
+// handshake is exactly spec-conformant. The previous hand-rolled handshake
+// rendered but never received data because its messages failed AppBridge's Zod
+// validation; the real App produces schema-correct messages.
+//
+// Loaded by the inner sandboxed iframe via `<script type="module">`. Relative
+// imports resolve against this module's URL (the sandbox origin), so
+// `./app-with-deps.js` is fetched from the same sidecar.
+
+import {
+  App,
+  PostMessageTransport,
+  applyHostStyleVariables,
+  applyHostFonts,
+  applyDocumentTheme,
+} from "./app-with-deps.js";
+
+const inEl = document.getElementById("in");
+const outEl = document.getElementById("out");
+const callBtn = document.getElementById("call");
+
+/** Render a CallToolResult `content` array into the result element. */
+function renderResult(content) {
+  const blocks = content ?? [];
+  outEl.textContent =
+    blocks
+      .map((block) => (block.type === "text" ? block.text : "<" + block.type + ">"))
+      .join(" ") || "(empty)";
+}
+
+const app = new App({ name: "SampleWeather", version: "1.0.0" }, {});
+
+// Register handlers BEFORE connect so the one-shot tool-input/result the host
+// sends right after the handshake are not missed.
+app.ontoolinput = (params) => {
+  inEl.textContent = JSON.stringify(params.arguments ?? {});
+};
+app.ontoolresult = (params) => {
+  renderResult(params.content);
+};
+
+/** Apply the host's theme + style variables to this document. */
+function applyHostStyles() {
+  const ctx = app.getHostContext();
+  if (ctx?.styles?.variables) {
+    applyHostStyleVariables(ctx.styles.variables);
+  }
+  if (ctx?.styles?.css?.fonts) {
+    applyHostFonts(ctx.styles.css.fonts);
+  }
+  if (ctx?.theme) {
+    applyDocumentTheme(ctx.theme);
+  }
+}
+app.onhostcontextchanged = () => applyHostStyles();
+
+// The Refresh button asks the host to run a tool on the App's behalf
+// (proxied to McpAppWidget's onCallTool prop in the story).
+callBtn.addEventListener("click", () => {
+  outEl.textContent = "(refreshing...)";
+  app
+    .callServerTool({ name: "refresh_weather", arguments: {} })
+    .then((result) => renderResult(result.content))
+    .catch((err) => {
+      outEl.textContent = "error: " + (err && err.message ? err.message : String(err));
+    });
+});
+
+await app.connect(new PostMessageTransport(window.parent, window.parent));
+applyHostStyles();

--- a/packages/web-components/mcp-app-sandbox/sandbox-relay.js
+++ b/packages/web-components/mcp-app-sandbox/sandbox-relay.js
@@ -1,0 +1,114 @@
+// Externalized relay for the MCP Apps outer sandbox proxy (loaded by sandbox.html).
+//
+// Kept as a separate module — served from the sandbox origin and loaded as
+// `script-src 'self'` — so the proxy CSP does NOT need `script-src 'unsafe-inline'`.
+// Implements the double-iframe relay between the host and the inner untrusted
+// widget per the MCP Apps spec (SEP-1865). Adapted from
+// modelcontextprotocol/ext-apps examples/basic-host/src/sandbox.ts (commit 9a37ad7).
+
+const RESOURCE_READY = "ui/notifications/sandbox-resource-ready";
+const PROXY_READY = "ui/notifications/sandbox-proxy-ready";
+const DEFAULT_SANDBOX = "allow-scripts allow-same-origin allow-forms";
+
+// Must run inside an iframe on a different origin than the host.
+if (window.self === window.top) {
+  throw new Error("sandbox.html must be loaded inside an iframe.");
+}
+if (!document.referrer) {
+  throw new Error("No referrer; cannot validate the embedding host origin.");
+}
+const EXPECTED_HOST_ORIGIN = new URL(document.referrer).origin;
+const OWN_ORIGIN = new URL(window.location.href).origin;
+
+// Security self-test: confirm we cannot reach the top window. Reading a property
+// on a cross-origin window.top throws a SecurityError without any visible side
+// effect (unlike alert()). If it does NOT throw, isolation is broken and we must
+// refuse to run.
+try {
+  const probe = window.top.location.href;
+  void probe;
+  throw "FAIL";
+} catch (e) {
+  if (e === "FAIL") {
+    throw new Error("Sandbox is not isolated (host and sandbox share an origin?).");
+  }
+}
+
+// Minimal copy of ext-apps buildAllowAttribute: maps requested permissions to an
+// iframe Permissions-Policy `allow` attribute.
+function buildAllowAttribute(permissions) {
+  if (!permissions || typeof permissions !== "object") {
+    return "";
+  }
+  const map = {
+    camera: "camera",
+    microphone: "microphone",
+    geolocation: "geolocation",
+    clipboardWrite: "clipboard-write",
+    clipboardRead: "clipboard-read",
+    displayCapture: "display-capture",
+  };
+  const out = [];
+  for (const key of Object.keys(permissions)) {
+    if (map[key]) {
+      out.push(`${map[key]} 'self'`);
+    }
+  }
+  return out.join("; ");
+}
+
+// Target origin for host -> inner messages. When the inner iframe keeps
+// `allow-same-origin`, its document shares OWN_ORIGIN, so we post to that exact
+// origin — if the widget navigates the frame elsewhere, delivery stops, which
+// prevents it from continuing to receive host-sent tool data. Opaque frames (no
+// `allow-same-origin`) have an unnameable null origin, so "*" is the only option.
+function innerTargetOrigin(sandboxValue) {
+  return /\ballow-same-origin\b/.test(sandboxValue) ? OWN_ORIGIN : "*";
+}
+
+const inner = document.createElement("iframe");
+inner.setAttribute("sandbox", DEFAULT_SANDBOX);
+let innerOrigin = innerTargetOrigin(DEFAULT_SANDBOX);
+document.body.appendChild(inner);
+
+window.addEventListener("message", (event) => {
+  if (event.source === window.parent) {
+    if (event.origin !== EXPECTED_HOST_ORIGIN) {
+      console.error("[sandbox] dropping parent message from", event.origin);
+      return;
+    }
+    if (event.data && event.data.method === RESOURCE_READY) {
+      const { html, sandbox, permissions } = event.data.params ?? {};
+      if (typeof sandbox === "string") {
+        inner.setAttribute("sandbox", sandbox);
+        innerOrigin = innerTargetOrigin(sandbox);
+      }
+      const allow = buildAllowAttribute(permissions);
+      if (allow) {
+        inner.setAttribute("allow", allow);
+      }
+      if (typeof html === "string") {
+        const doc = inner.contentDocument || inner.contentWindow?.document;
+        if (doc) {
+          doc.open();
+          doc.write(html);
+          doc.close();
+        } else {
+          inner.srcdoc = html;
+        }
+      }
+      return;
+    }
+    // Relay everything else host -> inner widget, scoped to the inner origin.
+    inner.contentWindow?.postMessage(event.data, innerOrigin);
+  } else if (event.source === inner.contentWindow) {
+    if (event.origin !== OWN_ORIGIN && event.origin !== "null") {
+      console.error("[sandbox] dropping inner message from", event.origin);
+      return;
+    }
+    // Relay inner widget -> host.
+    window.parent.postMessage(event.data, EXPECTED_HOST_ORIGIN);
+  }
+});
+
+window.parent.postMessage({ jsonrpc: "2.0", method: PROXY_READY, params: {} }, EXPECTED_HOST_ORIGIN);

--- a/packages/web-components/mcp-app-sandbox/sandbox.html
+++ b/packages/web-components/mcp-app-sandbox/sandbox.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
+    <!--
+      MCP Apps outer sandbox proxy.
+
+      Double-iframe pattern per the MCP Apps spec (SEP-1865). This page is the
+      OUTER proxy and MUST be served from a different origin than the host (see
+      serve.mjs / GRACKLE_SANDBOX_PORT). It creates an INNER iframe for the
+      untrusted widget HTML and relays postMessage between host and widget.
+
+      CSP for the inner widget is applied by serve.mjs via the HTTP
+      Content-Security-Policy header (built from the ?csp= query param) — it is
+      tamper-proof, unlike a <meta> tag. The relay below is inlined (no bundler);
+      that script-src 'unsafe-inline' is intentionally permitted by serve.mjs.
+
+      Adapted from modelcontextprotocol/ext-apps examples/basic-host/src/sandbox.ts
+      (commit 9a37ad7).
+    -->
+    <title>Grackle MCP App Sandbox</title>
+    <style>
+      html, body { margin: 0; height: 100vh; width: 100vw; background: transparent; }
+      body { display: flex; flex-direction: column; }
+      * { box-sizing: border-box; }
+      iframe {
+        background: transparent; border: 0 none transparent; padding: 0;
+        overflow: hidden; flex-grow: 1; color-scheme: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      const RESOURCE_READY = "ui/notifications/sandbox-resource-ready";
+      const PROXY_READY = "ui/notifications/sandbox-proxy-ready";
+
+      // Must run inside an iframe on a different origin than the host.
+      if (window.self === window.top) {
+        throw new Error("sandbox.html must be loaded inside an iframe.");
+      }
+      if (!document.referrer) {
+        throw new Error("No referrer; cannot validate the embedding host origin.");
+      }
+      const EXPECTED_HOST_ORIGIN = new URL(document.referrer).origin;
+      const OWN_ORIGIN = new URL(window.location.href).origin;
+
+      // Security self-test: confirm we cannot reach the top window. If this does
+      // NOT throw, isolation is broken and we must refuse to run.
+      try {
+        window.top.alert("sandbox isolation broken");
+        throw "FAIL";
+      } catch (e) {
+        if (e === "FAIL") {
+          throw new Error("Sandbox is not isolated (host and sandbox share an origin?).");
+        }
+      }
+
+      // Minimal copy of ext-apps buildAllowAttribute: maps requested permissions
+      // to an iframe Permissions-Policy `allow` attribute.
+      function buildAllowAttribute(permissions) {
+        if (!permissions || typeof permissions !== "object") return "";
+        const map = {
+          camera: "camera",
+          microphone: "microphone",
+          geolocation: "geolocation",
+          clipboardWrite: "clipboard-write",
+          clipboardRead: "clipboard-read",
+          displayCapture: "display-capture",
+        };
+        const out = [];
+        for (const key of Object.keys(permissions)) {
+          if (map[key]) out.push(`${map[key]} 'self'`);
+        }
+        return out.join("; ");
+      }
+
+      const inner = document.createElement("iframe");
+      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      document.body.appendChild(inner);
+
+      window.addEventListener("message", (event) => {
+        if (event.source === window.parent) {
+          if (event.origin !== EXPECTED_HOST_ORIGIN) {
+            console.error("[sandbox] dropping parent message from", event.origin);
+            return;
+          }
+          if (event.data && event.data.method === RESOURCE_READY) {
+            const { html, sandbox, permissions } = event.data.params ?? {};
+            if (typeof sandbox === "string") inner.setAttribute("sandbox", sandbox);
+            const allow = buildAllowAttribute(permissions);
+            if (allow) inner.setAttribute("allow", allow);
+            if (typeof html === "string") {
+              const doc = inner.contentDocument || inner.contentWindow?.document;
+              if (doc) { doc.open(); doc.write(html); doc.close(); }
+              else { inner.srcdoc = html; }
+            }
+            return;
+          }
+          // Relay everything else host -> inner widget.
+          inner.contentWindow?.postMessage(event.data, "*");
+        } else if (event.source === inner.contentWindow) {
+          if (event.origin !== OWN_ORIGIN && event.origin !== "null") {
+            console.error("[sandbox] dropping inner message from", event.origin);
+            return;
+          }
+          // Relay inner widget -> host.
+          window.parent.postMessage(event.data, EXPECTED_HOST_ORIGIN);
+        }
+      });
+
+      window.parent.postMessage({ jsonrpc: "2.0", method: PROXY_READY, params: {} }, EXPECTED_HOST_ORIGIN);
+    </script>
+  </body>
+</html>

--- a/packages/web-components/mcp-app-sandbox/sandbox.html
+++ b/packages/web-components/mcp-app-sandbox/sandbox.html
@@ -11,10 +11,11 @@
       serve.mjs / GRACKLE_SANDBOX_PORT). It creates an INNER iframe for the
       untrusted widget HTML and relays postMessage between host and widget.
 
-      CSP for the inner widget is applied by serve.mjs via the HTTP
+      CSP for the proxy + the inner widget is applied by serve.mjs via the HTTP
       Content-Security-Policy header (built from the ?csp= query param) — it is
-      tamper-proof, unlike a <meta> tag. The relay below is inlined (no bundler);
-      that script-src 'unsafe-inline' is intentionally permitted by serve.mjs.
+      tamper-proof, unlike a <meta> tag. The relay is loaded as an EXTERNAL module
+      (sandbox-relay.js) from the sandbox origin so the CSP can keep
+      `script-src 'self'` (no 'unsafe-inline').
 
       Adapted from modelcontextprotocol/ext-apps examples/basic-host/src/sandbox.ts
       (commit 9a37ad7).
@@ -31,88 +32,6 @@
     </style>
   </head>
   <body>
-    <script type="module">
-      const RESOURCE_READY = "ui/notifications/sandbox-resource-ready";
-      const PROXY_READY = "ui/notifications/sandbox-proxy-ready";
-
-      // Must run inside an iframe on a different origin than the host.
-      if (window.self === window.top) {
-        throw new Error("sandbox.html must be loaded inside an iframe.");
-      }
-      if (!document.referrer) {
-        throw new Error("No referrer; cannot validate the embedding host origin.");
-      }
-      const EXPECTED_HOST_ORIGIN = new URL(document.referrer).origin;
-      const OWN_ORIGIN = new URL(window.location.href).origin;
-
-      // Security self-test: confirm we cannot reach the top window. Reading a
-      // property on a cross-origin window.top throws a SecurityError without any
-      // visible side effect (unlike alert()). If it does NOT throw, isolation is
-      // broken and we must refuse to run.
-      try {
-        const probe = window.top.location.href;
-        void probe;
-        throw "FAIL";
-      } catch (e) {
-        if (e === "FAIL") {
-          throw new Error("Sandbox is not isolated (host and sandbox share an origin?).");
-        }
-      }
-
-      // Minimal copy of ext-apps buildAllowAttribute: maps requested permissions
-      // to an iframe Permissions-Policy `allow` attribute.
-      function buildAllowAttribute(permissions) {
-        if (!permissions || typeof permissions !== "object") return "";
-        const map = {
-          camera: "camera",
-          microphone: "microphone",
-          geolocation: "geolocation",
-          clipboardWrite: "clipboard-write",
-          clipboardRead: "clipboard-read",
-          displayCapture: "display-capture",
-        };
-        const out = [];
-        for (const key of Object.keys(permissions)) {
-          if (map[key]) out.push(`${map[key]} 'self'`);
-        }
-        return out.join("; ");
-      }
-
-      const inner = document.createElement("iframe");
-      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
-      document.body.appendChild(inner);
-
-      window.addEventListener("message", (event) => {
-        if (event.source === window.parent) {
-          if (event.origin !== EXPECTED_HOST_ORIGIN) {
-            console.error("[sandbox] dropping parent message from", event.origin);
-            return;
-          }
-          if (event.data && event.data.method === RESOURCE_READY) {
-            const { html, sandbox, permissions } = event.data.params ?? {};
-            if (typeof sandbox === "string") inner.setAttribute("sandbox", sandbox);
-            const allow = buildAllowAttribute(permissions);
-            if (allow) inner.setAttribute("allow", allow);
-            if (typeof html === "string") {
-              const doc = inner.contentDocument || inner.contentWindow?.document;
-              if (doc) { doc.open(); doc.write(html); doc.close(); }
-              else { inner.srcdoc = html; }
-            }
-            return;
-          }
-          // Relay everything else host -> inner widget.
-          inner.contentWindow?.postMessage(event.data, "*");
-        } else if (event.source === inner.contentWindow) {
-          if (event.origin !== OWN_ORIGIN && event.origin !== "null") {
-            console.error("[sandbox] dropping inner message from", event.origin);
-            return;
-          }
-          // Relay inner widget -> host.
-          window.parent.postMessage(event.data, EXPECTED_HOST_ORIGIN);
-        }
-      });
-
-      window.parent.postMessage({ jsonrpc: "2.0", method: PROXY_READY, params: {} }, EXPECTED_HOST_ORIGIN);
-    </script>
+    <script type="module" src="./sandbox-relay.js"></script>
   </body>
 </html>

--- a/packages/web-components/mcp-app-sandbox/sandbox.html
+++ b/packages/web-components/mcp-app-sandbox/sandbox.html
@@ -45,10 +45,13 @@
       const EXPECTED_HOST_ORIGIN = new URL(document.referrer).origin;
       const OWN_ORIGIN = new URL(window.location.href).origin;
 
-      // Security self-test: confirm we cannot reach the top window. If this does
-      // NOT throw, isolation is broken and we must refuse to run.
+      // Security self-test: confirm we cannot reach the top window. Reading a
+      // property on a cross-origin window.top throws a SecurityError without any
+      // visible side effect (unlike alert()). If it does NOT throw, isolation is
+      // broken and we must refuse to run.
       try {
-        window.top.alert("sandbox isolation broken");
+        const probe = window.top.location.href;
+        void probe;
         throw "FAIL";
       } catch (e) {
         if (e === "FAIL") {

--- a/packages/web-components/mcp-app-sandbox/serve.mjs
+++ b/packages/web-components/mcp-app-sandbox/serve.mjs
@@ -32,8 +32,13 @@ try {
   APP_WITH_DEPS_FILE = undefined;
 }
 
-// Static JS files served (as ES modules) to the inner sandboxed widget.
+// The externalized proxy relay (loaded by sandbox.html as `script-src 'self'`).
+const SANDBOX_RELAY_FILE = join(HERE, "sandbox-relay.js");
+
+// Static JS files served (as ES modules). The relay runs in the proxy page; the
+// widget modules run in the inner sandboxed iframe (both as same-origin 'self').
 const JS_ROUTES = {
+  "/sandbox-relay.js": () => SANDBOX_RELAY_FILE,
   "/sample-widget.js": () => SAMPLE_WIDGET_FILE,
   "/app-with-deps.js": () => APP_WITH_DEPS_FILE,
 };
@@ -51,8 +56,14 @@ function buildCspHeader(csp) {
   const frameDomains = sanitizeCspDomains(csp?.frameDomains).join(" ");
   const baseUriDomains = sanitizeCspDomains(csp?.baseUriDomains).join(" ");
   return [
-    "default-src 'self' 'unsafe-inline'",
-    `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: ${resourceDomains}`.trim(),
+    "default-src 'self'",
+    // Scripts: only same-origin (the relay + widget modules are served from this
+    // origin) plus blob: for widgets that spawn workers. No 'unsafe-inline' (the
+    // relay is an external module), no 'unsafe-eval' (the ext-apps App runs zod in
+    // jitless mode), no data: scripts.
+    `script-src 'self' blob: ${resourceDomains}`.trim(),
+    // Styles still allow 'unsafe-inline' — widgets routinely use <style> blocks
+    // and inline style attributes, which is far lower-risk than inline scripts.
     `style-src 'self' 'unsafe-inline' blob: data: ${resourceDomains}`.trim(),
     `img-src 'self' data: blob: ${resourceDomains}`.trim(),
     `font-src 'self' data: blob: ${resourceDomains}`.trim(),

--- a/packages/web-components/mcp-app-sandbox/serve.mjs
+++ b/packages/web-components/mcp-app-sandbox/serve.mjs
@@ -1,0 +1,134 @@
+// Sidecar static server for the MCP Apps sandbox proxy.
+//
+// Serves sandbox.html from a DIFFERENT ORIGIN than the host (Storybook), with a
+// per-request Content-Security-Policy set via HTTP header (built from the ?csp=
+// query param) — tamper-proof, unlike a <meta> tag. The CSP governs the inner
+// widget written into sandbox.html's inner iframe.
+//
+// Used in T1 (#1236) for Storybook; the production equivalent is the
+// GRACKLE_SANDBOX_PORT server in #1238. CSP-building logic mirrors
+// modelcontextprotocol/ext-apps examples/basic-host/serve.ts (commit 9a37ad7).
+
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const PORT = parseInt(process.env.MCP_SANDBOX_PORT ?? "6007", 10);
+const HOST = process.env.MCP_SANDBOX_HOST ?? "127.0.0.1";
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SANDBOX_FILE = join(HERE, "sandbox.html");
+// The thin app-side widget module loaded by the inner iframe.
+const SAMPLE_WIDGET_FILE = join(HERE, "sample-widget.js");
+// The REAL @modelcontextprotocol/ext-apps App, pre-bundled with deps inlined,
+// resolved from node_modules so it stays in sync with the installed version.
+let APP_WITH_DEPS_FILE;
+try {
+  APP_WITH_DEPS_FILE = require.resolve("@modelcontextprotocol/ext-apps/app-with-deps");
+} catch {
+  APP_WITH_DEPS_FILE = undefined;
+}
+
+// Static JS files served (as ES modules) to the inner sandboxed widget.
+const JS_ROUTES = {
+  "/sample-widget.js": () => SAMPLE_WIDGET_FILE,
+  "/app-with-deps.js": () => APP_WITH_DEPS_FILE,
+};
+
+/** Reject CSP domain entries with characters that could break out of a directive. */
+function sanitizeCspDomains(domains) {
+  if (!Array.isArray(domains)) return [];
+  return domains.filter((d) => typeof d === "string" && !/[;\r\n'" ]/.test(d));
+}
+
+/** Build the Content-Security-Policy header value from an optional McpUiResourceCsp. */
+function buildCspHeader(csp) {
+  const resourceDomains = sanitizeCspDomains(csp?.resourceDomains).join(" ");
+  const connectDomains = sanitizeCspDomains(csp?.connectDomains).join(" ");
+  const frameDomains = sanitizeCspDomains(csp?.frameDomains).join(" ");
+  const baseUriDomains = sanitizeCspDomains(csp?.baseUriDomains).join(" ");
+  return [
+    "default-src 'self' 'unsafe-inline'",
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: ${resourceDomains}`.trim(),
+    `style-src 'self' 'unsafe-inline' blob: data: ${resourceDomains}`.trim(),
+    `img-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `font-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `media-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `connect-src 'self' ${connectDomains}`.trim(),
+    `worker-src 'self' blob: ${resourceDomains}`.trim(),
+    frameDomains ? `frame-src ${frameDomains}` : "frame-src 'none'",
+    "object-src 'none'",
+    baseUriDomains ? `base-uri ${baseUriDomains}` : "base-uri 'none'",
+  ].join("; ");
+}
+
+const server = createServer((req, res) => {
+  const requestUrl = new URL(req.url ?? "/", `http://${req.headers.host ?? HOST}`);
+  const path = requestUrl.pathname;
+
+  // Serve the app-side JS modules (the bundled App + the sample widget) that the
+  // inner widget loads. `script-src 'self'` permits these because the inner
+  // iframe shares the sandbox origin (allow-same-origin).
+  const jsResolver = JS_ROUTES[path];
+  if (jsResolver) {
+    const file = jsResolver();
+    let js;
+    try {
+      js = file ? readFileSync(file, "utf-8") : undefined;
+    } catch {
+      js = undefined;
+    }
+    if (!js) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end(`Not found: ${path}`);
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": "text/javascript; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(js);
+    return;
+  }
+
+  if (path !== "/" && path !== "/sandbox.html") {
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Only sandbox.html and the widget JS modules are served on this port.");
+    return;
+  }
+
+  let csp;
+  const cspParam = requestUrl.searchParams.get("csp");
+  if (cspParam) {
+    try {
+      csp = JSON.parse(cspParam);
+    } catch {
+      // Ignore an unparseable csp param and fall back to the locked-down default.
+    }
+  }
+
+  let html;
+  try {
+    html = readFileSync(SANDBOX_FILE, "utf-8");
+  } catch {
+    res.writeHead(500, { "Content-Type": "text/plain" });
+    res.end("sandbox.html not found");
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Security-Policy": buildCspHeader(csp),
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.end(html);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[mcp-sandbox] serving sandbox.html at http://${HOST}:${PORT}/sandbox.html`);
+});

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -3,6 +3,10 @@
   "version": "0.110.2",
   "description": "Presentational React component library for the Grackle web UI",
   "license": "MIT",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/nick-pape/grackle.git",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -30,12 +30,16 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook",
+    "mcp-sandbox": "node mcp-app-sandbox/serve.mjs",
+    "storybook:mcp": "concurrently -k -n sandbox,storybook \"node mcp-app-sandbox/serve.mjs\" \"storybook dev -p 6006\"",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.0",
     "@grackle-ai/common": "workspace:*",
+    "@modelcontextprotocol/ext-apps": "1.7.2",
+    "@modelcontextprotocol/sdk": "^1.27.0",
     "@dagrejs/dagre": "^2.0.4",
     "@xyflow/react": "^12.10.0",
     "motion": "^11.18.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^2.5.0",
     "@grackle-ai/common": "workspace:*",
     "@modelcontextprotocol/ext-apps": "1.7.2",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@dagrejs/dagre": "^2.0.4",
     "@xyflow/react": "^12.10.0",
     "motion": "^11.18.0",

--- a/packages/web-components/src/components/display/McpAppWidget.stories.tsx
+++ b/packages/web-components/src/components/display/McpAppWidget.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn } from "@storybook/test";
+import { McpAppWidget } from "./McpAppWidget.js";
+
+// The sandbox proxy MUST be served from a different origin than Storybook.
+// Run `npm run storybook:mcp` (Storybook + the sidecar CSP server) so this is up.
+const SANDBOX_ORIGIN: string = "http://localhost:6007";
+const SANDBOX_URL: string = SANDBOX_ORIGIN + "/sandbox.html";
+
+// A sample widget that loads the REAL @modelcontextprotocol/ext-apps `App` (the
+// dependency-inlined bundle served by serve.mjs) so the MCP Apps handshake is
+// fully spec-conformant. The widget logic lives in sample-widget.js; this is just
+// the DOM skeleton plus the module script tag. ASCII-only (the Storybook acorn
+// indexer breaks on non-ASCII in .stories.tsx).
+const SAMPLE_WIDGET_HTML: string = [
+  "<!doctype html><html><head><meta charset=\"utf-8\"><style>",
+  "body{margin:0;font-family:var(--font-sans,sans-serif);color:var(--color-text-primary,#111);",
+  "background:var(--color-background-secondary,#f5f5f5);padding:16px}",
+  ".card{background:var(--color-background-primary,#fff);border:1px solid var(--color-border-primary,#ddd);",
+  "border-radius:var(--border-radius-md,6px);padding:16px}",
+  "code{font-family:var(--font-mono,monospace)} button{margin-top:12px}",
+  "</style></head><body><div class=\"card\">",
+  "<h2 id=\"title\">Weather</h2>",
+  "<div>Input: <code id=\"in\">(none)</code></div>",
+  "<div>Result: <code id=\"out\">(pending)</code></div>",
+  "<button id=\"call\">Refresh</button></div>",
+  "<script type=\"module\" src=\"" + SANDBOX_ORIGIN + "/sample-widget.js\"></script>",
+  "</body></html>",
+].join("");
+
+const meta: Meta<typeof McpAppWidget> = {
+  title: "Grackle/Display/McpAppWidget",
+  component: McpAppWidget,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    widgetHtml: SAMPLE_WIDGET_HTML,
+    sandboxProxyUrl: SANDBOX_URL,
+    toolInput: { location: "Seattle" },
+    toolResult: { content: [{ type: "text", text: "72F and clear" }] },
+    onCallTool: fn(async () => ({ content: [{ type: "text", text: "refreshed: 70F" }] })),
+    onOpenLink: fn(),
+    onSendMessage: fn(),
+    onSizeChange: fn(),
+  },
+  // Sidecar-independent smoke check: the host iframe mounts. The full handshake
+  // (proxy ready -> initialize -> tool-input/result -> size-changed) is exercised
+  // visually via `npm run storybook:mcp` and the PR screenshot, since it requires
+  // the cross-origin sidecar which is not part of the headless test phase.
+  play: async ({ canvas }) => {
+    const iframe = await canvas.findByTestId("mcp-app-widget");
+    await expect(iframe).toBeInTheDocument();
+    await expect(iframe.tagName.toLowerCase()).toBe("iframe");
+  },
+};

--- a/packages/web-components/src/components/display/McpAppWidget.test.tsx
+++ b/packages/web-components/src/components/display/McpAppWidget.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { McpAppWidget } from "./McpAppWidget.js";
+
+describe("McpAppWidget", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("mounts an iframe host for the widget", () => {
+    render(
+      <McpAppWidget
+        widgetHtml="<!doctype html><html><body>hi</body></html>"
+        sandboxProxyUrl="http://localhost:6007/sandbox.html"
+      />,
+    );
+    const iframe = screen.getByTestId("mcp-app-widget");
+    expect(iframe.tagName.toLowerCase()).toBe("iframe");
+  });
+
+  it("points the iframe at the sandbox proxy origin", () => {
+    render(
+      <McpAppWidget
+        widgetHtml="<!doctype html><html><body>hi</body></html>"
+        sandboxProxyUrl="http://localhost:6007/sandbox.html"
+      />,
+    );
+    const iframe = screen.getByTestId("mcp-app-widget") as HTMLIFrameElement;
+    expect(iframe.getAttribute("src") ?? "").toContain("localhost:6007");
+  });
+});

--- a/packages/web-components/src/components/display/McpAppWidget.test.tsx
+++ b/packages/web-components/src/components/display/McpAppWidget.test.tsx
@@ -29,4 +29,18 @@ describe("McpAppWidget", () => {
     const iframe = screen.getByTestId("mcp-app-widget") as HTMLIFrameElement;
     expect(iframe.getAttribute("src") ?? "").toContain("localhost:6007");
   });
+
+  it("fails fast when the sandbox proxy shares the host origin", () => {
+    // A same-origin proxy breaks the double-iframe isolation guarantee, so the
+    // component throws rather than silently rendering an insecure widget.
+    const sameOrigin = `${window.location.origin}/sandbox.html`;
+    expect(() =>
+      render(
+        <McpAppWidget
+          widgetHtml="<!doctype html><html><body>hi</body></html>"
+          sandboxProxyUrl={sameOrigin}
+        />,
+      ),
+    ).toThrow(/different origin/i);
+  });
 });

--- a/packages/web-components/src/components/display/McpAppWidget.tsx
+++ b/packages/web-components/src/components/display/McpAppWidget.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useRef, type JSX } from "react";
+import {
+  AppBridge,
+  PostMessageTransport,
+  buildAllowAttribute,
+  type McpUiResourceCsp,
+  type McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { McpUiStyles } from "@modelcontextprotocol/ext-apps";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { grackleHostStyleVariables } from "../../utils/grackleHostStyleVariables.js";
+
+/** Notification method the outer sandbox proxy posts once it is ready. */
+const SANDBOX_PROXY_READY: string = "ui/notifications/sandbox-proxy-ready";
+
+/** Identifies this host to widgets during the MCP Apps handshake. */
+const HOST_INFO: Readonly<{ name: string; version: string }> = { name: "Grackle", version: "0.0.0" };
+
+/** A tool call the widget asked the host to run on its behalf. */
+export interface McpAppWidgetCallToolParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * Props for {@link McpAppWidget}. Presentational only — all data and side
+ * effects arrive as props (no `useGrackle()`).
+ */
+export interface McpAppWidgetProps {
+  /** Widget HTML (`text/html;profile=mcp-app` contents) rendered in the sandbox. */
+  widgetHtml: string;
+  /** URL of the sandbox proxy, served from a DIFFERENT origin than the host. */
+  sandboxProxyUrl: string;
+  /** Tool input delivered to the widget via `ui/notifications/tool-input`. */
+  toolInput?: Record<string, unknown>;
+  /** Tool result delivered to the widget via `ui/notifications/tool-result`. */
+  toolResult?: CallToolResult;
+  /** Content-Security-Policy domains for the widget (from the resource `_meta.ui`). */
+  csp?: McpUiResourceCsp;
+  /** Permissions to grant the widget iframe (from the resource `_meta.ui`). */
+  permissions?: McpUiResourcePermissions;
+  /** Style variables for `hostContext.styles`; defaults to Grackle's live theme. */
+  hostStyleVariables?: McpUiStyles;
+  /** Color theme reported to the widget; defaults to the document's `data-theme`. */
+  theme?: "light" | "dark";
+  /** Handle a tool call the widget requests (no MCP client is wired in T1). */
+  onCallTool?: (params: McpAppWidgetCallToolParams) => Promise<CallToolResult>;
+  /** Handle a link the widget asks the host to open. */
+  onOpenLink?: (url: string) => void;
+  /** Handle a message the widget asks the host to surface. */
+  onSendMessage?: (message: unknown) => void;
+  /** Handle a model-context update pushed by the widget. */
+  onUpdateModelContext?: (context: unknown) => void;
+  /** Notified when the widget requests a new size. */
+  onSizeChange?: (size: { width?: number; height?: number }) => void;
+}
+
+/** Resolve the active theme, preferring the prop, then the document, then light. */
+function resolveTheme(theme: McpAppWidgetProps["theme"]): "light" | "dark" {
+  if (theme) {
+    return theme;
+  }
+  if (typeof document !== "undefined") {
+    const attr: string | null = document.documentElement.getAttribute("data-theme");
+    if (attr === "dark") {
+      return "dark";
+    }
+  }
+  return "light";
+}
+
+/**
+ * Point the iframe at the sandbox proxy and resolve once the proxy reports
+ * ready. Returns `false` if the iframe was already loaded (guards against an
+ * accidental double-invoke).
+ */
+function loadSandboxProxy(
+  iframe: HTMLIFrameElement,
+  sandboxProxyUrl: string,
+  csp: McpUiResourceCsp | undefined,
+  permissions: McpUiResourcePermissions | undefined,
+): Promise<boolean> {
+  if (iframe.src) {
+    return Promise.resolve(false);
+  }
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+  const allow: string = buildAllowAttribute(permissions);
+  if (allow) {
+    iframe.setAttribute("allow", allow);
+  }
+  const ready: Promise<boolean> = new Promise<boolean>((resolve) => {
+    const listener = (event: MessageEvent): void => {
+      const data: { method?: string } | undefined = event.data as { method?: string } | undefined;
+      if (event.source === iframe.contentWindow && data?.method === SANDBOX_PROXY_READY) {
+        window.removeEventListener("message", listener);
+        resolve(true);
+      }
+    };
+    window.addEventListener("message", listener);
+  });
+  const url: URL = new URL(sandboxProxyUrl);
+  if (csp) {
+    url.searchParams.set("csp", JSON.stringify(csp));
+  }
+  iframe.src = url.href;
+  return ready;
+}
+
+/** Swallow a settled promise's rejection (the host outlives transient widget errors). */
+function ignoreRejection(promise: Promise<unknown> | void): void {
+  Promise.resolve(promise).catch(() => undefined);
+}
+
+/**
+ * Renders an MCP Apps widget (untrusted HTML) inside a double-iframe sandbox and
+ * drives it over the `ext-apps` `AppBridge` postMessage protocol.
+ *
+ * The Grackle chat pane is not an MCP client, so this constructs the bridge with
+ * `null` (no client) and serves tool input/result from props. Wiring the bridge
+ * to a live MCP server is a later ticket (#1238).
+ */
+export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
+  const {
+    widgetHtml,
+    sandboxProxyUrl,
+    csp,
+    permissions,
+    hostStyleVariables,
+    theme,
+    toolInput,
+    toolResult,
+    onCallTool,
+    onOpenLink,
+    onSendMessage,
+    onUpdateModelContext,
+    onSizeChange,
+  } = props;
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const bridgeRef = useRef<AppBridge | undefined>(undefined);
+
+  // Keep the latest callbacks/data in a ref so the setup effect can be keyed
+  // only on the widget identity (re-running it would reload the iframe).
+  const handlers = useRef({ toolInput, toolResult, onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange });
+  handlers.current = { toolInput, toolResult, onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange };
+
+  useEffect(() => {
+    const iframe: HTMLIFrameElement | null = iframeRef.current;
+    if (!iframe) {
+      return undefined;
+    }
+    // Object holder so the async closure below reads a value lint can't narrow.
+    const state: { cancelled: boolean } = { cancelled: false };
+    // Read through a function so flow analysis can't narrow it to a literal
+    // (it is reassigned in the cleanup closure below).
+    const isCancelled = (): boolean => state.cancelled;
+    let resizeObserver: ResizeObserver | undefined;
+
+    const run = async (): Promise<void> => {
+      const firstTime: boolean = await loadSandboxProxy(iframe, sandboxProxyUrl, csp, permissions);
+      if (!firstTime || isCancelled()) {
+        return;
+      }
+
+      const bridge = new AppBridge(
+        null,
+        HOST_INFO,
+        { openLinks: {}, updateModelContext: { text: {} } },
+        {
+          hostContext: {
+            theme: resolveTheme(theme),
+            platform: "web",
+            styles: { variables: hostStyleVariables ?? grackleHostStyleVariables() },
+            containerDimensions: { maxHeight: 6000 },
+            displayMode: "inline",
+            availableDisplayModes: ["inline"],
+          },
+        },
+      );
+      bridgeRef.current = bridge;
+
+      bridge.oncalltool = async (params): Promise<CallToolResult> => {
+        const handler = handlers.current.onCallTool;
+        if (handler) {
+          return handler({ name: params.name, arguments: params.arguments });
+        }
+        return { isError: true, content: [{ type: "text", text: "No MCP client is connected to this host." }] };
+      };
+      bridge.onopenlink = async ({ url }): Promise<Record<string, never>> => {
+        const handler = handlers.current.onOpenLink;
+        if (handler) {
+          handler(url);
+        } else {
+          window.open(url, "_blank", "noopener,noreferrer");
+        }
+        return {};
+      };
+      bridge.onmessage = async (params): Promise<Record<string, never>> => {
+        handlers.current.onSendMessage?.(params);
+        return {};
+      };
+      bridge.onupdatemodelcontext = async (params): Promise<Record<string, never>> => {
+        handlers.current.onUpdateModelContext?.(params);
+        return {};
+      };
+      bridge.onsizechange = ({ width, height }): void => {
+        if (width !== undefined) {
+          iframe.style.minWidth = `min(${width}px, 100%)`;
+        }
+        if (height !== undefined) {
+          iframe.style.height = `${height}px`;
+        }
+        handlers.current.onSizeChange?.({ width, height });
+      };
+      bridge.onrequestdisplaymode = async (): Promise<{ mode: "inline" }> => ({ mode: "inline" });
+
+      const initialized: Promise<void> = new Promise<void>((resolve) => {
+        bridge.oninitialized = (): void => resolve();
+      });
+
+      await bridge.connect(new PostMessageTransport(iframe.contentWindow as Window, iframe.contentWindow as Window));
+      if (isCancelled()) {
+        return;
+      }
+      await bridge.sendSandboxResourceReady({ html: widgetHtml, csp, permissions });
+      await initialized;
+      if (isCancelled()) {
+        return;
+      }
+
+      await bridge.sendToolInput({ arguments: handlers.current.toolInput ?? {} });
+      const result = handlers.current.toolResult;
+      if (result) {
+        await bridge.sendToolResult(result);
+      }
+
+      resizeObserver = new ResizeObserver(([entry]) => {
+        const width: number = Math.round(entry.contentRect.width);
+        if (width > 0) {
+          ignoreRejection(bridge.sendHostContextChange({ containerDimensions: { width, maxHeight: 6000 } }));
+        }
+      });
+      resizeObserver.observe(iframe);
+    };
+
+    run().catch(() => undefined);
+
+    return (): void => {
+      state.cancelled = true;
+      resizeObserver?.disconnect();
+      const bridge: AppBridge | undefined = bridgeRef.current;
+      bridgeRef.current = undefined;
+      if (bridge) {
+        ignoreRejection(bridge.teardownResource({}));
+      }
+      iframe.removeAttribute("src");
+    };
+    // Setup is keyed on the widget identity; theme updates flow via the effect
+    // below, and other props are read at mount.
+  }, [widgetHtml, sandboxProxyUrl]);
+
+  // Propagate theme changes to a live widget.
+  useEffect(() => {
+    ignoreRejection(bridgeRef.current?.sendHostContextChange({ theme: resolveTheme(theme) }));
+  }, [theme]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      data-testid="mcp-app-widget"
+      title="MCP App widget"
+      style={{ width: "100%", border: "none", display: "block" }}
+    />
+  );
+}

--- a/packages/web-components/src/components/display/McpAppWidget.tsx
+++ b/packages/web-components/src/components/display/McpAppWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import {
   AppBridge,
   PostMessageTransport,
@@ -13,8 +13,23 @@ import { grackleHostStyleVariables } from "../../utils/grackleHostStyleVariables
 /** Notification method the outer sandbox proxy posts once it is ready. */
 const SANDBOX_PROXY_READY: string = "ui/notifications/sandbox-proxy-ready";
 
-/** Identifies this host to widgets during the MCP Apps handshake. */
-const HOST_INFO: Readonly<{ name: string; version: string }> = { name: "Grackle", version: "0.0.0" };
+/** Default host identity reported to widgets during the MCP Apps handshake. */
+const DEFAULT_HOST_INFO: Readonly<{ name: string; version: string }> = {
+  name: "Grackle",
+  version: "0.0.0",
+};
+
+/** URL schemes the default link handler is permitted to open. */
+const SAFE_LINK_PROTOCOLS: ReadonlySet<string> = new Set(["http:", "https:"]);
+
+/** True if `url` parses as an `http(s)` URL safe to open in a new browsing context. */
+function isSafeHttpUrl(url: string): boolean {
+  try {
+    return SAFE_LINK_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
 
 /** A tool call the widget asked the host to run on its behalf. */
 export interface McpAppWidgetCallToolParams {
@@ -43,6 +58,8 @@ export interface McpAppWidgetProps {
   hostStyleVariables?: McpUiStyles;
   /** Color theme reported to the widget; defaults to the document's `data-theme`. */
   theme?: "light" | "dark";
+  /** Host identity reported to the widget; defaults to {@link DEFAULT_HOST_INFO}. */
+  hostInfo?: { name: string; version: string };
   /** Handle a tool call the widget requests (no MCP client is wired in T1). */
   onCallTool?: (params: McpAppWidgetCallToolParams) => Promise<CallToolResult>;
   /** Handle a link the widget asks the host to open. */
@@ -72,13 +89,18 @@ function resolveTheme(theme: McpAppWidgetProps["theme"]): "light" | "dark" {
 /**
  * Point the iframe at the sandbox proxy and resolve once the proxy reports
  * ready. Returns `false` if the iframe was already loaded (guards against an
- * accidental double-invoke).
+ * accidental double-invoke) or if `signal` aborts before the proxy responds.
+ *
+ * The ready listener is bound to `signal` so it is removed on effect cleanup,
+ * and only messages from the proxy window AND its expected origin are accepted.
  */
 function loadSandboxProxy(
   iframe: HTMLIFrameElement,
   sandboxProxyUrl: string,
+  proxyOrigin: string,
   csp: McpUiResourceCsp | undefined,
   permissions: McpUiResourcePermissions | undefined,
+  signal: AbortSignal,
 ): Promise<boolean> {
   if (iframe.src) {
     return Promise.resolve(false);
@@ -91,14 +113,20 @@ function loadSandboxProxy(
   const ready: Promise<boolean> = new Promise<boolean>((resolve) => {
     const listener = (event: MessageEvent): void => {
       const data: { method?: string } | undefined = event.data as { method?: string } | undefined;
-      if (event.source === iframe.contentWindow && data?.method === SANDBOX_PROXY_READY) {
-        window.removeEventListener("message", listener);
+      if (
+        event.source === iframe.contentWindow &&
+        event.origin === proxyOrigin &&
+        data?.method === SANDBOX_PROXY_READY
+      ) {
         resolve(true);
       }
     };
-    window.addEventListener("message", listener);
+    // `{ signal }` removes the listener automatically on effect cleanup, so it
+    // never outlives the component even if the proxy never responds.
+    window.addEventListener("message", listener, { signal });
+    signal.addEventListener("abort", () => resolve(false), { once: true });
   });
-  const url: URL = new URL(sandboxProxyUrl);
+  const url: URL = new URL(sandboxProxyUrl, window.location.href);
   if (csp) {
     url.searchParams.set("csp", JSON.stringify(csp));
   }
@@ -127,6 +155,7 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
     permissions,
     hostStyleVariables,
     theme,
+    hostInfo,
     toolInput,
     toolResult,
     onCallTool,
@@ -136,35 +165,66 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
     onSizeChange,
   } = props;
 
+  // Fail fast on the isolation-breaking misconfiguration: the sandbox proxy MUST
+  // be a different origin than the host, otherwise `window.top` is reachable and
+  // the double-iframe guarantee is void.
+  if (
+    typeof window !== "undefined" &&
+    new URL(sandboxProxyUrl, window.location.href).origin === window.location.origin
+  ) {
+    throw new Error(
+      "McpAppWidget: sandboxProxyUrl must be served from a DIFFERENT origin than the host.",
+    );
+  }
+
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const bridgeRef = useRef<AppBridge | undefined>(undefined);
+  // Flips true once the ui/initialize handshake completes; the tool-input/result
+  // effects below key on it so late-arriving props still reach the widget.
+  const [initialized, setInitialized] = useState<boolean>(false);
 
-  // Keep the latest callbacks/data in a ref so the setup effect can be keyed
-  // only on the widget identity (re-running it would reload the iframe).
-  const handlers = useRef({ toolInput, toolResult, onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange });
-  handlers.current = { toolInput, toolResult, onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange };
+  // Keep the latest callbacks in a ref so the setup effect can be keyed only on
+  // the widget identity (re-running it would reload the iframe).
+  const handlers = useRef({ onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange });
+  handlers.current = { onCallTool, onOpenLink, onSendMessage, onUpdateModelContext, onSizeChange };
+
+  // csp/permissions are part of the widget identity (they affect the proxy URL
+  // and sendSandboxResourceReady), so the iframe must reload when they change.
+  const cspKey: string = JSON.stringify(csp ?? null);
+  const permissionsKey: string = JSON.stringify(permissions ?? null);
 
   useEffect(() => {
     const iframe: HTMLIFrameElement | null = iframeRef.current;
     if (!iframe) {
       return undefined;
     }
-    // Object holder so the async closure below reads a value lint can't narrow.
-    const state: { cancelled: boolean } = { cancelled: false };
-    // Read through a function so flow analysis can't narrow it to a literal
-    // (it is reassigned in the cleanup closure below).
-    const isCancelled = (): boolean => state.cancelled;
+
+    // Origin of the proxy, used to validate inbound proxy messages. The
+    // different-origin invariant is enforced at render time (see above).
+    const proxyOrigin: string = new URL(sandboxProxyUrl, window.location.href).origin;
+    const abortController: AbortController = new AbortController();
+    const { signal } = abortController;
+    // Read abort state through a function so TS flow-analysis can't narrow it to
+    // a constant across the awaits below (cleanup flips it asynchronously).
+    const isAborted = (): boolean => signal.aborted;
     let resizeObserver: ResizeObserver | undefined;
 
     const run = async (): Promise<void> => {
-      const firstTime: boolean = await loadSandboxProxy(iframe, sandboxProxyUrl, csp, permissions);
-      if (!firstTime || isCancelled()) {
+      const firstTime: boolean = await loadSandboxProxy(
+        iframe,
+        sandboxProxyUrl,
+        proxyOrigin,
+        csp,
+        permissions,
+        signal,
+      );
+      if (!firstTime || isAborted()) {
         return;
       }
 
       const bridge = new AppBridge(
         null,
-        HOST_INFO,
+        hostInfo ?? DEFAULT_HOST_INFO,
         { openLinks: {}, updateModelContext: { text: {} } },
         {
           hostContext: {
@@ -190,7 +250,8 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
         const handler = handlers.current.onOpenLink;
         if (handler) {
           handler(url);
-        } else {
+        } else if (isSafeHttpUrl(url)) {
+          // Only http(s) — never javascript:/data: from an untrusted widget.
           window.open(url, "_blank", "noopener,noreferrer");
         }
         return {};
@@ -214,25 +275,22 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
       };
       bridge.onrequestdisplaymode = async (): Promise<{ mode: "inline" }> => ({ mode: "inline" });
 
-      const initialized: Promise<void> = new Promise<void>((resolve) => {
+      const handshakeComplete: Promise<void> = new Promise<void>((resolve) => {
         bridge.oninitialized = (): void => resolve();
       });
 
       await bridge.connect(new PostMessageTransport(iframe.contentWindow as Window, iframe.contentWindow as Window));
-      if (isCancelled()) {
+      if (isAborted()) {
         return;
       }
       await bridge.sendSandboxResourceReady({ html: widgetHtml, csp, permissions });
-      await initialized;
-      if (isCancelled()) {
+      await handshakeComplete;
+      if (isAborted()) {
         return;
       }
-
-      await bridge.sendToolInput({ arguments: handlers.current.toolInput ?? {} });
-      const result = handlers.current.toolResult;
-      if (result) {
-        await bridge.sendToolResult(result);
-      }
+      // Tool input/result are delivered (and kept in sync) by the effects below
+      // now that the handshake is complete.
+      setInitialized(true);
 
       resizeObserver = new ResizeObserver(([entry]) => {
         const width: number = Math.round(entry.contentRect.width);
@@ -246,7 +304,8 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
     run().catch(() => undefined);
 
     return (): void => {
-      state.cancelled = true;
+      abortController.abort();
+      setInitialized(false);
       resizeObserver?.disconnect();
       const bridge: AppBridge | undefined = bridgeRef.current;
       bridgeRef.current = undefined;
@@ -255,14 +314,38 @@ export function McpAppWidget(props: McpAppWidgetProps): JSX.Element {
       }
       iframe.removeAttribute("src");
     };
-    // Setup is keyed on the widget identity; theme updates flow via the effect
-    // below, and other props are read at mount.
-  }, [widgetHtml, sandboxProxyUrl]);
+    // Setup is keyed on the widget identity (html + proxy URL + csp/permissions).
+    // Tool input/result and theme updates flow via the dedicated effects below.
+  }, [widgetHtml, sandboxProxyUrl, cspKey, permissionsKey]);
 
-  // Propagate theme changes to a live widget.
+  // Deliver tool input after the handshake, and whenever it changes afterwards.
   useEffect(() => {
-    ignoreRejection(bridgeRef.current?.sendHostContextChange({ theme: resolveTheme(theme) }));
-  }, [theme]);
+    if (!initialized) {
+      return;
+    }
+    ignoreRejection(bridgeRef.current?.sendToolInput({ arguments: toolInput ?? {} }));
+  }, [initialized, toolInput]);
+
+  // Deliver the tool result once it is available, and whenever it changes. The
+  // host commonly renders the widget before the result exists.
+  useEffect(() => {
+    if (!initialized || !toolResult) {
+      return;
+    }
+    ignoreRejection(bridgeRef.current?.sendToolResult(toolResult));
+  }, [initialized, toolResult]);
+
+  // Propagate theme + style-variable changes to a live widget. When
+  // hostStyleVariables is omitted, the Grackle token values themselves change
+  // with the theme, so the resolved variables are re-sent too.
+  useEffect(() => {
+    ignoreRejection(
+      bridgeRef.current?.sendHostContextChange({
+        theme: resolveTheme(theme),
+        styles: { variables: hostStyleVariables ?? grackleHostStyleVariables() },
+      }),
+    );
+  }, [theme, hostStyleVariables]);
 
   return (
     <iframe

--- a/packages/web-components/src/components/display/index.ts
+++ b/packages/web-components/src/components/display/index.ts
@@ -14,9 +14,7 @@ export { Spinner } from "./Spinner.js";
 export { SplashScreen } from "./SplashScreen.js";
 export { Tooltip } from "./Tooltip.js";
 export { SessionAttemptSelector } from "./SessionAttemptSelector.js";
-export { McpAppWidget } from "./McpAppWidget.js";
 
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button.js";
 export type { TooltipProps, TooltipPlacement } from "./Tooltip.js";
 export type { SessionAttemptSelectorProps } from "./SessionAttemptSelector.js";
-export type { McpAppWidgetProps, McpAppWidgetCallToolParams } from "./McpAppWidget.js";

--- a/packages/web-components/src/components/display/index.ts
+++ b/packages/web-components/src/components/display/index.ts
@@ -14,7 +14,9 @@ export { Spinner } from "./Spinner.js";
 export { SplashScreen } from "./SplashScreen.js";
 export { Tooltip } from "./Tooltip.js";
 export { SessionAttemptSelector } from "./SessionAttemptSelector.js";
+export { McpAppWidget } from "./McpAppWidget.js";
 
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button.js";
 export type { TooltipProps, TooltipPlacement } from "./Tooltip.js";
 export type { SessionAttemptSelectorProps } from "./SessionAttemptSelector.js";
+export type { McpAppWidgetProps, McpAppWidgetCallToolParams } from "./McpAppWidget.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -19,12 +19,15 @@ export { useDagLayout } from "./components/dag/useDagLayout.js";
 export {
   Breadcrumbs, Button, CopyButton, DemoBanner, SplitButton,
   EventRenderer, ConfirmDialog, Skeleton, SkeletonText, SkeletonCard,
-  Spinner, SplashScreen, Tooltip, McpAppWidget,
+  Spinner, SplashScreen, Tooltip,
 } from "./components/display/index.js";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/display/index.js";
 export type { TooltipProps, TooltipPlacement } from "./components/display/index.js";
-export type { McpAppWidgetProps, McpAppWidgetCallToolParams } from "./components/display/index.js";
-export { grackleHostStyleVariables } from "./utils/grackleHostStyleVariables.js";
+// NOTE: McpAppWidget + grackleHostStyleVariables are intentionally NOT re-exported
+// from the package entrypoint yet. Doing so pulls @modelcontextprotocol/ext-apps
+// into @grackle-ai/web's bundle (which does not consume the widget in T1),
+// tripping the Vite chunk-size limit. The public re-export lands when the widget
+// is wired into the app with a code-split import (#1238).
 export { EventStream } from "./components/display/EventStream.js";
 export { EventHoverRow } from "./components/display/EventHoverRow.js";
 export type { EventHoverRowProps } from "./components/display/EventHoverRow.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -19,15 +19,12 @@ export { useDagLayout } from "./components/dag/useDagLayout.js";
 export {
   Breadcrumbs, Button, CopyButton, DemoBanner, SplitButton,
   EventRenderer, ConfirmDialog, Skeleton, SkeletonText, SkeletonCard,
-  Spinner, SplashScreen, Tooltip,
+  Spinner, SplashScreen, Tooltip, McpAppWidget,
 } from "./components/display/index.js";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/display/index.js";
 export type { TooltipProps, TooltipPlacement } from "./components/display/index.js";
-// NOTE: McpAppWidget + grackleHostStyleVariables are intentionally NOT re-exported
-// from the package entrypoint yet. Doing so pulls @modelcontextprotocol/ext-apps
-// into @grackle-ai/web's bundle (which does not consume the widget in T1),
-// tripping the Vite chunk-size limit. The public re-export lands when the widget
-// is wired into the app with a code-split import (#1238).
+export type { McpAppWidgetProps, McpAppWidgetCallToolParams } from "./components/display/index.js";
+export { grackleHostStyleVariables } from "./utils/grackleHostStyleVariables.js";
 export { EventStream } from "./components/display/EventStream.js";
 export { EventHoverRow } from "./components/display/EventHoverRow.js";
 export type { EventHoverRowProps } from "./components/display/EventHoverRow.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -19,10 +19,12 @@ export { useDagLayout } from "./components/dag/useDagLayout.js";
 export {
   Breadcrumbs, Button, CopyButton, DemoBanner, SplitButton,
   EventRenderer, ConfirmDialog, Skeleton, SkeletonText, SkeletonCard,
-  Spinner, SplashScreen, Tooltip,
+  Spinner, SplashScreen, Tooltip, McpAppWidget,
 } from "./components/display/index.js";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/display/index.js";
 export type { TooltipProps, TooltipPlacement } from "./components/display/index.js";
+export type { McpAppWidgetProps, McpAppWidgetCallToolParams } from "./components/display/index.js";
+export { grackleHostStyleVariables } from "./utils/grackleHostStyleVariables.js";
 export { EventStream } from "./components/display/EventStream.js";
 export { EventHoverRow } from "./components/display/EventHoverRow.js";
 export type { EventHoverRowProps } from "./components/display/EventHoverRow.js";

--- a/packages/web-components/src/utils/grackleHostStyleVariables.test.ts
+++ b/packages/web-components/src/utils/grackleHostStyleVariables.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { grackleHostStyleVariables } from "./grackleHostStyleVariables.js";
+
+describe("grackleHostStyleVariables", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("always returns the MCP-standard fallback variables", () => {
+    const vars = grackleHostStyleVariables();
+    expect(vars["--color-background-primary"]).toBeDefined();
+    expect(vars["--color-text-primary"]).toBeDefined();
+    expect(vars["--font-sans"]).toBeDefined();
+    expect(vars["--border-radius-md"]).toBeDefined();
+  });
+
+  it("maps a live Grackle token onto its MCP-standard name", () => {
+    document.documentElement.style.setProperty("--bg-base", "rgb(1, 2, 3)");
+    document.documentElement.style.setProperty("--text-primary", "rgb(4, 5, 6)");
+    const vars = grackleHostStyleVariables();
+    expect(vars["--color-background-primary"]).toBe("rgb(1, 2, 3)");
+    expect(vars["--color-text-primary"]).toBe("rgb(4, 5, 6)");
+  });
+});

--- a/packages/web-components/src/utils/grackleHostStyleVariables.ts
+++ b/packages/web-components/src/utils/grackleHostStyleVariables.ts
@@ -1,0 +1,134 @@
+import type { McpUiStyles } from "@modelcontextprotocol/ext-apps";
+
+/**
+ * MCP Apps widgets consume a fixed, standard set of CSS custom properties
+ * (`--color-*`, `--font-*`, `--border-radius-*`, `--shadow-*`). Grackle's own
+ * theme tokens live under different names (`--bg-*`, `--text-*`, `--radius-*`) in
+ * `src/styles/theme.scss`. This module exposes Grackle's current theme to widgets
+ * under the MCP-standard names so a widget renders coherently inside the host.
+ *
+ * `McpUiStyles` requires the complete variable set, so we seed from the standard
+ * theme-adaptive defaults (verbatim from modelcontextprotocol/ext-apps
+ * examples/basic-host/src/host-styles.ts, commit 9a37ad7) and override the subset
+ * we can source from Grackle's live theme.
+ */
+
+/** Complete MCP-standard default style variables (theme-adaptive via `light-dark()`). */
+const DEFAULT_MCP_STYLES: McpUiStyles = {
+  "--color-background-primary": "light-dark(#ffffff, #1a1a1a)",
+  "--color-background-secondary": "light-dark(#f5f5f5, #2d2d2d)",
+  "--color-background-tertiary": "light-dark(#e5e5e5, #404040)",
+  "--color-background-inverse": "light-dark(#1a1a1a, #ffffff)",
+  "--color-background-ghost": "light-dark(rgba(255,255,255,0), rgba(26,26,26,0))",
+  "--color-background-info": "light-dark(#eff6ff, #1e3a5f)",
+  "--color-background-danger": "light-dark(#fef2f2, #7f1d1d)",
+  "--color-background-success": "light-dark(#f0fdf4, #14532d)",
+  "--color-background-warning": "light-dark(#fefce8, #713f12)",
+  "--color-background-disabled": "light-dark(rgba(255,255,255,0.5), rgba(26,26,26,0.5))",
+  "--color-text-primary": "light-dark(#1f2937, #f3f4f6)",
+  "--color-text-secondary": "light-dark(#6b7280, #9ca3af)",
+  "--color-text-tertiary": "light-dark(#9ca3af, #6b7280)",
+  "--color-text-inverse": "light-dark(#f3f4f6, #1f2937)",
+  "--color-text-ghost": "light-dark(rgba(107,114,128,0.5), rgba(156,163,175,0.5))",
+  "--color-text-info": "light-dark(#1d4ed8, #60a5fa)",
+  "--color-text-danger": "light-dark(#b91c1c, #f87171)",
+  "--color-text-success": "light-dark(#15803d, #4ade80)",
+  "--color-text-warning": "light-dark(#a16207, #fbbf24)",
+  "--color-text-disabled": "light-dark(rgba(31,41,55,0.5), rgba(243,244,246,0.5))",
+  "--color-border-primary": "light-dark(#e5e7eb, #404040)",
+  "--color-border-secondary": "light-dark(#d1d5db, #525252)",
+  "--color-border-tertiary": "light-dark(#f3f4f6, #374151)",
+  "--color-border-inverse": "light-dark(rgba(255,255,255,0.3), rgba(0,0,0,0.3))",
+  "--color-border-ghost": "light-dark(rgba(229,231,235,0), rgba(64,64,64,0))",
+  "--color-border-info": "light-dark(#93c5fd, #1e40af)",
+  "--color-border-danger": "light-dark(#fca5a5, #991b1b)",
+  "--color-border-success": "light-dark(#86efac, #166534)",
+  "--color-border-warning": "light-dark(#fde047, #854d0e)",
+  "--color-border-disabled": "light-dark(rgba(229,231,235,0.5), rgba(64,64,64,0.5))",
+  "--color-ring-primary": "light-dark(#3b82f6, #60a5fa)",
+  "--color-ring-secondary": "light-dark(#6b7280, #9ca3af)",
+  "--color-ring-inverse": "light-dark(#ffffff, #1f2937)",
+  "--color-ring-info": "light-dark(#2563eb, #3b82f6)",
+  "--color-ring-danger": "light-dark(#dc2626, #ef4444)",
+  "--color-ring-success": "light-dark(#16a34a, #22c55e)",
+  "--color-ring-warning": "light-dark(#ca8a04, #eab308)",
+  "--font-sans": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  "--font-mono": "ui-monospace, 'SF Mono', Monaco, 'Cascadia Code', monospace",
+  "--font-weight-normal": "400",
+  "--font-weight-medium": "500",
+  "--font-weight-semibold": "600",
+  "--font-weight-bold": "700",
+  "--font-text-xs-size": "0.75rem",
+  "--font-text-sm-size": "0.875rem",
+  "--font-text-md-size": "1rem",
+  "--font-text-lg-size": "1.125rem",
+  "--font-heading-xs-size": "0.75rem",
+  "--font-heading-sm-size": "0.875rem",
+  "--font-heading-md-size": "1rem",
+  "--font-heading-lg-size": "1.25rem",
+  "--font-heading-xl-size": "1.5rem",
+  "--font-heading-2xl-size": "1.875rem",
+  "--font-heading-3xl-size": "2.25rem",
+  "--font-text-xs-line-height": "1.4",
+  "--font-text-sm-line-height": "1.4",
+  "--font-text-md-line-height": "1.5",
+  "--font-text-lg-line-height": "1.5",
+  "--font-heading-xs-line-height": "1.4",
+  "--font-heading-sm-line-height": "1.4",
+  "--font-heading-md-line-height": "1.4",
+  "--font-heading-lg-line-height": "1.3",
+  "--font-heading-xl-line-height": "1.25",
+  "--font-heading-2xl-line-height": "1.2",
+  "--font-heading-3xl-line-height": "1.1",
+  "--border-radius-xs": "2px",
+  "--border-radius-sm": "4px",
+  "--border-radius-md": "6px",
+  "--border-radius-lg": "8px",
+  "--border-radius-xl": "12px",
+  "--border-radius-full": "9999px",
+  "--border-width-regular": "1px",
+  "--shadow-hairline": "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+  "--shadow-sm": "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)",
+  "--shadow-md": "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
+  "--shadow-lg": "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
+};
+
+/** MCP-standard variable name -> Grackle theme token to read its value from. */
+const GRACKLE_TOKEN_BY_MCP_NAME: Readonly<Record<string, string>> = {
+  "--color-background-primary": "--bg-base",
+  "--color-background-secondary": "--bg-surface",
+  "--color-background-tertiary": "--bg-elevated",
+  "--color-text-primary": "--text-primary",
+  "--color-text-secondary": "--text-secondary",
+  "--color-text-tertiary": "--text-tertiary",
+  "--color-border-primary": "--border-primary",
+  "--color-border-secondary": "--border-subtle",
+  "--font-sans": "--font-sans",
+  "--font-mono": "--font-mono",
+  "--border-radius-sm": "--radius-sm",
+  "--border-radius-md": "--radius-md",
+  "--border-radius-lg": "--radius-lg",
+  "--border-radius-full": "--radius-full",
+};
+
+/**
+ * Build the MCP-standard style-variable map from Grackle's live theme, falling
+ * back to theme-adaptive defaults for any token that cannot be read.
+ *
+ * @returns Style variables suitable for `hostContext.styles.variables`.
+ */
+export function grackleHostStyleVariables(): McpUiStyles {
+  const out: McpUiStyles = { ...DEFAULT_MCP_STYLES };
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return out;
+  }
+  const computed: CSSStyleDeclaration = window.getComputedStyle(document.documentElement);
+  const writable: Record<string, string> = out as Record<string, string>;
+  for (const [mcpName, grackleToken] of Object.entries(GRACKLE_TOKEN_BY_MCP_NAME)) {
+    const value: string = computed.getPropertyValue(grackleToken).trim();
+    if (value) {
+      writable[mcpName] = value;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- Adds `McpAppWidget` to `@grackle-ai/web-components`: a conformant **MCP Apps (SEP-1865) host-render** primitive that renders an untrusted `ui://` widget inside a **double-iframe cross-origin sandbox** and drives it over the `@modelcontextprotocol/ext-apps` `AppBridge` postMessage protocol. The chat pane is not an MCP client, so the bridge is built with `AppBridge(null)` + manual handlers; tool input/result arrive as props.
- Cross-origin sandbox proxy (`sandbox.html`) + sidecar CSP server (`serve.mjs`). The sidecar also serves the **real `ext-apps` `App`** (dependency-inlined `app-with-deps` bundle) plus a thin `sample-widget.js`, so the Storybook demo's handshake is fully spec-conformant (a hand-rolled handshake failed `AppBridge`'s Zod validation).
- `grackleHostStyleVariables`: maps Grackle theme tokens to the MCP-standard CSS variable names so widgets render coherently in the host.
- Storybook story + vitest/jsdom unit tests.

This is **T1** of epic #542 (agents author reusable generative UI). Host-render only — no `packages/mcp` resources, no chat-pane wiring, and no agent-authored widget registry yet (#1237 / #1238 / #1239).

## Screenshots
Storybook `Grackle/Display/McpAppWidget` — the sample widget rendered inside the sandboxed iframe, themed via host style variables:

![McpAppWidget rendered in sandbox](https://gist.githubusercontent.com/nick-pape/74f68a788a0680e6272ffee1c2695714/raw/e5031569ff89fda04b9ee3504fe2c19e0c718961/mcp-widget-pr.svg)

## Test plan
- [x] `rush build` green and warning-free (includes the Storybook build / acorn indexer)
- [x] Storybook (`npm run storybook:mcp`): `ui/initialize -> initialized` handshake completes; tool input (`{"location":"Seattle"}`) and result (`72F and clear`) render; host styles applied; widget -> host `callServerTool` round-trip (Refresh -> `refreshed: 70F`)
- [ ] CI: unit tests + Storybook interaction tests

Closes #1236