### PR TITLE
Multiline chat composer + markdown rendering of user messages

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-chat-multiline-markdown_2026-05-22-21-18.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-chat-multiline-markdown_2026-05-22-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Chat: multiline auto-resizing composer (Enter for newline, Ctrl/Cmd+Enter to send) and render user messages as markdown",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/chat/ChatInput.module.scss
+++ b/packages/web-components/src/components/chat/ChatInput.module.scss
@@ -7,7 +7,7 @@
 .bar {
   @include surface-panel;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   border-top: 1px solid var(--border-subtle);
@@ -22,9 +22,17 @@
 // Form controls
 // ---------------------------------------------------------------------------
 
-.input {
+.textarea {
   @include input-field;
   flex: 1;
+  // Auto-resizing multiline composer: starts at one row and grows (JS sets the
+  // inline height); max-height must match MAX_COMPOSER_HEIGHT_PX in ChatInput.tsx.
+  box-sizing: border-box;
+  resize: none;
+  max-height: 200px;
+  overflow-y: auto;
+  line-height: var(--line-height);
+  font-family: var(--font-ui);
 
   @include mobile {
     min-width: 0;

--- a/packages/web-components/src/components/chat/ChatInput.stories.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.stories.tsx
@@ -134,3 +134,38 @@ export const SendModeActive: Story = {
     await expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
   },
 };
+
+/**
+ * The composer is multiline: a plain Enter inserts a newline and does NOT submit.
+ */
+export const ComposerEnterInsertsNewline: Story = {
+  args: {
+    mode: "send",
+    sessionId: "sess-1",
+    environmentId: "local",
+  },
+  play: async ({ canvas, args }) => {
+    const input = canvas.getByPlaceholderText("Type a message...");
+    await userEvent.type(input, "line one{Enter}line two");
+    await expect(input).toHaveValue("line one\nline two");
+    await expect(args.onSendInput).not.toHaveBeenCalled();
+  },
+};
+
+/**
+ * Ctrl/Cmd+Enter submits the composer (mirrors clicking Send) and clears the box.
+ */
+export const ComposerCtrlEnterSubmits: Story = {
+  args: {
+    mode: "send",
+    sessionId: "sess-1",
+    environmentId: "local",
+  },
+  play: async ({ canvas, args }) => {
+    const input = canvas.getByPlaceholderText("Type a message...");
+    await userEvent.type(input, "hello there");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await expect(args.onSendInput).toHaveBeenCalledWith("sess-1", "hello there");
+    await expect(input).toHaveValue("");
+  },
+};

--- a/packages/web-components/src/components/chat/ChatInput.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.tsx
@@ -1,7 +1,13 @@
-import { useState, type FormEvent, type JSX } from "react";
+import { useState, useLayoutEffect, useRef, type FormEvent, type KeyboardEvent, type JSX } from "react";
 import type { ToastVariant } from "../../context/ToastContext.js";
 import type { Environment, PersonaData } from "../../hooks/types.js";
 import styles from "./ChatInput.module.scss";
+
+/**
+ * Maximum height (px) the composer grows to before scrolling internally.
+ * Must stay in sync with `max-height` on `.textarea` in ChatInput.module.scss.
+ */
+const MAX_COMPOSER_HEIGHT_PX: number = 200;
 
 // --- Helpers ---
 
@@ -38,6 +44,77 @@ function DisconnectedBanner({ environmentId, onReconnect }: DisconnectedBannerPr
         Reconnect
       </button>
     </>
+  );
+}
+
+/** Props for the auto-resizing chat composer textarea. */
+interface ComposerTextAreaProps {
+  /** Current text value. */
+  value: string;
+  /** Called on every keystroke with the new value. */
+  onChange: (value: string) => void;
+  /** Called when the user submits via Ctrl/Cmd+Enter. */
+  onSubmit: () => void;
+  /** Placeholder text shown when empty. */
+  placeholder: string;
+  /** Whether the textarea is disabled. */
+  disabled?: boolean;
+  /** Whether to auto-focus the textarea on mount. */
+  autoFocus?: boolean;
+  /** Accessible label for the textarea. */
+  ariaLabel: string;
+}
+
+/**
+ * Auto-resizing multiline chat composer.
+ *
+ * Enter inserts a newline; Ctrl/Cmd+Enter submits (the Send button submits too).
+ * The textarea grows with its content up to {@link MAX_COMPOSER_HEIGHT_PX}, then
+ * scrolls internally.
+ */
+function ComposerTextArea({
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  disabled,
+  autoFocus,
+  ariaLabel,
+}: ComposerTextAreaProps): JSX.Element {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize: collapse to measure natural height, then grow to fit (capped).
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, MAX_COMPOSER_HEIGHT_PX)}px`;
+  }, [value]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    // Ctrl/Cmd+Enter submits; plain Enter falls through to insert a newline.
+    // The isComposing guard avoids submitting mid-IME composition (e.g. CJK input).
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <textarea
+      ref={ref}
+      rows={1}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={handleKeyDown}
+      placeholder={placeholder}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      className={styles.textarea}
+      aria-label={ariaLabel}
+    />
   );
 }
 
@@ -92,8 +169,8 @@ export function ChatInput({
 
   const envDisconnected = isEnvDisconnected(environmentId, environments);
 
-  const handleSubmit = (e: FormEvent): void => {
-    e.preventDefault();
+  /** Performs the mode-specific submit action. Called by the form and Ctrl/Cmd+Enter. */
+  const submit = (): void => {
     if (!text.trim()) {
       return;
     }
@@ -122,6 +199,11 @@ export function ChatInput({
     }
   };
 
+  const handleSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    submit();
+  };
+
   // --- spawn mode ---
   if (mode === "spawn") {
     return (
@@ -129,7 +211,7 @@ export function ChatInput({
         <span className={styles.badge}>
           new chat
         </span>
-        <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="Enter prompt..." autoFocus className={styles.input} aria-label="Enter prompt" />
+        <ComposerTextArea value={text} onChange={setText} onSubmit={submit} placeholder="Enter prompt..." autoFocus ariaLabel="Enter prompt" />
         {showPersonaSelect && (
           <select value={spawnPersonaId} onChange={(e) => setSpawnPersonaId(e.target.value)} className={styles.select} aria-label="Select persona">
             <option value="">(Default)</option>
@@ -147,7 +229,7 @@ export function ChatInput({
   if (mode === "start") {
     return (
       <form onSubmit={handleSubmit} className={styles.bar}>
-        <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="Type a message..." autoFocus className={styles.input} aria-label="Type a message" />
+        <ComposerTextArea value={text} onChange={setText} onSubmit={submit} placeholder="Type a message..." autoFocus ariaLabel="Type a message" />
         <button type="submit" disabled={!text.trim()} className={styles.btnPrimary}>Send</button>
       </form>
     );
@@ -159,7 +241,7 @@ export function ChatInput({
       {envDisconnected && environmentId && (
         <DisconnectedBanner environmentId={environmentId} onReconnect={onProvisionEnvironment} />
       )}
-      <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="Type a message..." autoFocus={!envDisconnected} disabled={envDisconnected} className={styles.input} aria-label="Type a message" />
+      <ComposerTextArea value={text} onChange={setText} onSubmit={submit} placeholder="Type a message..." autoFocus={!envDisconnected} disabled={envDisconnected} ariaLabel="Type a message" />
       <span title={envDisconnected ? "Environment is unavailable — reconnect first" : undefined}>
         <button type="submit" disabled={!text.trim() || envDisconnected} className={styles.btnPrimary}>Send</button>
       </span>

--- a/packages/web-components/src/components/display/EventRenderer.module.scss
+++ b/packages/web-components/src/components/display/EventRenderer.module.scss
@@ -81,91 +81,7 @@
   padding-left: var(--space-xs);
   line-height: var(--line-height);
 
-  // --- Markdown element styles ---
-
-  h1, h2, h3, h4, h5, h6 {
-    margin: var(--space-sm) 0 var(--space-xs);
-    font-weight: var(--font-weight-bold);
-  }
-
-  h1 { font-size: 1.4em; }
-  h2 { font-size: 1.2em; }
-  h3 { font-size: 1.1em; }
-
-  p {
-    margin: var(--space-xs) 0;
-  }
-
-  pre {
-    @include surface-inset;
-    padding: var(--space-sm);
-    margin: var(--space-xs) 0;
-    overflow: auto;
-    font-size: 11px;
-    white-space: pre-wrap;
-  }
-
-  code {
-    font-family: var(--font-mono);
-    font-size: 0.9em;
-    background: var(--bg-overlay);
-    padding: 1px 4px;
-    border-radius: var(--radius-sm);
-  }
-
-  pre code {
-    background: none;
-    padding: 0;
-  }
-
-  table {
-    border-collapse: collapse;
-    margin: var(--space-xs) 0;
-    font-size: var(--font-size-sm);
-    width: 100%;
-  }
-
-  th, td {
-    border: 1px solid var(--border-subtle);
-    padding: var(--space-xs) var(--space-sm);
-    text-align: left;
-  }
-
-  th {
-    background: var(--bg-overlay);
-    font-weight: var(--font-weight-bold);
-  }
-
-  ul, ol {
-    padding-left: var(--space-lg);
-    margin: var(--space-xs) 0;
-  }
-
-  li {
-    margin: 2px 0;
-  }
-
-  strong {
-    font-weight: var(--font-weight-bold);
-  }
-
-  a {
-    color: var(--accent-blue);
-    text-decoration: underline;
-  }
-
-  hr {
-    border: none;
-    border-top: 1px solid var(--border-subtle);
-    margin: var(--space-sm) 0;
-  }
-
-  blockquote {
-    border-left: 3px solid var(--border-subtle);
-    padding-left: var(--space-sm);
-    margin: var(--space-xs) 0;
-    color: var(--text-secondary);
-  }
+  @include markdown-content;
 }
 
 // --- Copy button positioning ---
@@ -219,6 +135,23 @@
   word-break: break-word;
   font-size: var(--font-size-sm);
   line-height: var(--line-height);
+
+  @include markdown-content;
+
+  // Collapse outer block margins so the bubble hugs its markdown content.
+  & > :first-child {
+    margin-top: 0;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+
+  // Keep wide block content (code, tables) within the bubble bounds.
+  pre,
+  table {
+    max-width: 100%;
+  }
 
   @include mobile {
     max-width: 90%;

--- a/packages/web-components/src/components/display/EventRenderer.stories.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.stories.tsx
@@ -170,6 +170,22 @@ export const MarkdownParagraphWrapping: Story = {
   },
 };
 
+/** User input events render as markdown (bold, lists, inline code) inside the bubble. */
+export const UserMessageMarkdown: Story = {
+  args: {
+    event: makeEvent({
+      eventType: "user_input",
+      content: "Please fix **the bug** in:\n\n- `index.ts`\n- `app.ts`",
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByTestId("user-input-content")).toBeInTheDocument();
+    await expect(canvas.getByText("the bug").tagName).toBe("STRONG");
+    await expect(canvas.getAllByRole("listitem")).toHaveLength(2);
+    await expect(canvas.getByText("index.ts").tagName).toBe("CODE");
+  },
+};
+
 /** System context event renders as collapsible prompt. */
 export const SystemContext: Story = {
   args: {

--- a/packages/web-components/src/components/display/EventRenderer.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.tsx
@@ -107,13 +107,25 @@ const markdownComponents: Record<string, typeof CodeBlockWrapper> = {
   pre: CodeBlockWrapper,
 };
 
+/**
+ * Renders a markdown string with GFM support and syntax-highlighted code blocks.
+ *
+ * Shared by both assistant text events and user input events so the two render
+ * through an identical pipeline.
+ */
+function MarkdownContent({ content }: { content: string }): JSX.Element {
+  return (
+    <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypePrismPlus]} components={markdownComponents}>
+      {content}
+    </Markdown>
+  );
+}
+
 /** Renders an assistant text output event with markdown formatting. */
 function TextEvent({ content }: { content: string }): JSX.Element {
   return (
     <div className={styles.textEvent}>
-      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypePrismPlus]} components={markdownComponents}>
-        {content}
-      </Markdown>
+      <MarkdownContent content={content} />
     </div>
   );
 }
@@ -140,11 +152,13 @@ function StatusEvent({ content }: { content: string }): JSX.Element {
   );
 }
 
-/** Renders a user input event, right-aligned to distinguish it from agent output. */
+/** Renders a user input event as markdown, right-aligned to distinguish it from agent output. */
 function UserInputEvent({ content }: { content: string }): JSX.Element {
   return (
     <div className={styles.userInputEvent}>
-      <span className={styles.userInputContent}>{content}</span>
+      <div className={styles.userInputContent} data-testid="user-input-content">
+        <MarkdownContent content={content} />
+      </div>
     </div>
   );
 }

--- a/packages/web-components/src/components/display/EventStream.stories.tsx
+++ b/packages/web-components/src/components/display/EventStream.stories.tsx
@@ -5,6 +5,8 @@ import type { DisplayEvent } from "../../utils/sessionEvents.js";
 import { makeEvent, makeSession, makeEnvironment } from "../../test-utils/storybook-helpers.js";
 
 const sampleEvents: DisplayEvent[] = [
+  // User messages render as markdown, same as agent output.
+  makeEvent({ eventType: "user_input", content: "Can you check **`auth.ts`**? The `refreshToken` flow looks broken:\n\n1. token isn't refreshed before expiry\n2. the retry has an off-by-one", timestamp: "2026-01-01T00:00:00Z" }),
   makeEvent({ eventType: "text", content: "First message", timestamp: "2026-01-01T00:00:01Z" }),
   makeEvent({ eventType: "text", content: "Second message", timestamp: "2026-01-01T00:00:02Z" }),
   makeEvent({ eventType: "text", content: "Third message", timestamp: "2026-01-01T00:00:03Z" }),
@@ -12,7 +14,7 @@ const sampleEvents: DisplayEvent[] = [
 
 /** A richer set of events including non-content types for selection mode tests. */
 const mixedEvents: DisplayEvent[] = [
-  makeEvent({ eventType: "user_input", content: "Fix the bug", timestamp: "2026-01-01T00:00:01Z" }),
+  makeEvent({ eventType: "user_input", content: "Fix the **login bug** in `auth.ts`:\n\n- token isn't refreshed\n- expiry check is off-by-one", timestamp: "2026-01-01T00:00:01Z" }),
   makeEvent({ eventType: "text", content: "Looking into it.", timestamp: "2026-01-01T00:00:02Z" }),
   makeEvent({ eventType: "status", content: "running", timestamp: "2026-01-01T00:00:03Z" }),
   makeEvent({ eventType: "text", content: "Found the issue in auth.ts", timestamp: "2026-01-01T00:00:04Z" }),

--- a/packages/web-components/src/mocks/mockData.ts
+++ b/packages/web-components/src/mocks/mockData.ts
@@ -267,6 +267,12 @@ export const MOCK_EVENTS: SessionEvent[] = [
   },
   {
     sessionId: "sess-001",
+    eventType: "user_input",
+    timestamp: "2026-02-27T08:15:03Z",
+    content: "Pick up the **JWT auth migration** from the previous session. A few requirements:\n\n- use `jsonwebtoken`, not `jose`\n- access tokens expire in `24h`\n- store refresh tokens in the DB\n\nMake sure the existing tests still pass.",
+  },
+  {
+    sessionId: "sess-001",
     eventType: "text",
     timestamp: "2026-02-27T08:15:04Z",
     content: "I'll pick up the JWT auth migration. The previous session identified 3 files that need updating. Let me verify the current state and start implementing.",
@@ -491,6 +497,12 @@ export const MOCK_EVENTS: SessionEvent[] = [
     eventType: "text",
     timestamp: "2026-02-27T08:15:42Z",
     content: "All 14 tests pass. Here's a summary of the changes:\n\n### Changes made\n\n| File | Action |\n|------|--------|\n| `src/middleware/auth.ts` | Rewrote to verify JWT Bearer tokens |\n| `src/routes/login.ts` | Now issues JWT access + refresh tokens |\n| `src/routes/protected.ts` | Updated to read `req.user` from JWT payload |\n| `src/middleware/__tests__/auth.test.ts` | Updated tests for JWT verification |\n\n### Key decisions\n- **Access token expiry**: 24 hours (configurable via `JWT_SECRET` env var)\n- **Refresh tokens**: 48-byte random hex, stored in DB\n- **Error handling**: Distinguishes expired tokens (401) from invalid tokens (403)",
+  },
+  {
+    sessionId: "sess-001",
+    eventType: "user_input",
+    timestamp: "2026-02-27T08:15:50Z",
+    content: "Looks great! Two follow-ups:\n\n1. add a `/refresh` endpoint that swaps a refresh token for a new access token\n2. note the token flow in `README.md`",
   },
 
   // ── sess-002: completed unit test session ──

--- a/packages/web-components/src/styles/mixins.scss
+++ b/packages/web-components/src/styles/mixins.scss
@@ -265,6 +265,99 @@ $tablet: 1024px;
 }
 
 // =============================================================================
+// Markdown Content
+// =============================================================================
+
+/// Styles for a rendered react-markdown element tree (headings, code, tables,
+/// lists, links, etc.). Applied to any container that renders markdown output,
+/// e.g. agent text events and user message bubbles.
+@mixin markdown-content {
+  h1, h2, h3, h4, h5, h6 {
+    margin: var(--space-sm) 0 var(--space-xs);
+    font-weight: var(--font-weight-bold);
+  }
+
+  h1 { font-size: 1.4em; }
+  h2 { font-size: 1.2em; }
+  h3 { font-size: 1.1em; }
+
+  p {
+    margin: var(--space-xs) 0;
+  }
+
+  pre {
+    @include surface-inset;
+    padding: var(--space-sm);
+    margin: var(--space-xs) 0;
+    overflow: auto;
+    font-size: 11px;
+    white-space: pre-wrap;
+  }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-overlay);
+    padding: 1px 4px;
+    border-radius: var(--radius-sm);
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: var(--space-xs) 0;
+    font-size: var(--font-size-sm);
+    width: 100%;
+  }
+
+  th, td {
+    border: 1px solid var(--border-subtle);
+    padding: var(--space-xs) var(--space-sm);
+    text-align: left;
+  }
+
+  th {
+    background: var(--bg-overlay);
+    font-weight: var(--font-weight-bold);
+  }
+
+  ul, ol {
+    padding-left: var(--space-lg);
+    margin: var(--space-xs) 0;
+  }
+
+  li {
+    margin: 2px 0;
+  }
+
+  strong {
+    font-weight: var(--font-weight-bold);
+  }
+
+  a {
+    color: var(--accent-blue);
+    text-decoration: underline;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: var(--space-sm) 0;
+  }
+
+  blockquote {
+    border-left: 3px solid var(--border-subtle);
+    padding-left: var(--space-sm);
+    margin: var(--space-xs) 0;
+    color: var(--text-secondary);
+  }
+}
+
+// =============================================================================
 // Animation Helpers
 // =============================================================================
 

--- a/tests/e2e-tests/tests/accessibility.spec.ts
+++ b/tests/e2e-tests/tests/accessibility.spec.ts
@@ -101,7 +101,7 @@ test.describe("Accessibility attributes", { tag: ["@a11y"] }, () => {
       await page.getByTestId("task-header-start").click();
 
       // Wait for input to appear
-      const input = page.locator('input[placeholder="Type a message..."]');
+      const input = page.locator('textarea[placeholder="Type a message..."]');
       await expect(input).toBeVisible({ timeout: 15_000 });
 
       // Assert aria-label
@@ -116,9 +116,9 @@ test.describe("Accessibility attributes", { tag: ["@a11y"] }, () => {
       await expect(page).toHaveURL(/\/chat/);
 
       // Wait for the spawn-mode input (uses "Enter prompt..." or "Type a message..." placeholder)
-      const input = page.locator('input[placeholder="Enter prompt..."]');
+      const input = page.locator('textarea[placeholder="Enter prompt..."]');
       // The input may not be visible if there's no environment — fall back to other placeholder
-      const altInput = page.locator('input[placeholder="Type a message..."]');
+      const altInput = page.locator('textarea[placeholder="Type a message..."]');
       const spawnInput = await input.isVisible().catch(() => false) ? input : altInput;
       await expect(spawnInput).toBeVisible({ timeout: 5_000 });
 

--- a/tests/e2e-tests/tests/chat.spec.ts
+++ b/tests/e2e-tests/tests/chat.spec.ts
@@ -53,7 +53,7 @@ test.describe("Chat Page (root task)", { tag: ["@session"] }, () => {
     await expect(page).toHaveURL(/\/chat/);
 
     // The UnifiedBar should show an input (since test harness has a local env)
-    const input = page.locator('input[placeholder="Type a message..."]');
+    const input = page.locator('textarea[placeholder="Type a message..."]');
     await expect(input).toBeVisible({ timeout: 5_000 });
   });
 
@@ -68,7 +68,7 @@ test.describe("Chat Page (root task)", { tag: ["@session"] }, () => {
 
     // Type a message and submit — this should start the root task with the
     // hardcoded initial prompt and queue the user's text for sendInput.
-    const input = page.locator('input[placeholder="Type a message..."]');
+    const input = page.locator('textarea[placeholder="Type a message..."]');
     await expect(input).toBeVisible({ timeout: 5_000 });
     await input.fill("Hello system");
     await page.getByRole("button", { name: "Send" }).click();

--- a/tests/e2e-tests/tests/concurrent-tasks.spec.ts
+++ b/tests/e2e-tests/tests/concurrent-tasks.spec.ts
@@ -30,7 +30,7 @@ test.describe("Concurrent Tasks", { tag: ["@task"] }, () => {
     await page.getByTestId("task-header-start").click();
 
     // Wait for task A to reach waiting_input (scenario goes idle)
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await inputField.waitFor({ timeout: 15_000 });
 
     // Start task B (navigate to it while A is running)
@@ -95,7 +95,7 @@ test.describe("Concurrent Tasks", { tag: ["@task"] }, () => {
 
     // Complete task X to review: navigate, send input
     await navigateToTask(page, "status-task-x");
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await inputField.waitFor({ timeout: 15_000 });
     await inputField.fill("continue");
     await page.locator("button", { hasText: "Send" }).click();

--- a/tests/e2e-tests/tests/disconnected-env-send.spec.ts
+++ b/tests/e2e-tests/tests/disconnected-env-send.spec.ts
@@ -34,7 +34,7 @@ test.describe("Disconnected environment blocks message send", { tag: ["@error"] 
     await page.getByTestId("task-header-start").click();
 
     // Wait for idle — input field appears
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
 
     // Stop the environment via RPC — triggers domain event
     await client.core.stopEnvironment({ id: "test-local" });
@@ -52,7 +52,7 @@ test.describe("Disconnected environment blocks message send", { tag: ["@error"] 
     const sendBtn = page.locator("button", { hasText: "Send" });
     await expect(sendBtn).toBeDisabled({ timeout: 5_000 });
 
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeDisabled({ timeout: 5_000 });
   });
 
@@ -133,7 +133,7 @@ test.describe("Disconnected environment blocks message send", { tag: ["@error"] 
     await provisionEnvironmentDirect("test-local", stubTask.client);
 
     // Input should be re-enabled — fill it so Send can be checked
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeEnabled({ timeout: 10_000 });
     await inputField.fill("hello");
 
@@ -160,13 +160,13 @@ test.describe("Disconnected environment blocks message send", { tag: ["@error"] 
     await page.getByTestId("env-nav-item").first().click();
     await page.getByRole("button", { name: "New Chat" }).click();
 
-    const promptInput = page.locator('input[placeholder="Enter prompt..."]');
+    const promptInput = page.locator('textarea[placeholder="Enter prompt..."]');
     await promptInput.fill("hello stub");
     await page.locator("button", { hasText: "Go" }).click();
 
     // Wait for the session to reach idle state
     await page
-      .locator('input[placeholder="Type a message..."]')
+      .locator('textarea[placeholder="Type a message..."]')
       .waitFor({ state: "visible", timeout: 15_000 });
 
     // Stop the environment to simulate a connectivity drop
@@ -180,7 +180,7 @@ test.describe("Disconnected environment blocks message send", { tag: ["@error"] 
     const sendBtn = page.locator("button", { hasText: "Send" });
     await expect(sendBtn).toBeDisabled({ timeout: 5_000 });
 
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeDisabled({ timeout: 5_000 });
 
     await expect(

--- a/tests/e2e-tests/tests/error-states.spec.ts
+++ b/tests/e2e-tests/tests/error-states.spec.ts
@@ -20,7 +20,7 @@ test.describe("Error States — UI", { tag: ["@error"] }, () => {
     await page.locator("button", { hasText: "Start" }).click();
 
     // Wait for task to be in_progress
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
 
     // Get taskId and try to start again via RPC
     const workspaceId = await getWorkspaceId(client, workspaceName);

--- a/tests/e2e-tests/tests/escalation.spec.ts
+++ b/tests/e2e-tests/tests/escalation.spec.ts
@@ -15,7 +15,7 @@ test.describe("Escalation auto-detection", () => {
     await page.getByTestId("task-header-start").click();
 
     // Wait for idle — input field appears
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
 
     // Poll for escalation to appear (auto-detection fires on task.updated event)
     const deadline = Date.now() + 10_000;

--- a/tests/e2e-tests/tests/helpers.ts
+++ b/tests/e2e-tests/tests/helpers.ts
@@ -291,7 +291,7 @@ export async function patchWsForStubMcpRuntime(page: Page, environmentId: string
 export async function runStubTaskToCompletion(page: Page): Promise<void> {
   await page.getByTestId("task-header-start").click();
 
-  const inputField = page.locator('input[placeholder="Type a message..."]');
+  const inputField = page.locator('textarea[placeholder="Type a message..."]');
   await inputField.waitFor({ timeout: 15_000 });
   await inputField.fill("continue");
   await page.getByRole("button", { name: "Send", exact: true }).click();
@@ -308,7 +308,7 @@ export async function runStubTaskToCompletion(page: Page): Promise<void> {
 export async function runStubMcpTaskToCompletion(page: Page): Promise<void> {
   await page.getByTestId("task-header-start").click();
 
-  const inputField = page.locator('input[placeholder="Type a message..."]');
+  const inputField = page.locator('textarea[placeholder="Type a message..."]');
   await inputField.waitFor({ timeout: 15_000 });
   await inputField.fill("continue");
   await page.getByRole("button", { name: "Send", exact: true }).click();

--- a/tests/e2e-tests/tests/kill-session.spec.ts
+++ b/tests/e2e-tests/tests/kill-session.spec.ts
@@ -10,12 +10,12 @@ test.describe("Kill Session", { tag: ["@session"] }, () => {
     // Start a stub session (uses default stub persona)
     await page.getByTestId("env-nav-item").first().click();
     await page.getByRole("button", { name: "New Chat" }).click();
-    const promptInput = page.locator('input[placeholder="Enter prompt..."]');
+    const promptInput = page.locator('textarea[placeholder="Enter prompt..."]');
     await promptInput.fill("kill test");
     await page.locator("button", { hasText: "Go" }).click();
 
     // Wait for waiting_input state
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 10_000 });
 
     // Click Kill via the split button dropdown (wait for session to be active first)

--- a/tests/e2e-tests/tests/multi-task.spec.ts
+++ b/tests/e2e-tests/tests/multi-task.spec.ts
@@ -68,7 +68,7 @@ test.describe("Multi-Task", { tag: ["@task"] }, () => {
     await expect(page.locator('[data-testid="task-status"]')).toContainText(/working|paused/, { timeout: 15_000 });
 
     // Complete to review
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await inputField.waitFor({ timeout: 15_000 });
     await inputField.fill("continue");
     await page.locator("button", { hasText: "Send" }).click();

--- a/tests/e2e-tests/tests/send-input-while-running.spec.ts
+++ b/tests/e2e-tests/tests/send-input-while-running.spec.ts
@@ -26,7 +26,7 @@ test.describe("Send input while agent is running", { tag: ["@session"] }, () => 
     await expect(page.getByText("Starting work...", { exact: true })).toBeVisible({ timeout: 15_000 });
 
     // The input field should be visible and enabled — not disabled with "Agent is working..."
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 10_000 });
     await expect(inputField).toBeEnabled();
 

--- a/tests/e2e-tests/tests/session-lifecycle.spec.ts
+++ b/tests/e2e-tests/tests/session-lifecycle.spec.ts
@@ -20,7 +20,7 @@ test.describe("Session Lifecycle (stub runtime)", { tag: ["@session"] }, () => {
     await expect(goButton).toBeDisabled();
 
     // Type prompt, click Go (uses default stub persona)
-    const promptInput = page.locator('input[placeholder="Enter prompt..."]');
+    const promptInput = page.locator('textarea[placeholder="Enter prompt..."]');
     await promptInput.fill("hello world");
     await expect(goButton).toBeEnabled();
     await goButton.click();
@@ -46,7 +46,7 @@ test.describe("Session Lifecycle (stub runtime)", { tag: ["@session"] }, () => {
     await expect(page.locator('[data-testid^="tool-card-"]').first()).toBeVisible();
 
     // Session reaches waiting_input — UnifiedBar shows text input + Send + Stop
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("button", { hasText: "Send" })).toBeVisible();
     await expect(page.getByTestId("stop-split-button")).toBeVisible();

--- a/tests/e2e-tests/tests/session-reanimate.spec.ts
+++ b/tests/e2e-tests/tests/session-reanimate.spec.ts
@@ -38,12 +38,12 @@ test.describe("Session Reanimate (stub runtime)", { tag: ["@session"] }, () => {
     await page.getByTestId("env-nav-item").first().click();
     await page.getByRole("button", { name: "New Chat" }).click();
 
-    const promptInput = page.locator('input[placeholder="Enter prompt..."]');
+    const promptInput = page.locator('textarea[placeholder="Enter prompt..."]');
     await promptInput.fill("reanimate me");
     await page.locator("button", { hasText: "Go" }).click();
 
     // ── 2. Wait for the session to reach waiting_input ──────────────────
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("text=Echo: reanimate me")).toBeVisible();
 
@@ -73,7 +73,7 @@ test.describe("Session Reanimate (stub runtime)", { tag: ["@session"] }, () => {
     // ── 6. UI transitions: session re-enters waiting_input ────────────────
     // The stub resume emits "Echo: (resumed session)" as its first text event
     await expect(page.locator("text=Echo: (resumed session)")).toBeVisible({ timeout: 10_000 });
-    const resumedInput = page.locator('input[placeholder="Type a message..."]');
+    const resumedInput = page.locator('textarea[placeholder="Type a message..."]');
     await expect(resumedInput).toBeVisible({ timeout: 10_000 });
 
     // ── 7. Send input to the reanimated session ───────────────────────────
@@ -98,10 +98,10 @@ test.describe("Session Reanimate (stub runtime)", { tag: ["@session"] }, () => {
     await page.getByTestId("env-nav-item").first().click();
     await page.getByRole("button", { name: "New Chat" }).click();
 
-    await page.locator('input[placeholder="Enter prompt..."]').fill("keep idle");
+    await page.locator('textarea[placeholder="Enter prompt..."]').fill("keep idle");
     await page.locator("button", { hasText: "Go" }).click();
 
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 10_000 });
 
     // Get the idle session ID

--- a/tests/e2e-tests/tests/stream-scroll.spec.ts
+++ b/tests/e2e-tests/tests/stream-scroll.spec.ts
@@ -26,7 +26,7 @@ function scrollableScenario(): { steps: ReturnType<typeof emitText>[] } {
 /** Start task, wait for idle, send input to complete. */
 async function runScenarioToCompletion(page: import("@playwright/test").Page): Promise<void> {
   await page.getByTestId("task-header-start").click();
-  const inputField = page.locator('input[placeholder="Type a message..."]');
+  const inputField = page.locator('textarea[placeholder="Type a message..."]');
   await inputField.waitFor({ timeout: 15_000 });
   await inputField.fill("continue");
   await page.getByRole("button", { name: "Send", exact: true }).click();

--- a/tests/e2e-tests/tests/stub-mcp-integration.spec.ts
+++ b/tests/e2e-tests/tests/stub-mcp-integration.spec.ts
@@ -34,7 +34,7 @@ test.describe("Stub MCP Integration", { tag: ["@persona"] }, () => {
     expect(cardText).toBeTruthy();
 
     // Send input to complete the session
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await inputField.waitFor({ timeout: 15_000 });
     await inputField.fill("continue");
     await page.getByRole("button", { name: "Send", exact: true }).click();

--- a/tests/e2e-tests/tests/task-lifecycle.spec.ts
+++ b/tests/e2e-tests/tests/task-lifecycle.spec.ts
@@ -38,7 +38,7 @@ test.describe("Task Lifecycle (stub runtime)", { tag: ["@task", "@smoke"] }, () 
     await expect(page.locator('[data-testid="task-status"]')).toContainText(/working|paused/, { timeout: 5_000 });
 
     // --- Step 6: Session reaches idle — send input ---
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 15_000 });
     await inputField.fill("continue work");
     await page.getByRole("button", { name: "Send", exact: true }).click();
@@ -71,7 +71,7 @@ test.describe("Task Lifecycle (stub runtime)", { tag: ["@task", "@smoke"] }, () 
     await page.getByTestId("task-header-start").click();
 
     // Wait for idle state, send input to advance to completed
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await inputField.waitFor({ timeout: 15_000 });
     await inputField.fill("continue");
     await page.getByRole("button", { name: "Send", exact: true }).click();

--- a/tests/e2e-tests/tests/task-retry.spec.ts
+++ b/tests/e2e-tests/tests/task-retry.spec.ts
@@ -22,7 +22,7 @@ test.describe("Task Resume after crash (paused → working)", { tag: ["@task"] }
     await page.getByTestId("task-header-start").click();
 
     // Wait for stub to reach waiting_input
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 15_000 });
 
     // --- Send "fail" to trigger scenario failure ---

--- a/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
+++ b/tests/e2e-tests/tests/task-start-env-resolution.spec.ts
@@ -26,7 +26,7 @@ test.describe("Task start with workspace-linked environment resolution", { tag: 
     await page.getByTestId("task-header-start").click();
 
     // Wait for stub to reach waiting_input
-    const inputField = page.locator('input[placeholder="Type a message..."]');
+    const inputField = page.locator('textarea[placeholder="Type a message..."]');
     await expect(inputField).toBeVisible({ timeout: 15_000 });
 
     // Send input to advance the stub

--- a/tests/e2e-tests/tests/task-stop-pause.spec.ts
+++ b/tests/e2e-tests/tests/task-stop-pause.spec.ts
@@ -10,7 +10,7 @@ import {
 async function runScenarioToCompletion(page: import("@playwright/test").Page): Promise<void> {
   await page.getByTestId("task-header-start").click();
 
-  const inputField = page.locator('input[placeholder="Type a message..."]');
+  const inputField = page.locator('textarea[placeholder="Type a message..."]');
   await inputField.waitFor({ timeout: 15_000 });
   await inputField.fill("continue");
   await page.getByRole("button", { name: "Send", exact: true }).click();

--- a/tests/e2e-tests/tests/tool-result-accordion.spec.ts
+++ b/tests/e2e-tests/tests/tool-result-accordion.spec.ts
@@ -28,7 +28,7 @@ test.describe("Tool card rendering (#935)", { tag: ["@webui"] }, () => {
 
     // Start the task and wait for idle
     await page.getByTestId("task-header-start").click();
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
 
     // Switch to stream tab
     await page.locator("button", { hasText: "Stream" }).click();
@@ -55,7 +55,7 @@ test.describe("Tool card rendering (#935)", { tag: ["@webui"] }, () => {
     );
 
     await page.getByTestId("task-header-start").click();
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
     await page.locator("button", { hasText: "Stream" }).click();
 
     // Should render as a ShellCard with the command visible
@@ -77,7 +77,7 @@ test.describe("Tool card rendering (#935)", { tag: ["@webui"] }, () => {
     );
 
     await page.getByTestId("task-header-start").click();
-    await page.locator('input[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Type a message..."]').waitFor({ timeout: 15_000 });
     await page.locator("button", { hasText: "Stream" }).click();
 
     // Should render as a FileReadCard (in-progress, no result)


### PR DESCRIPTION
## Summary
- **Multiline composer**: `ChatInput` now uses a single auto-resizing `<textarea>` instead of three single-line `<input>`s. **Enter inserts a newline**; **Ctrl/Cmd+Enter (or the Send button) submits**. The box grows with content up to 200px, then scrolls; the Send button stays bottom-aligned.
- **User messages render as markdown**: `EventRenderer`'s `UserInputEvent` now renders through a shared `MarkdownContent` component (same GFM + code-highlight pipeline as agent messages). Markdown element styles were extracted into a reusable `markdown-content` SCSS mixin shared by both agent and user bubbles.
- **Copy is unchanged** — still plain text (the hover Copy continues to copy the raw markdown source).

## Test plan
- [x] `rush build` clean (no warnings)
- [x] Added Storybook interaction tests: Enter-inserts-newline, Ctrl+Enter-submits, user-message-markdown renders (`<strong>`/`<li>`/`<code>`)
- [x] Manual (isolated stack + Playwright): Enter adds newlines and the composer auto-grows (75px across 3 lines, no submit); Ctrl+Enter submits, clears, and shrinks back to one row; a user message with `**bold**`, a list, and `` `inline code` `` renders formatted in the blue bubble
- [ ] CI green

## Screenshots

**Multiline composer (Enter = newline, auto-grown to 3 lines):**

![composer](https://gist.githubusercontent.com/nick-pape/1cd9b8a0c65d9fc60c2bf4896961e549/raw/40d17b227b6e319c3c46c6b27d68c0501409e1c6/shot-composer.svg)

**User message rendered as markdown (bold, list, inline code):**

![user bubble](https://gist.githubusercontent.com/nick-pape/1cd9b8a0c65d9fc60c2bf4896961e549/raw/e3c9684a32e2798eb33e749c27a6eef41ff9136f/shot-user-bubble.svg)

**Full conversation (agent + user both markdown):**

![conversation](https://gist.githubusercontent.com/nick-pape/1cd9b8a0c65d9fc60c2bf4896961e549/raw/c323243c237e8718a2b92448b6752d92775b8d48/shot-conversation.svg)