### PR TITLE
MCP Apps: MCP server app-side (resources + static widget)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1237-mcp-apps-server_2026-05-22-17-01.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1237-mcp-apps-server_2026-05-22-17-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add an MCP Apps (SEP-1865) app-side layer to @grackle-ai/mcp: resources capability (resources/list + resources/read), io.modelcontextprotocol/ui negotiation, and a static ui:// widget tool. Bump @modelcontextprotocol/sdk to ^1.29 across server packages.",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -440,9 +440,12 @@ importers:
       '@grackle-ai/common':
         specifier: workspace:*
         version: link:../common
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.7.2
+        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -466,8 +469,8 @@ importers:
   ../../packages/mcp-stdio:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*
@@ -724,8 +727,8 @@ importers:
         specifier: workspace:*
         version: link:../runtime-sdk
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -880,8 +883,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.0
-        version: 1.27.1(zod@4.3.6)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -1094,10 +1097,10 @@ importers:
         version: link:../common
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.2
-        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3500,21 +3503,12 @@ packages:
       react-dom:
         optional: true
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
-
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -13695,38 +13689,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       '@standard-schema/spec': 1.1.0
       zod: 4.3.6
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.18
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.29.0':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0

--- a/packages/mcp-stdio/package.json
+++ b/packages/mcp-stdio/package.json
@@ -41,7 +41,7 @@
     "_phase:test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0"
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -254,6 +254,31 @@ Query aggregated token usage and cost data.
 |------|-------------|------------|
 | `usage_get` | Get token usage and cost for a session, task, task tree, workspace, or environment. | `scope` (`session` \| `task` \| `task_tree` \| `workspace` \| `environment`), `id` (string) |
 
+### Widget Tools
+
+[MCP Apps](#mcp-apps-ui-widgets) UI widgets. These tools return data **and** reference a `ui://` HTML resource that capable hosts render inline. They appear in `tools/list` **only** when the connected host advertises the `io.modelcontextprotocol/ui` extension.
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `show_hello_widget` | Display the Grackle hello widget — a minimal interactive MCP Apps UI that echoes the provided message. | `message` (string, optional) |
+
+---
+
+## MCP Apps (UI widgets)
+
+Grackle's MCP server is a conformant **MCP Apps** ([SEP-1865](https://modelcontextprotocol.io/)) provider. Hosts that support MCP Apps can fetch and render interactive HTML widgets inline.
+
+How it works:
+
+- **Capability negotiation** — A host advertises support during `initialize` via the `io.modelcontextprotocol/ui` extension (with `mimeTypes` including `text/html;profile=mcp-app`). The server detects this and only lists [Widget Tools](#widget-tools) to capable hosts; other clients see the data-only tools.
+- **Resources** — The server declares the `resources` capability and implements `resources/list` and `resources/read`. Widget UIs are served as `ui://…` resources with MIME `text/html;profile=mcp-app`.
+- **Tool ↔ resource link** — A widget tool carries `_meta.ui.resourceUri` (and the legacy `_meta["ui/resourceUri"]`) pointing at its `ui://` resource. The host reads the resource and renders it, passing the tool's input and result into the widget.
+- **Widget assets** — The widget's browser scripts are served (unauthenticated, since they are non-sensitive static JS) from `/widgets/<name>/…` on the MCP server's HTTP origin.
+
+> **Note:** the widget's scripts load from the MCP server's origin, so a host whose sandbox CSP forbids cross-origin scripts won't render them. Grackle's own chat-pane host handles this; that integration is tracked separately.
+
+The current built-in widget is `show_hello_widget` (resource `ui://grackle/hello-widget`). Try it with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or Claude Desktop.
+
 ---
 
 ## Scoped Access

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -44,7 +44,8 @@
     "@connectrpc/connect-node": "^2.0.0",
     "@grackle-ai/auth": "workspace:*",
     "@grackle-ai/common": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "pino": "^10.3.1",
     "zod": "^4.0.0"
   },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,6 +3,9 @@ export type { McpServerOptions } from "./mcp-server.js";
 export { createToolRegistry } from "./tools/index.js";
 export { ToolRegistry } from "./tool-registry.js";
 export type { ToolDefinition, ToolResult } from "./tool-registry.js";
+export { createResourceRegistry } from "./resources/index.js";
+export { ResourceRegistry } from "./resource-registry.js";
+export type { ResourceDefinition, ResourceReadResult } from "./resource-registry.js";
 
 // Re-export auth primitives from @grackle-ai/auth for backwards compatibility
 export type { AuthContext, OAuthTokenClaims } from "@grackle-ai/auth";

--- a/packages/mcp/src/mcp-server.test.ts
+++ b/packages/mcp/src/mcp-server.test.ts
@@ -578,3 +578,174 @@ describe("scoped token workspaceId injection", () => {
     expect(capturedArgs[0]!.workspaceId).toBe("ws-odsp");
   });
 });
+
+describe("MCP Apps app-side (#1237)", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => { server!.close(() => resolve()); });
+      server = undefined;
+    }
+  });
+
+  /** Client capabilities advertising the io.modelcontextprotocol/ui extension. */
+  const UI_CAPABILITIES: Record<string, unknown> = {
+    extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+  };
+  const HELLO_URI: string = "ui://grackle/hello-widget";
+
+  interface JsonRpcResponse {
+    result?: Record<string, unknown>;
+    error?: { code: number; message: string };
+  }
+
+  /** Parse the first SSE `data:` line of an MCP response (or the raw JSON body). */
+  function parseResponse(raw: string): JsonRpcResponse {
+    const dataLine = raw.split("\n").find((l) => l.startsWith("data:"));
+    const json = dataLine ? dataLine.slice("data:".length).trim() : raw.trim();
+    return JSON.parse(json) as JsonRpcResponse;
+  }
+
+  /** Initialize with explicit capabilities; returns the session id + parsed result. */
+  function initializeWith(
+    srv: http.Server,
+    capabilities: Record<string, unknown>,
+  ): Promise<{ sessionId: string; response: JsonRpcResponse }> {
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-03-26", capabilities, clientInfo: { name: "test-client", version: "1.0.0" } },
+      });
+      const req = http.request(
+        { hostname: "127.0.0.1", port: port(srv), path: "/mcp", method: "POST", headers: postHeaders() },
+        (res) => {
+          const sessionId = res.headers["mcp-session-id"] as string | undefined;
+          let raw = "";
+          res.on("data", (chunk: Buffer) => { raw += chunk.toString(); });
+          res.on("end", () => {
+            if (!sessionId) { reject(new Error("No session ID in initialize response")); return; }
+            resolve({ sessionId, response: parseResponse(raw) });
+          });
+        },
+      );
+      req.on("error", reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  /** Send a JSON-RPC request to an existing session and parse the SSE result. */
+  function rpc(
+    srv: http.Server,
+    sessionId: string,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<JsonRpcResponse> {
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify({ jsonrpc: "2.0", id: 7, method, params });
+      const req = http.request(
+        { hostname: "127.0.0.1", port: port(srv), path: "/mcp", method: "POST", headers: postHeaders(sessionId) },
+        (res) => {
+          let raw = "";
+          res.on("data", (chunk: Buffer) => { raw += chunk.toString(); });
+          res.on("end", () => {
+            try { resolve(parseResponse(raw)); } catch (e) { reject(e as Error); }
+          });
+        },
+      );
+      req.on("error", reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  /** GET a static asset (no auth). */
+  function getAsset(
+    srv: http.Server,
+    path: string,
+  ): Promise<{ status: number; contentType: string; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        { hostname: "127.0.0.1", port: port(srv), path, method: "GET" },
+        (res) => {
+          let raw = "";
+          res.on("data", (chunk: Buffer) => { raw += chunk.toString(); });
+          res.on("end", () => resolve({
+            status: res.statusCode!,
+            contentType: String(res.headers["content-type"] ?? ""),
+            body: raw,
+          }));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("advertises the resources capability on initialize", async () => {
+    server = await startServer();
+    const { response } = await initializeWith(server, {});
+    const capabilities = (response.result?.capabilities ?? {}) as Record<string, unknown>;
+    expect(capabilities.resources).toBeDefined();
+  });
+
+  it("lists the hello widget resource with the MCP App MIME type", async () => {
+    server = await startServer();
+    const { sessionId } = await initializeWith(server, UI_CAPABILITIES);
+    const response = await rpc(server, sessionId, "resources/list", {});
+    const resources = (response.result?.resources ?? []) as Array<{ uri: string; mimeType: string }>;
+    const widget = resources.find((r) => r.uri === HELLO_URI);
+    expect(widget).toBeDefined();
+    expect(widget!.mimeType).toBe("text/html;profile=mcp-app");
+  });
+
+  it("reads the hello widget resource HTML", async () => {
+    server = await startServer();
+    const { sessionId } = await initializeWith(server, UI_CAPABILITIES);
+    const response = await rpc(server, sessionId, "resources/read", { uri: HELLO_URI });
+    const contents = (response.result?.contents ?? []) as Array<{ text: string; mimeType: string }>;
+    expect(contents[0]?.mimeType).toBe("text/html;profile=mcp-app");
+    expect(contents[0]?.text).toContain('id="result"');
+  });
+
+  it("returns a JSON-RPC error for an unknown resource uri", async () => {
+    server = await startServer();
+    const { sessionId } = await initializeWith(server, UI_CAPABILITIES);
+    const response = await rpc(server, sessionId, "resources/read", { uri: "ui://grackle/missing" });
+    expect(response.error).toBeDefined();
+  });
+
+  it("lists the widget tool with dual-key _meta only to UI-capable hosts", async () => {
+    server = await startServer();
+    const { sessionId } = await initializeWith(server, UI_CAPABILITIES);
+    const response = await rpc(server, sessionId, "tools/list", {});
+    const tools = (response.result?.tools ?? []) as Array<{
+      name: string;
+      _meta?: { ui?: { resourceUri?: string }; "ui/resourceUri"?: string };
+    }>;
+    const widget = tools.find((t) => t.name === "show_hello_widget");
+    expect(widget).toBeDefined();
+    expect(widget!._meta?.ui?.resourceUri).toBe(HELLO_URI);
+    expect(widget!._meta?.["ui/resourceUri"]).toBe(HELLO_URI);
+  });
+
+  it("hides the widget tool from non-UI hosts but keeps data tools", async () => {
+    server = await startServer();
+    const { sessionId } = await initializeWith(server, {});
+    const response = await rpc(server, sessionId, "tools/list", {});
+    const names = ((response.result?.tools ?? []) as Array<{ name: string }>).map((t) => t.name);
+    expect(names).not.toContain("show_hello_widget");
+    expect(names).toContain("get_version_status");
+  });
+
+  it("serves the widget JS assets without auth", async () => {
+    server = await startServer();
+    const asset = await getAsset(server, "/widgets/hello/index.js");
+    expect(asset.status).toBe(200);
+    expect(asset.contentType).toContain("javascript");
+    expect(asset.body).toContain("app-with-deps.js");
+  });
+});

--- a/packages/mcp/src/mcp-server.test.ts
+++ b/packages/mcp/src/mcp-server.test.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 import { createScopedToken } from "@grackle-ai/auth";
 import { ROOT_TASK_ID } from "@grackle-ai/common";
 import type { ToolDefinition } from "./tool-registry.js";
-import { createMcpServer } from "./mcp-server.js";
+import { createMcpServer, resolveAssetBaseUrl } from "./mcp-server.js";
 
 // API key must be exactly 64 hex characters (API_KEY_LENGTH in auth-middleware)
 const TEST_API_KEY = "a".repeat(64);
@@ -747,5 +747,32 @@ describe("MCP Apps app-side (#1237)", () => {
     expect(asset.status).toBe(200);
     expect(asset.contentType).toContain("javascript");
     expect(asset.body).toContain("app-with-deps.js");
+  });
+});
+
+describe("resolveAssetBaseUrl", () => {
+  it("defaults to http for a plain host", () => {
+    expect(resolveAssetBaseUrl("127.0.0.1:7435", undefined, false)).toBe("http://127.0.0.1:7435");
+  });
+
+  it("uses https when the connection is TLS-encrypted", () => {
+    expect(resolveAssetBaseUrl("example.com", undefined, true)).toBe("https://example.com");
+  });
+
+  it("honors X-Forwarded-Proto (including comma lists and arrays)", () => {
+    expect(resolveAssetBaseUrl("example.com", "https", false)).toBe("https://example.com");
+    expect(resolveAssetBaseUrl("example.com", "https, http", false)).toBe("https://example.com");
+    expect(resolveAssetBaseUrl("example.com", ["https"], false)).toBe("https://example.com");
+  });
+
+  it("falls back to http://localhost when the host is missing", () => {
+    expect(resolveAssetBaseUrl(undefined, undefined, false)).toBe("http://localhost");
+  });
+
+  it("normalizes a hostile Host header so no markup can be injected", () => {
+    const result = resolveAssetBaseUrl('evil.com" onload="alert(1)', undefined, false);
+    expect(result).not.toContain('"');
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(" ");
   });
 });

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -11,8 +11,13 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
   isInitializeRequest,
+  McpError,
+  ErrorCode,
   type CallToolResult,
+  type ReadResourceResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import pino, { type Logger } from "pino";
 import { z } from "zod";
@@ -22,6 +27,9 @@ import { grpcErrorToToolResult } from "./error-handler.js";
 import type { ToolDefinition, GrackleClients } from "./tool-registry.js";
 import { createToolRegistry } from "./tools/index.js";
 import { resolveToolForAuth, listToolsForAuth } from "./tool-scoping.js";
+import { createResourceRegistry } from "./resources/index.js";
+import { hostSupportsUiApps, uiToolMeta } from "./ui-app.js";
+import { tryServeWidgetAsset } from "./widget-asset-server.js";
 
 /** Read the package version from package.json at module load time. */
 const PACKAGE_VERSION: string = (JSON.parse(
@@ -110,9 +118,11 @@ async function resolvePersonaTools(
 async function createMcpServerInstance(
   grpcClients: GrackleClients,
   authContext: AuthContext,
+  assetBaseUrl: string,
   toolGroups?: ToolDefinition[][],
 ): Promise<Server> {
   const registry = createToolRegistry(toolGroups);
+  const resourceRegistry = createResourceRegistry(assetBaseUrl);
 
   // Resolve persona-scoped tool set once at session creation (cached for session lifetime)
   const personaAllowedTools = await resolvePersonaTools(grpcClients, authContext);
@@ -126,20 +136,61 @@ async function createMcpServerInstance(
 
   const server = new Server(
     { name: "grackle-mcp", version: PACKAGE_VERSION },
-    { capabilities: { tools: {} } },
+    { capabilities: { tools: {}, resources: {} } },
   );
 
-  // Pre-compute the visible tool list and names (immutable for this session)
+  // Pre-compute the visible tool list and names (immutable for this session).
+  // UI (MCP Apps) tools carry _meta.ui.resourceUri so a host knows which ui://
+  // resource to render.
   const visibleToolDefs = visibleTools.map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: z.toJSONSchema(t.inputSchema),
     annotations: t.annotations,
+    ...(t.uiResourceUri ? { _meta: uiToolMeta(t.uiResourceUri) } : {}),
   }));
   const visibleToolNames = visibleTools.map((t) => t.name).join(", ");
+  /** Names of UI tools — only listed to hosts that can render MCP Apps widgets. */
+  const uiToolNames = new Set(visibleTools.filter((t) => t.uiResourceUri).map((t) => t.name));
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: visibleToolDefs };
+    // Gate widget tools on the host advertising the io.modelcontextprotocol/ui
+    // extension (known only after initialize). Non-UI hosts see the rest.
+    const uiOn = hostSupportsUiApps(server.getClientCapabilities());
+    const tools = uiOn ? visibleToolDefs : visibleToolDefs.filter((t) => !uiToolNames.has(t.name));
+    return { tools };
+  });
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    return {
+      resources: resourceRegistry.list().map((r) => ({
+        uri: r.uri,
+        name: r.name,
+        ...(r.description ? { description: r.description } : {}),
+        mimeType: r.mimeType,
+        ...(r.meta ? { _meta: r.meta } : {}),
+      })),
+    };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request): Promise<ReadResourceResult> => {
+    // Resources are session-global and unscoped in #1237 (a widget shell is not
+    // sensitive). Per-session / auth-scoped resources are #1239.
+    const resource = resourceRegistry.get(request.params.uri);
+    if (!resource) {
+      throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${request.params.uri}`);
+    }
+    const { text } = resource.read();
+    return {
+      contents: [
+        {
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          text,
+          ...(resource.meta ? { _meta: resource.meta } : {}),
+        },
+      ],
+    };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
@@ -314,6 +365,13 @@ export function createMcpServer(options: McpServerOptions): http.Server {
       return;
     }
 
+    // Serve the built-in widget's browser assets (static JS) before the /mcp
+    // routing + auth check — an MCP Apps host sandbox fetches these without the
+    // API key. They are non-sensitive (the widget shell + the ext-apps App).
+    if (req.method?.toUpperCase() === "GET" && tryServeWidgetAsset(url.pathname, res)) {
+      return;
+    }
+
     // Only serve the /mcp endpoint
     if (url.pathname !== "/mcp") {
       res.writeHead(404, { "Content-Type": "application/json" });
@@ -429,7 +487,10 @@ async function handlePost(
         }
       };
 
-      const mcpServer = await createMcpServerInstance(grpcClients, authContext, toolGroups);
+      // Asset base URL is derived from the request Host header so the widget
+      // HTML references assets at the origin the client actually reached us on.
+      const assetBaseUrl = `http://${req.headers.host || "localhost"}`;
+      const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, toolGroups);
       await mcpServer.connect(transport);
       await transport.handleRequest(req, res, body);
       return;

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -438,6 +438,30 @@ async function parseBody(req: http.IncomingMessage): Promise<unknown> {
   });
 }
 
+/**
+ * Resolve the public origin the client reached us on, for embedding into widget
+ * asset URLs. Honors `X-Forwarded-Proto` (reverse proxies) and TLS for the
+ * scheme, and normalizes the Host header through `URL` so a hostile value cannot
+ * inject markup when interpolated into the widget HTML's `<script src>`.
+ *
+ * @returns A clean `scheme://host[:port]` origin, or `http://localhost` if the
+ *   Host header is missing or unparseable.
+ */
+export function resolveAssetBaseUrl(
+  hostHeader: string | undefined,
+  forwardedProto: string | string[] | undefined,
+  encrypted: boolean,
+): string {
+  const rawProto: string | undefined = Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto;
+  const proto: string | undefined = rawProto?.split(",")[0]?.trim();
+  const scheme: string = proto && proto.length > 0 ? proto : encrypted ? "https" : "http";
+  try {
+    return new URL(`${scheme}://${hostHeader ?? "localhost"}`).origin;
+  } catch {
+    return "http://localhost";
+  }
+}
+
 /** Handle POST requests to /mcp — initialization or tool calls. */
 async function handlePost(
   req: http.IncomingMessage,
@@ -487,9 +511,11 @@ async function handlePost(
         }
       };
 
-      // Asset base URL is derived from the request Host header so the widget
-      // HTML references assets at the origin the client actually reached us on.
-      const assetBaseUrl = `http://${req.headers.host || "localhost"}`;
+      // Asset base URL is the origin the client actually reached us on, so the
+      // widget HTML references assets correctly. Normalized via URL parsing to
+      // avoid attribute injection from a hostile Host header.
+      const encrypted = "encrypted" in req.socket && (req.socket as { encrypted?: boolean }).encrypted === true;
+      const assetBaseUrl = resolveAssetBaseUrl(req.headers.host, req.headers["x-forwarded-proto"], encrypted);
       const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, toolGroups);
       await mcpServer.connect(transport);
       await transport.handleRequest(req, res, body);

--- a/packages/mcp/src/resource-registry.test.ts
+++ b/packages/mcp/src/resource-registry.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest";
+import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
+import { ResourceRegistry, type ResourceDefinition } from "./resource-registry.js";
+import { createResourceRegistry } from "./resources/index.js";
+import { HELLO_WIDGET_URI, WIDGET_ASSET_BASE_PATH } from "./resources/hello-widget.js";
+
+const def = (uri: string): ResourceDefinition => ({
+  uri,
+  name: uri,
+  mimeType: "text/plain",
+  read: () => ({ text: "body" }),
+});
+
+describe("ResourceRegistry", () => {
+  test("register / get / list", () => {
+    const reg = new ResourceRegistry();
+    reg.register(def("ui://a"));
+    reg.register(def("ui://b"));
+    expect(reg.get("ui://a")?.uri).toBe("ui://a");
+    expect(reg.list().map((r) => r.uri)).toEqual(["ui://a", "ui://b"]);
+  });
+
+  test("duplicate uri throws", () => {
+    const reg = new ResourceRegistry();
+    reg.register(def("ui://a"));
+    expect(() => reg.register(def("ui://a"))).toThrow(/Duplicate resource uri/);
+  });
+
+  test("unknown uri returns undefined", () => {
+    expect(new ResourceRegistry().get("ui://missing")).toBeUndefined();
+  });
+});
+
+describe("createResourceRegistry", () => {
+  const baseUrl = "http://127.0.0.1:7435";
+  const reg = createResourceRegistry(baseUrl);
+
+  test("registers exactly the hello widget with the MCP App MIME type", () => {
+    const all = reg.list();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.uri).toBe(HELLO_WIDGET_URI);
+    expect(all[0]!.mimeType).toBe(RESOURCE_MIME_TYPE);
+  });
+
+  test("read() returns HTML referencing the asset script at the base URL", () => {
+    const html = reg.get(HELLO_WIDGET_URI)!.read().text;
+    expect(html).toContain('id="input"');
+    expect(html).toContain('id="result"');
+    expect(html).toContain(`${baseUrl}${WIDGET_ASSET_BASE_PATH}/index.js`);
+  });
+});

--- a/packages/mcp/src/resource-registry.ts
+++ b/packages/mcp/src/resource-registry.ts
@@ -1,0 +1,60 @@
+/** Content returned when an MCP resource is read. */
+export interface ResourceReadResult {
+  /** UTF-8 text body of the resource. */
+  text: string;
+}
+
+/**
+ * Declarative definition of an MCP resource served by the Grackle MCP server.
+ *
+ * `read` is a function (not a static string) so a later phase (#1239) can serve
+ * dynamic / per-session / agent-authored content without changing this shape.
+ */
+export interface ResourceDefinition {
+  /** Resource URI, e.g. `ui://grackle/hello-widget`. */
+  uri: string;
+  /** Human-readable name. */
+  name: string;
+  /** Optional description shown in `resources/list`. */
+  description?: string;
+  /** MIME type (e.g. `text/html;profile=mcp-app` for MCP Apps widgets). */
+  mimeType: string;
+  /** Optional `_meta` (e.g. MCP Apps `McpUiResourceMeta`); omitted in #1237. */
+  meta?: Record<string, unknown>;
+  /** Produce the resource body. */
+  read: () => ResourceReadResult;
+}
+
+/**
+ * Registry of MCP resource definitions with lookup support — mirrors
+ * {@link ToolRegistry}. Static (register-at-startup) in #1237; the mutable /
+ * per-session registry for agent-authored widgets is #1239.
+ */
+export class ResourceRegistry {
+  private readonly resources: Map<string, ResourceDefinition> = new Map();
+
+  /** Register a resource. Throws if a resource with the same URI already exists. */
+  public register(resource: ResourceDefinition): void {
+    if (this.resources.has(resource.uri)) {
+      throw new Error(`Duplicate resource uri: ${resource.uri}`);
+    }
+    this.resources.set(resource.uri, resource);
+  }
+
+  /** Register an array of resource definitions. */
+  public registerAll(resources: ResourceDefinition[]): void {
+    for (const resource of resources) {
+      this.register(resource);
+    }
+  }
+
+  /** Return all registered resources. */
+  public list(): ResourceDefinition[] {
+    return Array.from(this.resources.values());
+  }
+
+  /** Look up a resource by URI. Returns undefined if not found. */
+  public get(uri: string): ResourceDefinition | undefined {
+    return this.resources.get(uri);
+  }
+}

--- a/packages/mcp/src/resources/hello-widget.ts
+++ b/packages/mcp/src/resources/hello-widget.ts
@@ -1,0 +1,82 @@
+import { RESOURCE_MIME_TYPE } from "../ui-app.js";
+import type { ResourceDefinition } from "../resource-registry.js";
+
+/** URI of the built-in hello widget resource. Single source of truth. */
+export const HELLO_WIDGET_URI: string = "ui://grackle/hello-widget";
+
+/**
+ * Path prefix under which the MCP server serves this widget's browser assets
+ * (`/index.js` + `/app-with-deps.js`). Used both by the server's static router
+ * and by the widget HTML's `<script src>`.
+ */
+export const WIDGET_ASSET_BASE_PATH: string = "/widgets/hello";
+
+/**
+ * App-side ES module for the hello widget, served at
+ * `<base>${WIDGET_ASSET_BASE_PATH}/index.js`. Uses the REAL ext-apps `App`
+ * (imported from the sibling `app-with-deps.js` the server also serves) for a
+ * spec-conformant `ui/initialize` -> `initialized` -> tool-input/result
+ * handshake. Ported from the T1 Storybook sample widget (#1236). Kept as a
+ * string so it ships in `dist` without a heft asset-copy step.
+ */
+export const HELLO_WIDGET_CLIENT_JS: string = [
+  'import { App, PostMessageTransport, applyHostStyleVariables, applyHostFonts, applyDocumentTheme } from "./app-with-deps.js";',
+  'const inputEl = document.getElementById("input");',
+  'const resultEl = document.getElementById("result");',
+  "function renderResult(content) {",
+  "  const blocks = content || [];",
+  '  resultEl.textContent = blocks.map(function (b) { return b.type === "text" ? b.text : "<" + b.type + ">"; }).join(" ") || "(empty)";',
+  "}",
+  'const app = new App({ name: "GrackleHelloWidget", version: "1.0.0" }, {});',
+  "app.ontoolinput = function (params) { inputEl.textContent = JSON.stringify((params && params.arguments) || {}); };",
+  "app.ontoolresult = function (params) { renderResult(params && params.content); };",
+  "function applyHostStyles() {",
+  "  const ctx = app.getHostContext();",
+  "  if (ctx && ctx.styles && ctx.styles.variables) { applyHostStyleVariables(ctx.styles.variables); }",
+  "  if (ctx && ctx.styles && ctx.styles.css && ctx.styles.css.fonts) { applyHostFonts(ctx.styles.css.fonts); }",
+  "  if (ctx && ctx.theme) { applyDocumentTheme(ctx.theme); }",
+  "}",
+  "app.onhostcontextchanged = function () { applyHostStyles(); };",
+  "await app.connect(new PostMessageTransport(window.parent, window.parent));",
+  "applyHostStyles();",
+  "",
+].join("\n");
+
+/** Build the widget HTML document, pointing its script at the asset base URL. */
+function helloWidgetHtml(assetBaseUrl: string): string {
+  const src: string = `${assetBaseUrl}${WIDGET_ASSET_BASE_PATH}/index.js`;
+  return [
+    '<!doctype html><html><head><meta charset="utf-8" /><meta name="color-scheme" content="light dark" /><style>',
+    "body{margin:0;font-family:var(--font-sans,sans-serif);color:var(--color-text-primary,#111);",
+    "background:var(--color-background-secondary,#f5f5f5);padding:16px}",
+    ".card{background:var(--color-background-primary,#fff);border:1px solid var(--color-border-primary,#ddd);",
+    "border-radius:var(--border-radius-md,6px);padding:16px}",
+    "code{font-family:var(--font-mono,monospace)}",
+    '</style></head><body><div class="card">',
+    "<h2>Grackle</h2>",
+    '<div>Input: <code id="input">(none)</code></div>',
+    '<div>Result: <code id="result">(pending)</code></div>',
+    "</div>",
+    `<script type="module" src="${src}"></script>`,
+    "</body></html>",
+  ].join("");
+}
+
+/**
+ * Build the built-in hello widget resource. The widget's browser assets are
+ * loaded from `assetBaseUrl` (the MCP server's own public origin), so the host
+ * sandbox must be allowed to load cross-origin scripts from it — that host-CSP /
+ * cross-origin concern is out of scope for #1237 (handled for Grackle's own host
+ * in #1238).
+ *
+ * @param assetBaseUrl - Public origin of the MCP server, e.g. `http://127.0.0.1:7435`.
+ */
+export function createHelloWidgetResource(assetBaseUrl: string): ResourceDefinition {
+  return {
+    uri: HELLO_WIDGET_URI,
+    name: "Grackle Hello Widget",
+    description: "A minimal MCP Apps widget that displays the tool input and result.",
+    mimeType: RESOURCE_MIME_TYPE,
+    read: () => ({ text: helloWidgetHtml(assetBaseUrl) }),
+  };
+}

--- a/packages/mcp/src/resources/index.ts
+++ b/packages/mcp/src/resources/index.ts
@@ -1,0 +1,15 @@
+import { ResourceRegistry, type ResourceDefinition } from "../resource-registry.js";
+import { createHelloWidgetResource } from "./hello-widget.js";
+
+/**
+ * Create a ResourceRegistry pre-populated with the built-in MCP Apps resources.
+ *
+ * @param assetBaseUrl - Public origin of the MCP server (e.g. `http://127.0.0.1:7435`),
+ *   embedded into widget HTML so hosts can load the widget's browser assets.
+ */
+export function createResourceRegistry(assetBaseUrl: string): ResourceRegistry {
+  const registry = new ResourceRegistry();
+  const builtinResources: ResourceDefinition[] = [createHelloWidgetResource(assetBaseUrl)];
+  registry.registerAll(builtinResources);
+  return registry;
+}

--- a/packages/mcp/src/tool-registry.test.ts
+++ b/packages/mcp/src/tool-registry.test.ts
@@ -155,7 +155,7 @@ describe("createToolRegistry with plugin tools", () => {
 describe("Full tool registry", () => {
   it("contains exactly the expected number of tools", () => {
     const registry = createToolRegistry();
-    expect(registry.list()).toHaveLength(68);
+    expect(registry.list()).toHaveLength(69);
   });
 
   it("every tool name matches snake_case pattern", () => {
@@ -211,7 +211,7 @@ describe("Full tool registry", () => {
   it("groups are consistent within tool files", () => {
     const registry = createToolRegistry();
     const expectedGroups = new Set([
-      "env", "session", "workspace", "task", "finding", "persona", "logs", "credential", "token", "config", "ipc", "usage", "knowledge", "workpad", "schedule", "system", "escalation",
+      "env", "session", "workspace", "task", "finding", "persona", "logs", "credential", "token", "config", "ipc", "usage", "knowledge", "workpad", "schedule", "system", "escalation", "widget",
     ]);
     for (const tool of registry.list()) {
       expect(expectedGroups.has(tool.group), `unexpected group: ${tool.group}`).toBe(true);

--- a/packages/mcp/src/tool-registry.ts
+++ b/packages/mcp/src/tool-registry.ts
@@ -52,6 +52,12 @@ export interface ToolDefinition {
   mutating: boolean;
   /** Optional behavioral hints for the client. */
   annotations?: ToolAnnotations;
+  /**
+   * Optional MCP Apps UI resource (`ui://…`) this tool renders. When set, the
+   * tool carries `_meta.ui.resourceUri` in `tools/list` and is only listed to
+   * hosts that advertise the `io.modelcontextprotocol/ui` extension.
+   */
+  uiResourceUri?: string;
   /** Execute the tool, forwarding to the ConnectRPC backend. */
   handler: (args: Record<string, unknown>, clients: GrackleClients, authContext?: AuthContext) => Promise<ToolResult>;
 }

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -16,6 +16,7 @@ import { scheduleTools } from "./schedule.js";
 import { versionTools } from "./version.js";
 import { escalationTools } from "./escalation.js";
 import { pluginTools } from "./plugin.js";
+import { widgetTools } from "./widget.js";
 
 /** Built-in tool groups shipped with the MCP package. */
 const builtinToolGroups: ToolDefinition[][] = [
@@ -36,6 +37,7 @@ const builtinToolGroups: ToolDefinition[][] = [
   versionTools,
   escalationTools,
   pluginTools,
+  widgetTools,
 ];
 
 /**

--- a/packages/mcp/src/tools/widget.test.ts
+++ b/packages/mcp/src/tools/widget.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "vitest";
+import { widgetTools } from "./widget.js";
+import { HELLO_WIDGET_URI } from "../resources/hello-widget.js";
+import type { GrackleClients } from "../tool-registry.js";
+
+const tool = widgetTools.find((t) => t.name === "show_hello_widget")!;
+const noClients = {} as GrackleClients;
+
+describe("show_hello_widget", () => {
+  test("definition ties to the hello widget resource and is read-only", () => {
+    expect(tool.uiResourceUri).toBe(HELLO_WIDGET_URI);
+    expect(tool.group).toBe("widget");
+    expect(tool.mutating).toBe(false);
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  test("echoes the provided message", async () => {
+    const result = await tool.handler({ message: "hi there" }, noClients);
+    const parsed = JSON.parse(result.content[0]!.text) as { message: string; renderedAt: string };
+    expect(parsed.message).toBe("hi there");
+    expect(typeof parsed.renderedAt).toBe("string");
+  });
+
+  test("defaults the message when omitted", async () => {
+    const result = await tool.handler({}, noClients);
+    const parsed = JSON.parse(result.content[0]!.text) as { message: string };
+    expect(parsed.message).toBe("Hello from Grackle");
+  });
+});

--- a/packages/mcp/src/tools/widget.ts
+++ b/packages/mcp/src/tools/widget.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool-registry.js";
+import { jsonResult } from "../result-helpers.js";
+import { HELLO_WIDGET_URI } from "../resources/hello-widget.js";
+
+/**
+ * MCP Apps widget tools. The `uiResourceUri` ties each tool to a `ui://` HTML
+ * resource the host renders; these tools are only listed to hosts that advertise
+ * the `io.modelcontextprotocol/ui` extension (see `mcp-server.ts` gating).
+ */
+export const widgetTools: ToolDefinition[] = [
+  {
+    name: "show_hello_widget",
+    group: "widget",
+    description:
+      "Display the Grackle hello widget — a minimal interactive MCP Apps UI that echoes the provided message. Renders inline in hosts that support MCP Apps.",
+    inputSchema: z.object({
+      message: z.string().optional().describe("Message to echo back in the widget."),
+    }),
+    rpcMethod: "showHelloWidget",
+    mutating: false,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    uiResourceUri: HELLO_WIDGET_URI,
+    async handler(args: Record<string, unknown>) {
+      const message: string = typeof args.message === "string" ? args.message : "Hello from Grackle";
+      return jsonResult({ message, renderedAt: new Date().toISOString() });
+    },
+  },
+];

--- a/packages/mcp/src/ui-app.test.ts
+++ b/packages/mcp/src/ui-app.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "vitest";
+import { EXTENSION_ID, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
+import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
+import { uiToolMeta, hostSupportsUiApps } from "./ui-app.js";
+
+describe("uiToolMeta", () => {
+  test("populates both the modern and legacy resource-uri keys", () => {
+    const meta = uiToolMeta("ui://grackle/hello-widget");
+    expect(meta).toMatchObject({
+      ui: { resourceUri: "ui://grackle/hello-widget" },
+      "ui/resourceUri": "ui://grackle/hello-widget",
+    });
+    // No visibility key when not provided.
+    expect((meta.ui as Record<string, unknown>).visibility).toBeUndefined();
+  });
+
+  test("includes visibility when provided", () => {
+    const meta = uiToolMeta("ui://grackle/x", ["model", "app"]);
+    expect(meta.ui).toEqual({ resourceUri: "ui://grackle/x", visibility: ["model", "app"] });
+  });
+});
+
+describe("hostSupportsUiApps", () => {
+  const withUi = (mimeTypes?: string[]): ClientCapabilities =>
+    ({ extensions: { [EXTENSION_ID]: mimeTypes ? { mimeTypes } : {} } }) as ClientCapabilities;
+
+  test("false when capabilities are undefined", () => {
+    expect(hostSupportsUiApps(undefined)).toBe(false);
+  });
+
+  test("false when the host advertises no extensions", () => {
+    expect(hostSupportsUiApps({} as ClientCapabilities)).toBe(false);
+  });
+
+  test("false when the ui extension lacks the MCP App MIME type", () => {
+    expect(hostSupportsUiApps(withUi())).toBe(false);
+    expect(hostSupportsUiApps(withUi(["text/plain"]))).toBe(false);
+  });
+
+  test("true when the host advertises the ui extension with the MCP App MIME type", () => {
+    expect(hostSupportsUiApps(withUi([RESOURCE_MIME_TYPE]))).toBe(true);
+  });
+});

--- a/packages/mcp/src/ui-app.ts
+++ b/packages/mcp/src/ui-app.ts
@@ -1,0 +1,56 @@
+import {
+  EXTENSION_ID,
+  RESOURCE_MIME_TYPE,
+  RESOURCE_URI_META_KEY,
+  getUiCapability,
+} from "@modelcontextprotocol/ext-apps/server";
+import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * MCP Apps "app-side" helpers for Grackle's low-level MCP {@link Server}.
+ *
+ * The ext-apps `registerAppTool`/`registerAppResource` helpers require the
+ * high-level `McpServer`, which Grackle does not use, so we replicate their tiny
+ * `_meta` normalization here while still importing the spec constants/helper from
+ * `@modelcontextprotocol/ext-apps/server` (single source of truth — no copied
+ * string literals). See SEP-1865 (MCP Apps).
+ */
+
+/** Visibility of a UI tool, per the MCP Apps spec (`McpUiToolVisibility`). */
+export type UiToolVisibility = "model" | "app";
+
+/** Re-exported so callers tag UI resources with the MCP Apps MIME type. */
+export { RESOURCE_MIME_TYPE, EXTENSION_ID };
+
+/**
+ * Build a tool's `_meta` for MCP Apps, populating BOTH the modern nested key
+ * (`_meta.ui.resourceUri`) and the legacy flat key (`_meta["ui/resourceUri"]`)
+ * for host backwards-compatibility — mirroring ext-apps `registerAppTool`.
+ *
+ * @param resourceUri - The `ui://` resource the host should render for this tool.
+ * @param visibility - Optional audience(s) the widget targets (`model`/`app`).
+ * @returns A `_meta` object to attach to the tool's `tools/list` entry.
+ */
+export function uiToolMeta(
+  resourceUri: string,
+  visibility?: UiToolVisibility[],
+): Record<string, unknown> {
+  return {
+    ui: { resourceUri, ...(visibility ? { visibility } : {}) },
+    [RESOURCE_URI_META_KEY]: resourceUri,
+  };
+}
+
+/**
+ * Whether the connected host can render MCP Apps widgets — i.e. it advertised the
+ * `io.modelcontextprotocol/ui` extension during `initialize` with the MCP App
+ * HTML MIME in its supported `mimeTypes`. Use the SDK's
+ * `Server.getClientCapabilities()` (available after the handshake) as the input.
+ *
+ * @param capabilities - The negotiated client capabilities, or `undefined`.
+ * @returns `true` only when the host can render `text/html;profile=mcp-app`.
+ */
+export function hostSupportsUiApps(capabilities: ClientCapabilities | undefined): boolean {
+  const ui = getUiCapability(capabilities) as { mimeTypes?: string[] } | undefined;
+  return Boolean(ui?.mimeTypes?.includes(RESOURCE_MIME_TYPE));
+}

--- a/packages/mcp/src/widget-asset-server.ts
+++ b/packages/mcp/src/widget-asset-server.ts
@@ -1,0 +1,46 @@
+import type http from "node:http";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { WIDGET_ASSET_BASE_PATH, HELLO_WIDGET_CLIENT_JS } from "./resources/hello-widget.js";
+
+const nodeRequire: NodeRequire = createRequire(import.meta.url);
+
+/** Lazily-resolved, cached ext-apps app-side bundle (the real `App`, deps inlined). */
+let appWithDepsBundle: string | undefined;
+
+/** Resolve + read the ext-apps `app-with-deps` browser bundle from node_modules, once. */
+function readAppWithDeps(): string {
+  if (appWithDepsBundle === undefined) {
+    const bundlePath: string = nodeRequire.resolve("@modelcontextprotocol/ext-apps/app-with-deps");
+    appWithDepsBundle = readFileSync(bundlePath, "utf8");
+  }
+  return appWithDepsBundle;
+}
+
+/** Headers for the served JS modules. CORS-open: hosts fetch these into their sandbox. */
+const JS_HEADERS: Readonly<Record<string, string>> = {
+  "Content-Type": "text/javascript; charset=utf-8",
+  "Cache-Control": "no-cache",
+  "Access-Control-Allow-Origin": "*",
+};
+
+/**
+ * Serve the built-in widget's browser assets (the app-side module + the ext-apps
+ * `App` bundle it imports). These are static, non-sensitive JS that an MCP Apps
+ * host fetches into its sandbox iframe, so they are served WITHOUT auth.
+ *
+ * @returns `true` if the path matched a widget asset and a response was written.
+ */
+export function tryServeWidgetAsset(pathname: string, res: http.ServerResponse): boolean {
+  if (pathname === `${WIDGET_ASSET_BASE_PATH}/index.js`) {
+    res.writeHead(200, JS_HEADERS);
+    res.end(HELLO_WIDGET_CLIENT_JS);
+    return true;
+  }
+  if (pathname === `${WIDGET_ASSET_BASE_PATH}/app-with-deps.js`) {
+    res.writeHead(200, JS_HEADERS);
+    res.end(readAppWithDeps());
+    return true;
+  }
+  return false;
+}

--- a/packages/powerline/package.json
+++ b/packages/powerline/package.json
@@ -39,7 +39,7 @@
     "_phase:test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@bufbuild/protobuf": "^2.5.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",

--- a/packages/runtime-sdk/package.json
+++ b/packages/runtime-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@grackle-ai/common": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "pino": "^10.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
**T2 of epic #542.** Gives Grackle's MCP server an MCP Apps (SEP-1865) **app-side** layer so any MCP Apps host can discover, fetch, and render a built-in widget.

- Declares the `resources` capability + `resources/list`/`resources/read` (new static `ResourceRegistry`), and registers `show_hello_widget` whose `_meta.ui.resourceUri` (modern + legacy keys) points at `ui://grackle/hello-widget`.
- Negotiates the `io.modelcontextprotocol/ui` host extension via `getUiCapability` and **gates** widget tools — only listed to UI-capable hosts; plain LLM clients see the data tools unchanged.
- The widget reuses T1's real `ext-apps` `App` for a conformant `ui/initialize` handshake; its browser assets are served unauthenticated from `/widgets/hello/*` on the MCP HTTP origin.
- Bumps `@modelcontextprotocol/sdk` `^1.27`→`^1.29` across server packages (mcp, powerline, mcp-stdio, runtime-sdk) — **required**: SDK 1.27 strips client `extensions`, so UI negotiation cannot work without it. Adds `@modelcontextprotocol/ext-apps` to `@grackle-ai/mcp`.

## Test plan
- [x] `rush build` green and warning-free (full monorepo, including the SDK bump)
- [x] Unit tests: `ui-app` (`_meta` dual-key + negotiation), `resource-registry`, `widget` tool
- [x] Integration tests (`mcp-server.test.ts`): resources/list+read, gated tools/list (UI vs plain host), dual-key `_meta`, unauthenticated asset serving
- [x] Verified against a real running server via curl: `resources` capability advertised; widget resource listed/read; tool gating (present for UI host, absent for plain); assets served (`text/javascript`)
- [ ] CI
- [ ] Follow-up: render in an external MCP Apps host (MCP Inspector / Claude Desktop). The widget loads its scripts cross-origin from the MCP server, so a host whose sandbox CSP forbids that won't render — that host-CSP path is #1238's scope.

## Out of scope
Chat-pane rendering + production sandbox origin (#1238); agent-authored dynamic widgets (#1239).

Closes #1237