### PR TITLE
fix: navigate to new workspace after creation

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-fix-workspace-create-navigation_2026-05-22-23-22.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-fix-workspace-create-navigation_2026-05-22-23-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix: creating a workspace now navigates to the new workspace's detail view instead of the home dashboard",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -327,7 +327,7 @@ export interface UseWorkspacesResult {
     defaultPersonaId?: string,
     useWorktrees?: boolean,
     workingDirectory?: string,
-    onSuccess?: () => void,
+    onSuccess?: (workspace: Workspace) => void,
     onError?: (message: string) => void,
   ) => Promise<void>;
   /** Archive a workspace by ID. */

--- a/packages/web-components/src/mocks/MockGrackleProvider.tsx
+++ b/packages/web-components/src/mocks/MockGrackleProvider.tsx
@@ -382,7 +382,7 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
       defaultPersonaId?: string,
       useWorktrees?: boolean,
       workingDirectory?: string,
-      onSuccess?: () => void,
+      onSuccess?: (workspace: Workspace) => void,
       _onError?: (message: string) => void,
     ) => {
       console.log("[MockGrackle] createWorkspace", { name, description });
@@ -405,7 +405,7 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
 
       setWorkspaces((prev) => [...prev, newWorkspace]);
       if (onSuccess) {
-        onSuccess();
+        onSuccess(newWorkspace);
       }
     },
     [nextId],

--- a/packages/web/src/hooks/useWorkspaces.ts
+++ b/packages/web/src/hooks/useWorkspaces.ts
@@ -70,12 +70,12 @@ export function useWorkspaces(): UseWorkspacesResult {
       defaultPersonaId?: string,
       useWorktrees?: boolean,
       workingDirectory?: string,
-      onSuccess?: () => void,
+      onSuccess?: (workspace: Workspace) => void,
       onError?: (message: string) => void,
     ) => {
       setWorkspaceCreating(true);
       try {
-        await grackleClient.createWorkspace({
+        const created = await grackleClient.createWorkspace({
           name,
           description: description || "",
           repoUrl: repoUrl || "",
@@ -84,8 +84,14 @@ export function useWorkspaces(): UseWorkspacesResult {
           useWorktrees: useWorktrees ?? true,
           workingDirectory: workingDirectory || undefined,
         });
+        const workspace = protoToWorkspace(created);
+        // Optimistically seed local state so the workspace detail view we navigate
+        // to renders immediately, rather than waiting for the workspace.created
+        // WebSocket event to refresh the list. The later loadWorkspaces() replaces
+        // the whole array, so the dedupe guard prevents a transient duplicate.
+        setWorkspaces((prev) => (prev.some((w) => w.id === workspace.id) ? prev : [...prev, workspace]));
         setWorkspaceCreating(false);
-        onSuccess?.();
+        onSuccess?.(workspace);
       } catch (err) {
         setWorkspaceCreating(false);
         const message = err instanceof ConnectError ? err.message : "Failed to create workspace";

--- a/packages/web/src/pages/WorkspaceCreatePage.tsx
+++ b/packages/web/src/pages/WorkspaceCreatePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type JSX } from "react";
 import { useSearchParams } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
-import { Breadcrumbs, HOME_URL, Spinner, WorkspaceFormFields, defaultFormValues, environmentUrl, useAppNavigate, useToast } from "@grackle-ai/web-components";
+import { Breadcrumbs, HOME_URL, Spinner, WorkspaceFormFields, defaultFormValues, environmentUrl, useAppNavigate, useToast, workspaceUrl } from "@grackle-ai/web-components";
 import type { BreadcrumbSegment, WorkspaceFormValues } from "@grackle-ai/web-components";
 import styles from "./form-layout.module.scss";
 
@@ -72,9 +72,9 @@ export function WorkspaceCreatePage(): JSX.Element {
       values.defaultPersonaId,
       values.useWorktrees,
       values.workingDirectory,
-      () => {
+      (workspace) => {
         showToast("Workspace created", "success");
-        navigate(HOME_URL, { replace: true });
+        navigate(workspaceUrl(workspace.id, workspace.linkedEnvironmentIds[0] ?? values.environmentId), { replace: true });
       },
       (message: string) => {
         setSubmitError(message);

--- a/tests/e2e-tests/tests/workspaces.spec.ts
+++ b/tests/e2e-tests/tests/workspaces.spec.ts
@@ -54,8 +54,11 @@ test.describe("Workspaces", { tag: ["@workspace"] }, () => {
     await page.locator('[data-testid="workspace-form-name"]').fill("cta-workspace");
     await page.locator('[data-testid="workspace-create-save"]').click();
 
-    // Should navigate back to home
-    await page.waitForURL("/", { timeout: 5_000 });
+    // Should navigate to the new workspace's detail view, fully populated.
+    // (The page renders the name immediately from optimistically seeded state,
+    // so this also guards against a blank-flash regression.)
+    await page.waitForURL(/\/environments\/[^/]+\/workspaces\/[^/]+/, { timeout: 5_000 });
+    await expect(page.locator('[data-testid="workspace-name"]')).toContainText("cta-workspace", { timeout: 5_000 });
 
     // Navigate to the environment detail page — workspace card should appear there
     await page.locator('[data-testid="sidebar-tab-environments"]').click();


### PR DESCRIPTION
## Summary
- Creating a workspace previously bounced the user to the home dashboard (`/`) instead of the new workspace's detail view. The create-success handler navigated to `HOME_URL` because the `CreateWorkspace` RPC response (which contains the new workspace's `id`) was discarded.
- `useWorkspaces.createWorkspace` now captures the returned `Workspace`, optimistically seeds it into local state (so the detail view renders immediately rather than waiting for the `workspace.created` WebSocket event — avoids a blank flash), and passes it to `onSuccess`.
- `WorkspaceCreatePage` now navigates to `workspaceUrl(id, environmentId)` → `/environments/:environmentId/workspaces/:workspaceId`.
- Widened `UseWorkspacesResult.createWorkspace`'s `onSuccess` to receive the `Workspace`; updated `MockGrackleProvider` to match.

## Test plan
- [x] `rush build` clean (no warnings) after merging `main`
- [x] Manual verification via isolated stack + Playwright: creating a workspace lands on `/environments/local/workspaces/<id>` with the detail view fully populated (no blank flash, no bounce to `/`)
- [x] Updated E2E `workspaces.spec.ts` to assert the new navigation target instead of `waitForURL("/")`
- [ ] CI: full unit/Storybook/E2E suite

## Screenshots
After creating a workspace, the app lands directly on the new workspace's detail view:

![Workspace detail view after creation](https://gist.githubusercontent.com/nick-pape/73f9bab7bbe8bab73942a2549332eeba/raw/workspace-create-after.svg)