### PR TITLE
Reorder nav (Tasks before Sessions) and rename Chat to Sessions

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-nav-sessions_2026-05-22-22-43.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-nav-sessions_2026-05-22-22-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Nav: reorder so Tasks comes before Sessions, and rename the Chat tab to Sessions (route unchanged)",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/layout/AppNav.stories.tsx
+++ b/packages/web-components/src/components/layout/AppNav.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 export const AllTabsRendered: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("tab", { name: /Dashboard/ })).toBeInTheDocument();
-    await expect(canvas.getByRole("tab", { name: /Chat/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: /Sessions/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Tasks/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Environments/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Knowledge/ })).toBeInTheDocument();
@@ -30,14 +30,14 @@ export const CoreOnlyTabs: Story = {
   args: {
     tabs: [
       { view: "dashboard", label: "Dashboard", icon: <Home size={ICON_LG} />, route: HOME_URL, testId: "sidebar-tab-dashboard" },
-      { view: "chat", label: "Chat", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
+      { view: "chat", label: "Sessions", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
       { view: "environments", label: "Environments", icon: <Monitor size={ICON_LG} />, route: ENVIRONMENTS_URL, testId: "sidebar-tab-environments" },
       { view: "settings", label: "Settings", icon: <Settings size={ICON_LG} />, route: SETTINGS_CREDENTIALS_URL, testId: "sidebar-tab-settings" },
     ],
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("tab", { name: /Dashboard/ })).toBeInTheDocument();
-    await expect(canvas.getByRole("tab", { name: /Chat/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: /Sessions/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Environments/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Settings/ })).toBeInTheDocument();
     await expect(canvas.queryByRole("tab", { name: /Tasks/ })).not.toBeInTheDocument();
@@ -51,7 +51,7 @@ export const AllTabsExplicit: Story = {
   args: {
     tabs: [
       { view: "dashboard", label: "Dashboard", icon: <Home size={ICON_LG} />, route: HOME_URL, testId: "sidebar-tab-dashboard" },
-      { view: "chat", label: "Chat", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
+      { view: "chat", label: "Sessions", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
       { view: "tasks", label: "Tasks", icon: <ClipboardList size={ICON_LG} />, route: TASKS_URL, testId: "sidebar-tab-tasks" },
       { view: "environments", label: "Environments", icon: <Monitor size={ICON_LG} />, route: ENVIRONMENTS_URL, testId: "sidebar-tab-environments" },
       { view: "knowledge", label: "Knowledge", icon: <Brain size={ICON_LG} />, route: KNOWLEDGE_URL, testId: "sidebar-tab-knowledge" },
@@ -78,7 +78,7 @@ export const SettingsPinnedRight: Story = {
   args: {
     tabs: [
       { view: "dashboard", label: "Dashboard", icon: <Home size={ICON_LG} />, route: HOME_URL, testId: "sidebar-tab-dashboard" },
-      { view: "chat", label: "Chat", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
+      { view: "chat", label: "Sessions", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
       { view: "environments", label: "Environments", icon: <Monitor size={ICON_LG} />, route: ENVIRONMENTS_URL, testId: "sidebar-tab-environments" },
       { view: "settings", label: "Settings", icon: <Settings size={ICON_LG} />, route: SETTINGS_CREDENTIALS_URL, testId: "sidebar-tab-settings", align: "end" },
       { view: "tasks", label: "Tasks", icon: <ClipboardList size={ICON_LG} />, route: TASKS_URL, testId: "sidebar-tab-tasks" },

--- a/packages/web-components/src/components/layout/AppNav.tsx
+++ b/packages/web-components/src/components/layout/AppNav.tsx
@@ -21,18 +21,24 @@ export interface AppTab {
   route: string;
   /** data-testid suffix. */
   testId: string;
+  /**
+   * Display order within the nav bar (lower numbers appear first). Applied
+   * across all plugins so tab order is explicit rather than dependent on plugin
+   * load order. End-aligned tabs ignore this and are always pinned right.
+   */
+  order?: number;
   /** Horizontal alignment within the nav bar. `"end"` pins the tab to the right edge. */
   align?: "end";
 }
 
 /** Ordered list of all app navigation tabs. Exported for plugin registry use. */
 export const TABS: AppTab[] = [
-  { view: "dashboard", label: "Dashboard", icon: <Home size={ICON_LG} />, route: HOME_URL, testId: "sidebar-tab-dashboard" },
-  { view: "chat", label: "Chat", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat" },
-  { view: "tasks", label: "Tasks", icon: <ClipboardList size={ICON_LG} />, route: TASKS_URL, testId: "sidebar-tab-tasks" },
-  { view: "environments", label: "Environments", icon: <Monitor size={ICON_LG} />, route: ENVIRONMENTS_URL, testId: "sidebar-tab-environments" },
-  { view: "knowledge", label: "Knowledge", icon: <Brain size={ICON_LG} />, route: KNOWLEDGE_URL, testId: "sidebar-tab-knowledge" },
-  { view: "findings", label: "Findings", icon: <Search size={ICON_LG} />, route: FINDINGS_URL, testId: "sidebar-tab-findings" },
+  { view: "dashboard", label: "Dashboard", icon: <Home size={ICON_LG} />, route: HOME_URL, testId: "sidebar-tab-dashboard", order: 0 },
+  { view: "tasks", label: "Tasks", icon: <ClipboardList size={ICON_LG} />, route: TASKS_URL, testId: "sidebar-tab-tasks", order: 1 },
+  { view: "environments", label: "Environments", icon: <Monitor size={ICON_LG} />, route: ENVIRONMENTS_URL, testId: "sidebar-tab-environments", order: 2 },
+  { view: "chat", label: "Sessions", icon: <MessageSquare size={ICON_LG} />, route: CHAT_URL, testId: "sidebar-tab-chat", order: 3 },
+  { view: "findings", label: "Findings", icon: <Search size={ICON_LG} />, route: FINDINGS_URL, testId: "sidebar-tab-findings", order: 4 },
+  { view: "knowledge", label: "Knowledge", icon: <Brain size={ICON_LG} />, route: KNOWLEDGE_URL, testId: "sidebar-tab-knowledge", order: 5 },
   { view: "settings", label: "Settings", icon: <Settings size={ICON_LG} />, route: SETTINGS_CREDENTIALS_URL, testId: "sidebar-tab-settings", align: "end" },
 ];
 
@@ -67,15 +73,18 @@ export function AppNav({ tabs = TABS }: { tabs?: AppTab[] }): JSX.Element {
 
   const activeView = getActiveView(location.pathname);
 
-  // Render end-aligned tabs (e.g. Settings) last regardless of the incoming order,
-  // so they stay pinned to the right edge no matter which plugins contribute tabs.
-  const orderedTabs = useMemo(
-    () => [
-      ...tabs.filter((t) => t.align !== "end"),
+  // Sort by explicit `order`, then render end-aligned tabs (e.g. Settings) last
+  // regardless of order, so they stay pinned to the right edge no matter which
+  // plugins contribute tabs. Tabs without an `order` keep their incoming order
+  // (stable sort) and fall after explicitly-ordered ones.
+  const orderedTabs = useMemo(() => {
+    const byOrder = (a: AppTab, b: AppTab): number =>
+      (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER);
+    return [
+      ...tabs.filter((t) => t.align !== "end").sort(byOrder),
       ...tabs.filter((t) => t.align === "end"),
-    ],
-    [tabs],
-  );
+    ];
+  }, [tabs]);
   const firstEndAlignedView = orderedTabs.find((t) => t.align === "end")?.view;
 
   const handleClick = useCallback((tab: AppTab) => {

--- a/packages/web-components/src/components/panels/KeyboardShortcutsPanel.stories.tsx
+++ b/packages/web-components/src/components/panels/KeyboardShortcutsPanel.stories.tsx
@@ -25,7 +25,7 @@ export const AllCategoriesRendered: Story = {
     await expect(canvas.getByText("Workspace Page")).toBeInTheDocument();
     await expect(canvas.getByText("Navigation Lists")).toBeInTheDocument();
     await expect(canvas.getByText("Editing")).toBeInTheDocument();
-    await expect(canvas.getByText("Chat")).toBeInTheDocument();
+    await expect(canvas.getByText("Sessions")).toBeInTheDocument();
   },
 };
 
@@ -35,6 +35,6 @@ export const ShortcutDescriptions: Story = {
     await expect(canvas.getByText("Open keyboard shortcuts reference")).toBeInTheDocument();
     await expect(canvas.getByText("Create a new task")).toBeInTheDocument();
     await expect(canvas.getByText("Switch to Overview tab")).toBeInTheDocument();
-    await expect(canvas.getByText("Send message (when input is focused)")).toBeInTheDocument();
+    await expect(canvas.getByText("Send message (when the composer is focused)")).toBeInTheDocument();
   },
 };

--- a/packages/web-components/src/components/panels/KeyboardShortcutsPanel.tsx
+++ b/packages/web-components/src/components/panels/KeyboardShortcutsPanel.tsx
@@ -66,9 +66,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
-    title: "Chat",
+    title: "Sessions",
     shortcuts: [
-      { keys: ["Enter"], description: "Send message (when input is focused)" },
+      { keys: ["Ctrl/Cmd", "Enter"], description: "Send message (when the composer is focused)" },
+      { keys: ["Enter"], description: "Insert a new line in the message composer" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- **Reordered the top nav** so **Tasks** comes before **Sessions**. New order: `Dashboard · Tasks · Environments · Sessions · Findings · Knowledge · Settings`.
- **Renamed the "Chat" tab to "Sessions"** (the `/chat` route and `sidebar-tab-chat` testid are unchanged).
- Implemented via a new explicit `order` field on `AppTab` (sorted in `AppNav`) rather than moving views between plugin groups — so plugin ownership stays correct (`chat`→core, `tasks`→orchestration) and the plugin-disabled behavior is preserved.
- Updated `KeyboardShortcutsPanel`: renamed its "Chat" section to "Sessions" and corrected the send shortcut to **Ctrl/Cmd+Enter** (Enter now inserts a newline, per the recent composer change).

## Test plan
- [x] `rush build` clean (no warnings)
- [x] Updated `AppNav` + `KeyboardShortcutsPanel` Storybook stories/assertions for the new labels
- [x] Manual (isolated stack + `?mock`): nav renders `Dashboard · Tasks · Environments · Sessions · Findings · Knowledge · Settings`; the **Sessions** tab navigates to `/chat` and activates correctly (verified via accessibility tree)
- [ ] CI green

## Notes
- No route changes — only the visible label and ordering. E2E tests reference `sidebar-tab-chat` (unchanged), so they're unaffected.