### PR TITLE
fix: resolve public asset paths against Vite base URL (demo logo 404)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1243-demo-logo-base-path_2026-05-22-22-45.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1243-demo-logo-base-path_2026-05-22-22-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix Grackle logo/icon assets 404ing on sub-path deployments (e.g. the GitHub Pages demo): resolve public asset paths against the Vite base URL via a new assetUrl() helper, and make the PWA manifest paths relative.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/display/SplashScreen.tsx
+++ b/packages/web-components/src/components/display/SplashScreen.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 import { Spinner } from "./Spinner.js";
+import { assetUrl } from "../../utils/assetUrl.js";
 import styles from "./SplashScreen.module.scss";
 
 /**
@@ -9,7 +10,7 @@ import styles from "./SplashScreen.module.scss";
 export function SplashScreen(): JSX.Element {
   return (
     <div className={styles.splash} data-testid="splash-screen">
-      <img src="/grackle-logo.png" alt="Grackle" className={styles.logo} />
+      <img src={assetUrl("grackle-logo.png")} alt="Grackle" className={styles.logo} />
       <Spinner size="xl" label="Loading Grackle" liveRegion />
     </div>
   );

--- a/packages/web-components/src/components/layout/StatusBar.tsx
+++ b/packages/web-components/src/components/layout/StatusBar.tsx
@@ -3,6 +3,7 @@ import { Circle, Menu } from "lucide-react";
 import type { ConnectionStatus, Environment, Session } from "../../hooks/types.js";
 import { ICON_LG, ICON_XS } from "../../utils/iconSize.js";
 import { HOME_URL, useAppNavigate } from "../../utils/navigation.js";
+import { assetUrl } from "../../utils/assetUrl.js";
 import { Tooltip } from "../display/Tooltip.js";
 import styles from "./StatusBar.module.scss";
 
@@ -51,7 +52,7 @@ export function StatusBar({ connectionStatus, environments, sessions, onToggleSi
       )}
       <Tooltip text="Home" placement="bottom">
         <button type="button" className={styles.brand} onClick={() => navigate(HOME_URL)} data-testid="statusbar-brand">
-          <img src="/icon-192x192.png" alt="" className={styles.brandLogo} aria-hidden="true" data-testid="statusbar-logo" />
+          <img src={assetUrl("icon-192x192.png")} alt="" className={styles.brandLogo} aria-hidden="true" data-testid="statusbar-logo" />
           Grackle
         </button>
       </Tooltip>

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -202,6 +202,8 @@ export { computeKpis, getAttentionTasks, getActiveSessions, getWorkspaceSnapshot
 
 export { isNearAnchor, computeScrollCompensation, SCROLL_ANCHOR_THRESHOLD_PX } from "./utils/scrollUtils.js";
 
+export { assetUrl } from "./utils/assetUrl.js";
+
 // ─── Themes ──────────────────────────────────────────────────────────────────
 
 export { THEMES, THEME_IDS, DEFAULT_THEME_ID, getThemeById } from "./themes.js";

--- a/packages/web-components/src/utils/assetUrl.test.ts
+++ b/packages/web-components/src/utils/assetUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { assetUrl } from "./assetUrl.js";
+
+describe("assetUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefixes the file with the default base URL", () => {
+    vi.stubEnv("BASE_URL", "/");
+    expect(assetUrl("icon-192x192.png")).toBe("/icon-192x192.png");
+  });
+
+  it("prefixes the file with a sub-path base URL (demo deployment)", () => {
+    vi.stubEnv("BASE_URL", "/grackle/demo/");
+    expect(assetUrl("icon-192x192.png")).toBe("/grackle/demo/icon-192x192.png");
+  });
+
+  it("collapses a leading slash on the file name so the base join never double-slashes", () => {
+    vi.stubEnv("BASE_URL", "/grackle/demo/");
+    expect(assetUrl("/grackle-logo.png")).toBe("/grackle/demo/grackle-logo.png");
+  });
+});

--- a/packages/web-components/src/utils/assetUrl.ts
+++ b/packages/web-components/src/utils/assetUrl.ts
@@ -1,0 +1,33 @@
+// Minimal typing for Vite's `import.meta.env.BASE_URL`. We deliberately avoid a
+// full `/// <reference types="vite/client" />` so that Vite's broad ambient
+// asset-module declarations (`*.png`, `*.css`, ...) don't leak into the type
+// graph of every program that compiles this file — we only need `BASE_URL`.
+declare global {
+  interface ImportMetaEnv {
+    /** Base public path the app is served from (Vite `base`); always ends in `/`. */
+    readonly BASE_URL: string;
+  }
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
+/**
+ * Resolve a public asset path against the application's configured base URL.
+ *
+ * Public assets (logos, icons, the web manifest) sit at the site root in local
+ * development but under a sub-path when the app is deployed to a base URL — e.g.
+ * the GitHub Pages demo served from `/grackle/demo/`. A leading-slash `src` is
+ * resolved by the browser against the origin root and ignores Vite's `base`, so
+ * such assets 404 on sub-path deployments. Prefixing with
+ * `import.meta.env.BASE_URL` (always set by Vite, with a trailing slash) yields
+ * a path that is correct in every deployment.
+ *
+ * @param fileName - The asset's file name relative to the public root, ideally
+ *   without a leading slash (e.g. `"icon-192x192.png"`). A leading slash is
+ *   tolerated and stripped to avoid a double slash after the base.
+ * @returns The base-prefixed asset URL (e.g. `"/grackle/demo/icon-192x192.png"`).
+ */
+export function assetUrl(fileName: string): string {
+  return `${import.meta.env.BASE_URL}${fileName.replace(/^\//, "")}`;
+}

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -2,12 +2,12 @@
   "name": "Grackle",
   "short_name": "Grackle",
   "description": "Multi-agent orchestration for software teams",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#0e1218",
   "theme_color": "#0e1218",
   "icons": [
-    { "src": "/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512x512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "icon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icon-512x512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }

--- a/packages/web/src/hooks/useNotifications.ts
+++ b/packages/web/src/hooks/useNotifications.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { assetUrl } from "@grackle-ai/web-components";
 import type { DomainHook } from "./domainHook.js";
 
 /** Payload shape for notification.escalated domain events. */
@@ -62,7 +63,7 @@ export function useNotifications(): {
     const notification = new Notification(payload.title || "Agent needs input", {
       body: payload.message || "An agent is waiting for your input.",
       tag: payload.escalationId, // Prevents duplicate notifications for same escalation
-      icon: "/icon-192x192.png",
+      icon: assetUrl("icon-192x192.png"),
     });
 
     notification.onclick = () => {

--- a/packages/web/src/pages/setup/WelcomeStep.tsx
+++ b/packages/web/src/pages/setup/WelcomeStep.tsx
@@ -1,4 +1,5 @@
 import { type JSX } from "react";
+import { assetUrl } from "@grackle-ai/web-components";
 import styles from "../SetupWizard.module.scss";
 
 /** Props for the {@link WelcomeStep} component. */
@@ -11,7 +12,7 @@ export function WelcomeStep({ onNext }: WelcomeStepProps): JSX.Element {
   return (
     <div className={styles.stepContent} data-testid="setup-welcome">
       <div className={styles.logoArea}>
-        <img src="/grackle-logo.png" alt="Grackle" className={styles.logoImage} />
+        <img src={assetUrl("grackle-logo.png")} alt="Grackle" className={styles.logoImage} />
       </div>
       <h1 className={styles.heading}>Welcome to Grackle</h1>
       <p className={styles.tagline}>Multi-agent orchestration for software teams</p>


### PR DESCRIPTION
## Summary
The Grackle logo in the upper-left StatusBar (plus the splash/setup logos and the browser-notification icon) rendered broken on the GitHub Pages demo at `https://nick-pape.github.io/grackle/demo/`.

**Root cause:** those `<img>`/`Notification` references used hardcoded **root-absolute** paths (e.g. `/icon-192x192.png`). The browser resolves a leading-slash `src` against the origin root, ignoring Vite's `base`, so on the sub-path demo (`VITE_BASE_URL=/grackle/demo/`, set in `.github/workflows/publish.yml`) they request `https://nick-pape.github.io/icon-192x192.png` → **404**. Vite rewrites `base` for asset imports and `index.html`, but not for runtime string literals.

**Fix:**
- New shared `assetUrl(fileName)` helper in `@grackle-ai/web-components` that prefixes public assets with `import.meta.env.BASE_URL` (always set by Vite, with a trailing slash). It carries a minimal, self-contained `ImportMeta` type augmentation so it type-checks in the standalone `web-components` build, the `web` Vite build, Storybook, and vitest alike.
- Used at all four call sites: `StatusBar`, `SplashScreen`, `WelcomeStep`, `useNotifications`.
- Made the PWA `manifest.json` icon paths and `start_url` **relative** so they resolve against the manifest URL — correct under a sub-path and at root.

## Test plan
- [x] Unit test `assetUrl.test.ts` (3 cases: default `/`, sub-path `/grackle/demo/`, leading-slash input) — green
- [x] `rush build` (full, after merging main) — clean, **no warnings**
- [x] `web-components` vitest 174/174 and `web` vitest 245/245 — green
- [x] Demo build (`VITE_BASE_URL=/grackle/demo/`): bundle compiles the helper to `` `/grackle/demo/${fileName.replace(/^\//,"")}` `` and contains **no bare `/icon-192x192.png` literal**
- [x] Live check confirms the failure mode & target: `GET /icon-192x192.png` → 404, `GET /grackle/demo/icon-192x192.png` → 200

Note: a screenshot from a normal root-base launch wouldn't demonstrate this fix (the logo already renders at `/`); the bug and fix are specific to the sub-path deployment, verified via the demo bundle + live URL checks above.

Closes #1243