### PR TITLE
MCP Apps: render widgets inline in the chat pane (#1238)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@
 # MCP Apps widget sandbox port (separate origin for the double-iframe sandbox).
 # GRACKLE_SANDBOX_PORT=7436
 
+# Explicit browser-facing MCP Apps sandbox origin. Set this when the web UI is
+# served behind a reverse proxy / TLS, where the scheme + port the browser must
+# use for the sandbox cannot be inferred from the page origin + GRACKLE_SANDBOX_PORT
+# (e.g. SPA over HTTPS but sandbox on plain HTTP). Takes precedence over the port.
+# GRACKLE_SANDBOX_ORIGIN=https://sandbox.example.com
+
 # Local PowerLine (agent runtime) port.
 # GRACKLE_POWERLINE_PORT=7433
 

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@
 # MCP server port.
 # GRACKLE_MCP_PORT=7435
 
+# Explicit browser-facing MCP origin. Used as the trusted asset/CSP origin for
+# broker-captured MCP Apps widgets (the widget's <script src> + CSP allowlist),
+# so it never depends on the request Host header. Set this for reverse-proxy /
+# TLS deployments where the loopback MCP origin isn't browser-reachable. When
+# unset, the broker derives it from the bind host + GRACKLE_MCP_PORT.
+# GRACKLE_MCP_ORIGIN=https://mcp.example.com
+
 # MCP Apps widget sandbox port (separate origin for the double-iframe sandbox).
 # GRACKLE_SANDBOX_PORT=7436
 

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@
 # MCP server port.
 # GRACKLE_MCP_PORT=7435
 
+# MCP Apps widget sandbox port (separate origin for the double-iframe sandbox).
+# GRACKLE_SANDBOX_PORT=7436
+
 # Local PowerLine (agent runtime) port.
 # GRACKLE_POWERLINE_PORT=7433
 

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -309,6 +309,9 @@ export const DEFAULT_PERSONA_NAME: string;
 export const DEFAULT_POWERLINE_PORT: number;
 
 // @public
+export const DEFAULT_SANDBOX_PORT: number;
+
+// @public
 export const DEFAULT_SCOPED_MCP_TOOLS: readonly string[];
 
 // @public
@@ -476,7 +479,8 @@ enum EventType_2 {
     TOOL_USE = 2,
     UNSPECIFIED = 0,
     USAGE = 11,
-    USER_INPUT = 9
+    USER_INPUT = 9,
+    WIDGET = 13
 }
 
 // @public

--- a/common/api/web-server.public.api.md
+++ b/common/api/web-server.public.api.md
@@ -8,6 +8,12 @@ import type { ConnectRouter } from '@connectrpc/connect';
 import http from 'node:http';
 
 // @public
+export function buildCspHeader(csp: SandboxCsp | undefined): string;
+
+// @public
+export function createSandboxServer(options: SandboxServerOptions): http.Server;
+
+// @public
 export function createWebServer(options: WebServerOptions): http.Server;
 
 // @public
@@ -26,12 +32,31 @@ export interface ReadinessResult {
 }
 
 // @public
+export interface SandboxCsp {
+    // (undocumented)
+    baseUriDomains?: unknown;
+    // (undocumented)
+    connectDomains?: unknown;
+    // (undocumented)
+    frameDomains?: unknown;
+    // (undocumented)
+    resourceDomains?: unknown;
+}
+
+// @public
+export interface SandboxServerOptions {
+    bindHost: string;
+    sandboxPort: number;
+}
+
+// @public
 export interface WebServerOptions {
     apiKey: string;
     bindHost: string;
     connectRoutes?: (router: ConnectRouter) => void;
     pluginNames?: string[];
     readinessCheck?: () => ReadinessResult | Promise<ReadinessResult>;
+    sandboxPort?: number;
     webDistDir?: string;
     webPort: number;
 }

--- a/common/api/web-server.public.api.md
+++ b/common/api/web-server.public.api.md
@@ -56,6 +56,7 @@ export interface WebServerOptions {
     connectRoutes?: (router: ConnectRouter) => void;
     pluginNames?: string[];
     readinessCheck?: () => ReadinessResult | Promise<ReadinessResult>;
+    sandboxOrigin?: string;
     sandboxPort?: number;
     webDistDir?: string;
     webPort: number;

--- a/common/changes/@grackle-ai/cli/nick-pape-1238-mcp-apps-chat_2026-05-22-23-11.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1238-mcp-apps-chat_2026-05-22-23-11.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Render MCP Apps widgets inline in chat (#1238): when a session agent calls a ui:// widget tool, the in-process MCP server broker pushes a self-contained widget event into the session stream (new EVENT_TYPE_WIDGET + core publishWidgetEvent), and the web chat renders it via McpAppWidget served from a new production sandbox server on GRACKLE_SANDBOX_PORT.",
+      "comment": "Render MCP Apps widgets inline in chat (#1238): when a scoped agent calls a ui:// widget tool, the in-process MCP server broker captures it and pushes a self-contained widget event into the session stream (new EVENT_TYPE_WIDGET + core publishWidgetEvent), and the web chat renders it via McpAppWidget served from a new production sandbox server on GRACKLE_SANDBOX_PORT. Also wires widget tools through the tool-authz layer (broker exposes them regardless of the agent client's ui extension; show_hello_widget added to the scoped/orchestrator/all tool sets) and widens the web-app CSP frame-src so the chat can embed the sandbox origin.",
       "type": "minor",
       "packageName": "@grackle-ai/cli"
     }

--- a/common/changes/@grackle-ai/cli/nick-pape-1238-mcp-apps-chat_2026-05-22-23-11.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1238-mcp-apps-chat_2026-05-22-23-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Render MCP Apps widgets inline in chat (#1238): when a session agent calls a ui:// widget tool, the in-process MCP server broker pushes a self-contained widget event into the session stream (new EVENT_TYPE_WIDGET + core publishWidgetEvent), and the web chat renders it via McpAppWidget served from a new production sandbox server on GRACKLE_SANDBOX_PORT.",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1237,6 +1237,9 @@ importers:
       '@grackle-ai/web':
         specifier: workspace:*
         version: link:../web
+      '@grackle-ai/web-components':
+        specifier: workspace:*
+        version: link:../web-components
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*

--- a/packages/auth/src/security-headers.test.ts
+++ b/packages/auth/src/security-headers.test.ts
@@ -137,6 +137,28 @@ describe("security headers", () => {
         await new Promise<void>((resolve) => { server.close(() => resolve()); });
       }
     });
+
+    it("widens frame-src to the request hostname so the chat can embed the widget sandbox", async () => {
+      // The MCP Apps widget sandbox runs on the same hostname, different port
+      // (GRACKLE_SANDBOX_PORT); frame-src must allow it across ports.
+      const server = http.createServer((req, res) => {
+        setSecurityHeaders(res, "localhost:3000");
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html></html>");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const resp = await request(server, "/");
+        const csp = resp.headers["content-security-policy"] as string;
+        expect(csp).toContain("frame-src 'self' http://localhost:* https://localhost:*");
+      } finally {
+        await new Promise<void>((resolve) => { server.close(() => resolve()); });
+      }
+    });
   });
 
   describe("WEB_CONTENT_SECURITY_POLICY", () => {
@@ -149,6 +171,7 @@ describe("security headers", () => {
       expect(WEB_CONTENT_SECURITY_POLICY).toContain("connect-src 'self'");
       expect(WEB_CONTENT_SECURITY_POLICY).toContain("object-src 'none'");
       expect(WEB_CONTENT_SECURITY_POLICY).toContain("form-action 'self'");
+      expect(WEB_CONTENT_SECURITY_POLICY).toContain("frame-src 'self'");
       expect(WEB_CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
       expect(WEB_CONTENT_SECURITY_POLICY).toContain("base-uri 'self'");
     });

--- a/packages/auth/src/security-headers.ts
+++ b/packages/auth/src/security-headers.ts
@@ -29,6 +29,7 @@ const BASE_CSP_DIRECTIVES: readonly string[] = [
  */
 export const WEB_CONTENT_SECURITY_POLICY: string = [
   ...BASE_CSP_DIRECTIVES,
+  "frame-src 'self'",
   "form-action 'self'",
 ].join("; ");
 
@@ -54,15 +55,23 @@ export function setSecurityHeaders(res: ServerResponse, requestHost?: string): v
   // Validate via URL constructor to prevent CSP header injection (e.g. Host
   // containing ';' could splice directives).
   let formAction = "form-action 'self'";
+  // The chat embeds the MCP Apps widget sandbox in an iframe. The sandbox runs
+  // on the same hostname but a different port (GRACKLE_SANDBOX_PORT), and
+  // Chromium does not reliably match 'self' across ports — so allow the request
+  // hostname on any port (same workaround as form-action). The framed sandbox
+  // is itself origin-isolated with its own locked-down CSP, so this only widens
+  // which origins the app may *embed*, not what runs inside them.
+  let frameSrc = "frame-src 'self'";
   if (requestHost) {
     try {
       const parsed = new URL(`http://${requestHost}`);
       const hostname = parsed.hostname;
       formAction = `form-action 'self' http://${hostname}:* https://${hostname}:*`;
+      frameSrc = `frame-src 'self' http://${hostname}:* https://${hostname}:*`;
     } catch {
       // Malformed Host header — fall back to 'self' only
     }
   }
-  const csp = [...BASE_CSP_DIRECTIVES, formAction].join("; ");
+  const csp = [...BASE_CSP_DIRECTIVES, frameSrc, formAction].join("; ");
   res.setHeader("Content-Security-Policy", csp);
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,6 +81,7 @@ grackle serve --allow-network    # bind to 0.0.0.0 for LAN access
 | `--port <port>` | Server gRPC port | `7434` |
 | `--web-port <port>` | Web UI port | `3000` |
 | `--mcp-port <port>` | MCP server port | `7435` |
+| `--mcp-origin <origin>` | Browser-facing MCP origin (e.g. `https://mcp.example.com`) for reverse-proxy/TLS deployments; trusted asset/CSP origin for widgets | (derived from host + `--mcp-port`) |
 | `--sandbox-port <port>` | MCP Apps widget sandbox port | `7436` |
 | `--sandbox-origin <origin>` | Browser-facing MCP Apps sandbox origin (e.g. `https://sandbox.example.com`) for reverse-proxy/TLS deployments | (derived from host + `--sandbox-port`) |
 | `--powerline-port <port>` | Local PowerLine port | `7433` |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,6 +81,8 @@ grackle serve --allow-network    # bind to 0.0.0.0 for LAN access
 | `--port <port>` | Server gRPC port | `7434` |
 | `--web-port <port>` | Web UI port | `3000` |
 | `--mcp-port <port>` | MCP server port | `7435` |
+| `--sandbox-port <port>` | MCP Apps widget sandbox port | `7436` |
+| `--sandbox-origin <origin>` | Browser-facing MCP Apps sandbox origin (e.g. `https://sandbox.example.com`) for reverse-proxy/TLS deployments | (derived from host + `--sandbox-port`) |
 | `--powerline-port <port>` | Local PowerLine port | `7433` |
 | `--allow-network` | Bind to all interfaces (0.0.0.0) | Off (127.0.0.1) |
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,17 +8,19 @@ export function registerServeCommand(program: Command): void {
     .option("--port <port>", "Server port", "7434")
     .option("--web-port <port>", "Web UI port", "3000")
     .option("--mcp-port <port>", "MCP server port", "7435")
+    .option("--sandbox-port <port>", "MCP Apps widget sandbox port", "7436")
     .option("--powerline-port <port>", "Local PowerLine port", "7433")
     .option("--allow-network", "Bind to all interfaces (0.0.0.0) for LAN access")
-    .action(async (opts: { port: string; webPort: string; mcpPort: string; powerlinePort: string; allowNetwork: boolean }) => {
+    .action(async (opts: { port: string; webPort: string; mcpPort: string; sandboxPort: string; powerlinePort: string; allowNetwork: boolean }) => {
       process.env.GRACKLE_PORT = opts.port;
       process.env.GRACKLE_WEB_PORT = opts.webPort;
       process.env.GRACKLE_MCP_PORT = opts.mcpPort;
+      process.env.GRACKLE_SANDBOX_PORT = opts.sandboxPort;
       process.env.GRACKLE_POWERLINE_PORT = opts.powerlinePort;
       process.env.GRACKLE_HOST = opts.allowNetwork ? "0.0.0.0" : "127.0.0.1";
 
       console.log(`Starting Grackle server...`);
-      console.log(`gRPC on port ${opts.port}, Web UI on port ${opts.webPort}, MCP on port ${opts.mcpPort}, PowerLine on port ${opts.powerlinePort}`);
+      console.log(`gRPC on port ${opts.port}, Web UI on port ${opts.webPort}, MCP on port ${opts.mcpPort}, Sandbox on port ${opts.sandboxPort}, PowerLine on port ${opts.powerlinePort}`);
       if (opts.allowNetwork) {
         console.log("Network access enabled — binding to all interfaces");
       }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -9,13 +9,17 @@ export function registerServeCommand(program: Command): void {
     .option("--web-port <port>", "Web UI port", "3000")
     .option("--mcp-port <port>", "MCP server port", "7435")
     .option("--sandbox-port <port>", "MCP Apps widget sandbox port", "7436")
+    .option("--sandbox-origin <origin>", "Browser-facing MCP Apps sandbox origin (e.g. https://sandbox.example.com) for reverse-proxy/TLS deployments")
     .option("--powerline-port <port>", "Local PowerLine port", "7433")
     .option("--allow-network", "Bind to all interfaces (0.0.0.0) for LAN access")
-    .action(async (opts: { port: string; webPort: string; mcpPort: string; sandboxPort: string; powerlinePort: string; allowNetwork: boolean }) => {
+    .action(async (opts: { port: string; webPort: string; mcpPort: string; sandboxPort: string; sandboxOrigin?: string; powerlinePort: string; allowNetwork: boolean }) => {
       process.env.GRACKLE_PORT = opts.port;
       process.env.GRACKLE_WEB_PORT = opts.webPort;
       process.env.GRACKLE_MCP_PORT = opts.mcpPort;
       process.env.GRACKLE_SANDBOX_PORT = opts.sandboxPort;
+      if (opts.sandboxOrigin !== undefined) {
+        process.env.GRACKLE_SANDBOX_ORIGIN = opts.sandboxOrigin;
+      }
       process.env.GRACKLE_POWERLINE_PORT = opts.powerlinePort;
       process.env.GRACKLE_HOST = opts.allowNetwork ? "0.0.0.0" : "127.0.0.1";
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,14 +8,18 @@ export function registerServeCommand(program: Command): void {
     .option("--port <port>", "Server port", "7434")
     .option("--web-port <port>", "Web UI port", "3000")
     .option("--mcp-port <port>", "MCP server port", "7435")
+    .option("--mcp-origin <origin>", "Browser-facing MCP origin (e.g. https://mcp.example.com) for reverse-proxy/TLS deployments; trusted asset/CSP origin for widgets")
     .option("--sandbox-port <port>", "MCP Apps widget sandbox port", "7436")
     .option("--sandbox-origin <origin>", "Browser-facing MCP Apps sandbox origin (e.g. https://sandbox.example.com) for reverse-proxy/TLS deployments")
     .option("--powerline-port <port>", "Local PowerLine port", "7433")
     .option("--allow-network", "Bind to all interfaces (0.0.0.0) for LAN access")
-    .action(async (opts: { port: string; webPort: string; mcpPort: string; sandboxPort: string; sandboxOrigin?: string; powerlinePort: string; allowNetwork: boolean }) => {
+    .action(async (opts: { port: string; webPort: string; mcpPort: string; mcpOrigin?: string; sandboxPort: string; sandboxOrigin?: string; powerlinePort: string; allowNetwork: boolean }) => {
       process.env.GRACKLE_PORT = opts.port;
       process.env.GRACKLE_WEB_PORT = opts.webPort;
       process.env.GRACKLE_MCP_PORT = opts.mcpPort;
+      if (opts.mcpOrigin !== undefined) {
+        process.env.GRACKLE_MCP_ORIGIN = opts.mcpOrigin;
+      }
       process.env.GRACKLE_SANDBOX_PORT = opts.sandboxPort;
       if (opts.sandboxOrigin !== undefined) {
         process.env.GRACKLE_SANDBOX_ORIGIN = opts.sandboxOrigin;

--- a/packages/common/src/enum-converters.test.ts
+++ b/packages/common/src/enum-converters.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { eventTypeToEnum, eventTypeToString } from "./enum-converters.js";
+import { EventType } from "./gen/grackle/grackle_types_pb.js";
+
+describe("EventType converters — widget", () => {
+  it("maps the widget string to the enum and back", () => {
+    expect(eventTypeToEnum("widget")).toBe(EventType.WIDGET);
+    expect(eventTypeToString(EventType.WIDGET)).toBe("widget");
+  });
+
+  it("falls back to UNSPECIFIED / empty for unknown values", () => {
+    expect(eventTypeToEnum("nope")).toBe(EventType.UNSPECIFIED);
+    expect(eventTypeToString(999 as EventType)).toBe("");
+  });
+});

--- a/packages/common/src/enum-converters.ts
+++ b/packages/common/src/enum-converters.ts
@@ -29,6 +29,7 @@ const eventTypeToEnumMap: Record<string, EventType> = Object.assign(Object.creat
   "signal": EventType.SIGNAL,
   "usage": EventType.USAGE,
   "escalation": EventType.ESCALATION,
+  "widget": EventType.WIDGET,
 });
 
 const eventTypeToStringMap: Record<number, string> = {
@@ -45,6 +46,7 @@ const eventTypeToStringMap: Record<number, string> = {
   [EventType.SIGNAL]: "signal",
   [EventType.USAGE]: "usage",
   [EventType.ESCALATION]: "escalation",
+  [EventType.WIDGET]: "widget",
 };
 
 /** Convert a string event type to its proto enum value. */

--- a/packages/common/src/mcp-tool-presets.test.ts
+++ b/packages/common/src/mcp-tool-presets.test.ts
@@ -57,6 +57,7 @@ describe("DEFAULT_SCOPED_MCP_TOOLS", () => {
       "persona_list", "persona_show",
       "schedule_list", "schedule_show",
       "session_attach", "session_send_input",
+      "show_hello_widget",
       "task_complete", "task_create", "task_list", "task_search", "task_show", "task_start",
       "workpad_read", "workpad_write",
     ]);

--- a/packages/common/src/mcp-tool-presets.ts
+++ b/packages/common/src/mcp-tool-presets.ts
@@ -44,6 +44,8 @@ export const ALL_MCP_TOOL_NAMES: ReadonlySet<string> = new Set([
   "workspace_list", "workspace_create", "workspace_get", "workspace_update", "workspace_archive",
   // escalation
   "escalate_to_human", "escalation_list", "escalation_acknowledge",
+  // widget (MCP Apps) — render a ui:// widget in the chat via the broker
+  "show_hello_widget",
 ]);
 
 // ─── Preset Tool Sets ────────────────────────────────────────
@@ -64,6 +66,9 @@ export const DEFAULT_SCOPED_MCP_TOOLS: readonly string[] = [
   "logs_get",
   "workpad_write", "workpad_read",
   "schedule_list", "schedule_show",
+  // MCP Apps: agents can render a ui:// widget in the chat (Grackle's broker
+  // captures the call and renders it; SEP-1865).
+  "show_hello_widget",
 ] as const;
 
 /**
@@ -98,6 +103,8 @@ export const ORCHESTRATOR_MCP_TOOLS: readonly string[] = [
   "logs_get",
   "workpad_write", "workpad_read",
   "schedule_list", "schedule_show",
+  // MCP Apps widget (in DEFAULT_SCOPED_MCP_TOOLS — keep this a superset).
+  "show_hello_widget",
   // Additional management tools
   "task_update", "task_delete", "task_resume",
   "session_spawn", "session_kill", "session_status",

--- a/packages/common/src/proto/grackle/grackle_types.proto
+++ b/packages/common/src/proto/grackle/grackle_types.proto
@@ -35,6 +35,7 @@ enum EventType {
   EVENT_TYPE_SIGNAL = 10;
   EVENT_TYPE_USAGE = 11;
   EVENT_TYPE_ESCALATION = 12;
+  EVENT_TYPE_WIDGET = 13;
 }
 
 enum TaskStatus {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -89,6 +89,8 @@ export const DEFAULT_SERVER_PORT: number = 7434;
 export const DEFAULT_WEB_PORT: number = 3000;
 /** Default port for the MCP (Model Context Protocol) server. */
 export const DEFAULT_MCP_PORT: number = 7435;
+/** Default port for the MCP Apps widget sandbox (a separate origin for the double-iframe). */
+export const DEFAULT_SANDBOX_PORT: number = 7436;
 /** Name of the seed persona created on first run. */
 export const DEFAULT_PERSONA_NAME: string = "Software Engineer";
 /** ID of the seed persona created on first run. */

--- a/packages/core/src/event-processor.test.ts
+++ b/packages/core/src/event-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import { powerline } from "@grackle-ai/common";
+import { powerline, grackle } from "@grackle-ai/common";
 
 // ── Mock all heavy dependencies before importing ──────────────
 vi.mock("./trace-context.js", () => ({
@@ -14,6 +14,7 @@ vi.mock("./logger.js", () => ({
 
 vi.mock("./log-writer.js", () => ({
   initLog: vi.fn(),
+  ensureLogInitialized: vi.fn(),
   writeEvent: vi.fn(),
   endSession: vi.fn(),
   readLog: vi.fn().mockReturnValue([]),
@@ -36,7 +37,7 @@ import { openDatabase, initDatabase, sqlite as _sqlite, sessionStore, taskStore,
 openDatabase(":memory:");
 initDatabase();
 const sqlite = _sqlite!;
-import { processEventStream } from "./event-processor.js";
+import { processEventStream, publishWidgetEvent } from "./event-processor.js";
 import * as processorRegistry from "./processor-registry.js";
 import { emit } from "./event-bus.js";
 import * as logWriter from "./log-writer.js";
@@ -1554,5 +1555,69 @@ describe("event-processor traceId propagation", () => {
     });
 
     expect(runWithTrace).not.toHaveBeenCalled();
+  });
+});
+
+describe("publishWidgetEvent (MCP Apps widget broker, #1238)", () => {
+  const widgetPayload = {
+    resourceUri: "ui://grackle/hello-widget",
+    toolName: "show_hello_widget",
+    html: "<!doctype html><html><body><div class=\"card\">Grackle</div></body></html>",
+    csp: { resourceDomains: ["http://127.0.0.1:7435"], connectDomains: ["http://127.0.0.1:7435"] },
+    toolInput: { message: "hi" },
+    toolResult: { content: [{ type: "text", text: "ok" }] },
+  };
+
+  beforeEach(() => {
+    sqlite.exec("DROP TABLE IF EXISTS findings");
+    sqlite.exec("DROP TABLE IF EXISTS tasks");
+    sqlite.exec("DROP TABLE IF EXISTS sessions");
+    sqlite.exec("DROP TABLE IF EXISTS workspaces");
+    applySchema();
+    vi.clearAllMocks();
+    // writeEvent returns a promise (the impl chains .catch on it).
+    vi.mocked(logWriter.writeEvent).mockResolvedValue(undefined as never);
+  });
+
+  it("builds a WIDGET event, persists it to the session log, and broadcasts it", async () => {
+    sessionStore.createSession("sess-w", "env1", "claude-code", "test", "sonnet", "/tmp/widget-log");
+    const { publish } = await import("./stream-hub.js");
+
+    publishWidgetEvent("sess-w", widgetPayload);
+
+    // Persisted to the session's log (so it replays on reload).
+    expect(logWriter.ensureLogInitialized).toHaveBeenCalledWith("/tmp/widget-log");
+    expect(logWriter.writeEvent).toHaveBeenCalledTimes(1);
+    const [logPath, persisted] = vi.mocked(logWriter.writeEvent).mock.calls[0];
+    expect(logPath).toBe("/tmp/widget-log");
+    expect(persisted.type).toBe(grackle.EventType.WIDGET);
+
+    // Broadcast live with the same event.
+    expect(publish).toHaveBeenCalledTimes(1);
+    const broadcast = vi.mocked(publish).mock.calls[0][0];
+    expect(broadcast.sessionId).toBe("sess-w");
+    expect(broadcast.type).toBe(grackle.EventType.WIDGET);
+
+    // content is the payload as JSON, round-trips 1:1 to McpAppWidget props.
+    expect(JSON.parse(broadcast.content)).toEqual(widgetPayload);
+  });
+
+  it("broadcasts even when the session has no log path (skips persistence)", async () => {
+    sessionStore.createSession("sess-nolog", "env1", "claude-code", "test", "sonnet", "");
+    const { publish } = await import("./stream-hub.js");
+
+    publishWidgetEvent("sess-nolog", widgetPayload);
+
+    expect(logWriter.writeEvent).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("broadcasts a self-contained event even for an unknown session", async () => {
+    const { publish } = await import("./stream-hub.js");
+
+    publishWidgetEvent("does-not-exist", widgetPayload);
+
+    expect(logWriter.writeEvent).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -32,6 +32,55 @@ export interface EventStreamOptions {
   traceId?: string;
 }
 
+/** Payload for an MCP Apps widget render event pushed into a session stream. */
+export interface WidgetEventPayload {
+  /** The `ui://` resource the widget renders. */
+  resourceUri: string;
+  /** Name of the tool that produced the widget. */
+  toolName: string;
+  /** Widget HTML (`text/html;profile=mcp-app`). */
+  html: string;
+  /** CSP domains for the sandbox (e.g. `resourceDomains` = the MCP origin). */
+  csp?: unknown;
+  /** Tool input arguments. */
+  toolInput?: Record<string, unknown>;
+  /** Tool result (an MCP `CallToolResult`). */
+  toolResult?: unknown;
+}
+
+/** Callback that pushes a widget event into a session's stream (injected into the MCP server). */
+export type PublishWidgetEvent = (sessionId: string, payload: WidgetEventPayload) => void;
+
+/**
+ * Publish an MCP Apps widget render event into a session's event stream.
+ *
+ * Called by Grackle's MCP server (the broker) when an agent invokes a widget
+ * tool. The event is self-contained (resource HTML + tool input/result) so the
+ * web chat renders it without contacting the MCP server. Persisted to the
+ * session log (replays on reload) and broadcast live. Non-fatal on error.
+ */
+export function publishWidgetEvent(sessionId: string, payload: WidgetEventPayload): void {
+  try {
+    const event = create(grackle.SessionEventSchema, {
+      sessionId,
+      type: grackle.EventType.WIDGET,
+      timestamp: new Date().toISOString(),
+      content: JSON.stringify(payload),
+      raw: JSON.stringify({ widget: true, toolName: payload.toolName }),
+    });
+    const session = sessionStore.getSession(sessionId);
+    if (session?.logPath) {
+      logWriter.ensureLogInitialized(session.logPath);
+      logWriter.writeEvent(session.logPath, event).catch((err: unknown) => {
+        logger.error({ err, sessionId }, "Failed to persist widget event");
+      });
+    }
+    streamHub.publish(event);
+  } catch (err) {
+    logger.error({ err, sessionId }, "Failed to publish widget event");
+  }
+}
+
 /**
  * Process a finding event, storing it in the finding store and broadcasting.
  * Shared between live event processing and replay on late-bind.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,7 +64,8 @@ export * as logWriter from "./log-writer.js";
 export * as pipeDelivery from "./pipe-delivery.js";
 
 // ─── Individual Exports for Plugin-Core ──────────────────────
-export { processEventStream } from "./event-processor.js";
+export { processEventStream, publishWidgetEvent } from "./event-processor.js";
+export type { WidgetEventPayload, PublishWidgetEvent } from "./event-processor.js";
 export { createEventStream } from "./event-hub.js";
 export { recoverSuspendedSessions } from "./session-recovery.js";
 export { clearReconnectState, isReconnecting } from "./auto-reconnect.js";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -275,9 +275,11 @@ How it works:
 - **Tool ↔ resource link** — A widget tool carries `_meta.ui.resourceUri` (and the legacy `_meta["ui/resourceUri"]`) pointing at its `ui://` resource. The host reads the resource and renders it, passing the tool's input and result into the widget.
 - **Widget assets** — The widget's browser scripts are served (unauthenticated, since they are non-sensitive static JS) from `/widgets/<name>/…` on the MCP server's HTTP origin.
 
-> **Note:** the widget's scripts load from the MCP server's origin, so a host whose sandbox CSP forbids cross-origin scripts won't render them. Grackle's own chat-pane host handles this; that integration is tracked separately.
+- **Grackle chat-pane capture** — When an agent in a Grackle session calls a widget tool, the MCP server also pushes a self-contained "widget" event (resource HTML + tool input/result) into that session's event stream, so the widget renders inline in Grackle's own chat UI — independent of whether the agent runtime preserves MCP `_meta`. (This in-process capture only runs when the MCP server is co-located with the Grackle server; the standalone `npx @grackle-ai/mcp` server does not emit chat widget events.)
 
-The current built-in widget is `show_hello_widget` (resource `ui://grackle/hello-widget`). Try it with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or Claude Desktop.
+> **Note:** the widget's scripts load from the MCP server's origin, so a host whose sandbox CSP forbids cross-origin scripts won't render them. Grackle's own chat pane allows the MCP origin in its sandbox CSP, so widgets render there.
+
+The current built-in widget is `show_hello_widget` (resource `ui://grackle/hello-widget`). Try it with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), Claude Desktop, or Grackle's own chat.
 
 ---
 

--- a/packages/mcp/src/mcp-server.test.ts
+++ b/packages/mcp/src/mcp-server.test.ts
@@ -15,19 +15,21 @@ import { z } from "zod";
 import { createScopedToken } from "@grackle-ai/auth";
 import { ROOT_TASK_ID } from "@grackle-ai/common";
 import type { ToolDefinition } from "./tool-registry.js";
-import { createMcpServer, resolveAssetBaseUrl } from "./mcp-server.js";
+import { createMcpServer, resolveAssetBaseUrl, type PublishWidgetEvent } from "./mcp-server.js";
+import { HELLO_WIDGET_URI } from "./resources/hello-widget.js";
 
 // API key must be exactly 64 hex characters (API_KEY_LENGTH in auth-middleware)
 const TEST_API_KEY = "a".repeat(64);
 
 /** Spin up a real MCP server on an ephemeral port. */
-function startServer(toolGroups?: ToolDefinition[][]): Promise<http.Server> {
+function startServer(toolGroups?: ToolDefinition[][], publishWidgetEvent?: PublishWidgetEvent): Promise<http.Server> {
   const server = createMcpServer({
     bindHost: "127.0.0.1",
     mcpPort: 0,
     grpcPort: 19999, // dummy — no gRPC backend needed for these tests
     apiKey: TEST_API_KEY,
     toolGroups,
+    publishWidgetEvent,
   });
   return new Promise<http.Server>((resolve) => {
     server.listen(0, "127.0.0.1", () => resolve(server));
@@ -774,5 +776,79 @@ describe("resolveAssetBaseUrl", () => {
     expect(result).not.toContain('"');
     expect(result).not.toContain("<");
     expect(result).not.toContain(" ");
+  });
+});
+
+describe("MCP Apps widget capture (#1238)", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => { server!.close(() => resolve()); });
+      server = undefined;
+    }
+  });
+
+  interface WidgetCall {
+    sessionId: string;
+    payload: {
+      resourceUri: string;
+      toolName: string;
+      html: string;
+      csp?: { resourceDomains?: string[] };
+      toolInput?: Record<string, unknown>;
+      toolResult?: unknown;
+    };
+  }
+
+  /** A widget tool (uiResourceUri set) that captures its args, for capture testing. */
+  function makeWidgetSpyTool(capturedArgs: Record<string, unknown>[]): ToolDefinition {
+    return {
+      ...makeSpyTool("widget_spy", "widget", capturedArgs, z.object({ message: z.string().optional() })),
+      uiResourceUri: HELLO_WIDGET_URI,
+    };
+  }
+
+  it("emits a widget event when a scoped agent calls a widget tool", async () => {
+    const widgetCalls: WidgetCall[] = [];
+    server = await startServer(
+      [[makeWidgetSpyTool([])]],
+      (sessionId, payload) => { widgetCalls.push({ sessionId, payload } as WidgetCall); },
+    );
+    const scopedToken = createScopedToken(
+      { sub: ROOT_TASK_ID, pid: "default-ws", per: "system", sid: "sess-widget" },
+      TEST_API_KEY,
+    );
+    const authHeader = `Bearer ${scopedToken}`;
+    const sessionId = await initialize(server, authHeader);
+    await callTool(server, sessionId, "widget_spy", { message: "hi widget" }, authHeader);
+
+    expect(widgetCalls).toHaveLength(1);
+    expect(widgetCalls[0]!.sessionId).toBe("sess-widget");
+    const payload = widgetCalls[0]!.payload;
+    expect(payload.resourceUri).toBe(HELLO_WIDGET_URI);
+    expect(payload.toolName).toBe("widget_spy");
+    expect(payload.html).toContain("Grackle");
+    expect(payload.csp?.resourceDomains?.length).toBe(1);
+    expect(payload.toolInput).toMatchObject({ message: "hi widget" });
+    expect(payload.toolResult).toBeTruthy();
+  });
+
+  it("does not emit a widget event for a non-widget tool", async () => {
+    const widgetCalls: WidgetCall[] = [];
+    const plainSpy = makeSpyTool("workspace_spy", "workspace", [], z.object({ workspaceId: z.string() }));
+    server = await startServer(
+      [[plainSpy]],
+      (sessionId, payload) => { widgetCalls.push({ sessionId, payload } as WidgetCall); },
+    );
+    const scopedToken = createScopedToken(
+      { sub: ROOT_TASK_ID, pid: "default-ws", per: "system", sid: "sess-plain" },
+      TEST_API_KEY,
+    );
+    const authHeader = `Bearer ${scopedToken}`;
+    const sessionId = await initialize(server, authHeader);
+    await callTool(server, sessionId, "workspace_spy", { workspaceId: "ws-1" }, authHeader);
+
+    expect(widgetCalls).toHaveLength(0);
   });
 });

--- a/packages/mcp/src/mcp-server.test.ts
+++ b/packages/mcp/src/mcp-server.test.ts
@@ -734,13 +734,28 @@ describe("MCP Apps app-side (#1237)", () => {
     expect(widget!._meta?.["ui/resourceUri"]).toBe(HELLO_URI);
   });
 
-  it("hides the widget tool from non-UI hosts but keeps data tools", async () => {
+  it("hides the widget tool from non-UI hosts in standalone mode (no broker)", async () => {
+    // No publishWidgetEvent injected → standalone MCP server → spec-compliant
+    // client-capability gating: a client that does not advertise the ui ext does
+    // not see widget tools (it could not render them).
     server = await startServer();
     const { sessionId } = await initializeWith(server, {});
     const response = await rpc(server, sessionId, "tools/list", {});
     const names = ((response.result?.tools ?? []) as Array<{ name: string }>).map((t) => t.name);
     expect(names).not.toContain("show_hello_widget");
     expect(names).toContain("get_version_status");
+  });
+
+  it("exposes the widget tool to a non-UI host when the broker is active", async () => {
+    // Grackle's broker (publishWidgetEvent injected) is itself the ui-capable
+    // host: it captures the widget call and renders it in the chat, so the
+    // agent's MCP client (e.g. the Claude Agent SDK, which does not advertise the
+    // ui ext) still gets the widget tool listed.
+    server = await startServer(undefined, () => {});
+    const { sessionId } = await initializeWith(server, {});
+    const response = await rpc(server, sessionId, "tools/list", {});
+    const names = ((response.result?.tools ?? []) as Array<{ name: string }>).map((t) => t.name);
+    expect(names).toContain("show_hello_widget");
   });
 
   it("serves the widget JS assets without auth", async () => {

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -174,9 +174,15 @@ async function createMcpServerInstance(
   const uiToolNames = new Set(visibleTools.filter((t) => t.uiResourceUri).map((t) => t.name));
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    // Gate widget tools on the host advertising the io.modelcontextprotocol/ui
-    // extension (known only after initialize). Non-UI hosts see the rest.
-    const uiOn = hostSupportsUiApps(server.getClientCapabilities());
+    // Expose widget tools when EITHER:
+    //  (a) the broker is active (publishWidgetEvent injected) — Grackle is itself
+    //      the ui-capable host. It captures the widget call and renders it in the
+    //      chat, so the agent's own MCP client (a mere conduit here) need not
+    //      advertise the io.modelcontextprotocol/ui extension; or
+    //  (b) the connecting client advertises that extension — the spec-compliant
+    //      path for the standalone MCP server, where the client renders the
+    //      widget itself.
+    const uiOn = publishWidgetEvent !== undefined || hostSupportsUiApps(server.getClientCapabilities());
     const tools = uiOn ? visibleToolDefs : visibleToolDefs.filter((t) => !uiToolNames.has(t.name));
     return { tools };
   });

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -44,6 +44,23 @@ const logger: Logger = pino({
     : undefined,
 });
 
+/**
+ * Pushes an MCP Apps widget render event into a session's stream. Injected by the
+ * server (wraps `@grackle-ai/core`'s `publishWidgetEvent`). Declared structurally
+ * to avoid widening this package's runtime dependencies onto core.
+ */
+export type PublishWidgetEvent = (
+  sessionId: string,
+  payload: {
+    resourceUri: string;
+    toolName: string;
+    html: string;
+    csp?: unknown;
+    toolInput?: Record<string, unknown>;
+    toolResult?: unknown;
+  },
+) => void;
+
 /** Options for creating an MCP server. */
 export interface McpServerOptions {
   /** Host address to bind the MCP server to. */
@@ -58,6 +75,8 @@ export interface McpServerOptions {
   authorizationServerUrl?: string;
   /** Optional plugin-contributed tool groups to register alongside built-in tools. */
   toolGroups?: ToolDefinition[][];
+  /** Push MCP Apps widget render events into session streams (in-process, from the server). */
+  publishWidgetEvent?: PublishWidgetEvent;
 }
 
 /** Create per-service ConnectRPC clients pointing at the co-located Grackle gRPC server. */
@@ -119,6 +138,7 @@ async function createMcpServerInstance(
   grpcClients: GrackleClients,
   authContext: AuthContext,
   assetBaseUrl: string,
+  publishWidgetEvent: PublishWidgetEvent | undefined,
   toolGroups?: ToolDefinition[][],
 ): Promise<Server> {
   const registry = createToolRegistry(toolGroups);
@@ -293,6 +313,26 @@ async function createMcpServerInstance(
     try {
       logger.info({ tool: name, resolved: tool.name }, "Executing MCP tool: %s", name);
       const result = await tool.handler(parsed.data as Record<string, unknown>, grpcClients, authContext);
+      // MCP Apps: when a session agent invokes a widget tool, push a self-contained
+      // widget render event into that session's stream (broker capture — does not
+      // depend on the agent SDK preserving _meta). Non-fatal.
+      if (tool.uiResourceUri && authContext.type === "scoped" && publishWidgetEvent) {
+        try {
+          const resource = resourceRegistry.get(tool.uiResourceUri);
+          if (resource) {
+            publishWidgetEvent(authContext.taskSessionId, {
+              resourceUri: tool.uiResourceUri,
+              toolName: tool.name,
+              html: resource.read().text,
+              csp: { resourceDomains: [assetBaseUrl], connectDomains: [assetBaseUrl] },
+              toolInput: parsed.data as Record<string, unknown>,
+              toolResult: result,
+            });
+          }
+        } catch (widgetErr) {
+          logger.warn({ tool: name, err: widgetErr }, "Widget event capture failed (non-fatal)");
+        }
+      }
       return result as CallToolResult;
     } catch (error: unknown) {
       logger.error({ tool: name, err: error }, "Tool execution failed: %s", name);
@@ -321,7 +361,7 @@ const REVOCATION_PRUNE_INTERVAL_MS: number = 60 * 60 * 1000;
  * and Server instance, tracked by session ID.
  */
 export function createMcpServer(options: McpServerOptions): http.Server {
-  const { bindHost, grpcPort, apiKey, authorizationServerUrl, toolGroups } = options;
+  const { bindHost, grpcPort, apiKey, authorizationServerUrl, toolGroups, publishWidgetEvent } = options;
   /** Parsed auth server URL, used for dynamic derivation of authorization_servers. */
   const parsedAuthServerUrl = authorizationServerUrl
     ? new URL(authorizationServerUrl)
@@ -395,7 +435,7 @@ export function createMcpServer(options: McpServerOptions): http.Server {
     const method = req.method?.toUpperCase();
 
     if (method === "POST") {
-      await handlePost(req, res, grpcClients, transports, authContexts, authContext, toolGroups);
+      await handlePost(req, res, grpcClients, transports, authContexts, authContext, publishWidgetEvent, toolGroups);
     } else if (method === "GET") {
       await handleGet(req, res, transports);
     } else if (method === "DELETE") {
@@ -470,6 +510,7 @@ async function handlePost(
   transports: Map<string, StreamableHTTPServerTransport>,
   authContexts: Map<string, AuthContext>,
   authContext: AuthContext,
+  publishWidgetEvent: PublishWidgetEvent | undefined,
   toolGroups?: ToolDefinition[][],
 ): Promise<void> {
   try {
@@ -516,7 +557,7 @@ async function handlePost(
       // avoid attribute injection from a hostile Host header.
       const encrypted = "encrypted" in req.socket && (req.socket as { encrypted?: boolean }).encrypted === true;
       const assetBaseUrl = resolveAssetBaseUrl(req.headers.host, req.headers["x-forwarded-proto"], encrypted);
-      const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, toolGroups);
+      const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, publishWidgetEvent, toolGroups);
       await mcpServer.connect(transport);
       await transport.handleRequest(req, res, body);
       return;

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -73,6 +73,13 @@ export interface McpServerOptions {
   apiKey: string;
   /** Base URL of the OAuth authorization server (web server). When set, enables OAuth discovery. */
   authorizationServerUrl?: string;
+  /**
+   * Explicit browser-facing MCP origin (GRACKLE_MCP_ORIGIN), e.g.
+   * `https://mcp.example.com`. Used as the trusted asset/CSP origin for
+   * broker-captured widgets so it never depends on the (spoofable) request
+   * `Host` header. When unset, the broker derives it from `bindHost` + `mcpPort`.
+   */
+  mcpOrigin?: string;
   /** Optional plugin-contributed tool groups to register alongside built-in tools. */
   toolGroups?: ToolDefinition[][];
   /** Push MCP Apps widget render events into session streams (in-process, from the server). */
@@ -138,11 +145,16 @@ async function createMcpServerInstance(
   grpcClients: GrackleClients,
   authContext: AuthContext,
   assetBaseUrl: string,
+  brokerAssetOrigin: string,
   publishWidgetEvent: PublishWidgetEvent | undefined,
   toolGroups?: ToolDefinition[][],
 ): Promise<Server> {
   const registry = createToolRegistry(toolGroups);
-  const resourceRegistry = createResourceRegistry(assetBaseUrl);
+  // In broker mode the captured widget's asset/CSP origin must be the trusted,
+  // browser-facing MCP origin (config-derived), never the request Host. In
+  // standalone mode the direct client reached us on `assetBaseUrl`, so use that.
+  const widgetAssetOrigin: string = publishWidgetEvent !== undefined ? brokerAssetOrigin : assetBaseUrl;
+  const resourceRegistry = createResourceRegistry(widgetAssetOrigin);
 
   // Resolve persona-scoped tool set once at session creation (cached for session lifetime)
   const personaAllowedTools = await resolvePersonaTools(grpcClients, authContext);
@@ -330,7 +342,7 @@ async function createMcpServerInstance(
               resourceUri: tool.uiResourceUri,
               toolName: tool.name,
               html: resource.read().text,
-              csp: { resourceDomains: [assetBaseUrl], connectDomains: [assetBaseUrl] },
+              csp: { resourceDomains: [widgetAssetOrigin], connectDomains: [widgetAssetOrigin] },
               toolInput: parsed.data as Record<string, unknown>,
               toolResult: result,
             });
@@ -367,7 +379,14 @@ const REVOCATION_PRUNE_INTERVAL_MS: number = 60 * 60 * 1000;
  * and Server instance, tracked by session ID.
  */
 export function createMcpServer(options: McpServerOptions): http.Server {
-  const { bindHost, grpcPort, apiKey, authorizationServerUrl, toolGroups, publishWidgetEvent } = options;
+  const { bindHost, mcpPort, grpcPort, apiKey, authorizationServerUrl, toolGroups, publishWidgetEvent, mcpOrigin } = options;
+  // Trusted, browser-facing MCP origin for broker-captured widgets (their
+  // `<script src>` + CSP allowlist). Derived from server config — NOT the request
+  // `Host` header, which a hostile MCP client could spoof to point widget assets
+  // / CSP at an attacker origin. Override via GRACKLE_MCP_ORIGIN for
+  // reverse-proxy / TLS deployments where loopback isn't browser-reachable.
+  const dialableMcpHost: string = bindHost === "0.0.0.0" || bindHost === "::" ? "127.0.0.1" : bindHost;
+  const brokerAssetOrigin: string = mcpOrigin ?? `http://${dialableMcpHost}:${mcpPort}`;
   /** Parsed auth server URL, used for dynamic derivation of authorization_servers. */
   const parsedAuthServerUrl = authorizationServerUrl
     ? new URL(authorizationServerUrl)
@@ -441,7 +460,7 @@ export function createMcpServer(options: McpServerOptions): http.Server {
     const method = req.method?.toUpperCase();
 
     if (method === "POST") {
-      await handlePost(req, res, grpcClients, transports, authContexts, authContext, publishWidgetEvent, toolGroups);
+      await handlePost(req, res, grpcClients, transports, authContexts, authContext, publishWidgetEvent, brokerAssetOrigin, toolGroups);
     } else if (method === "GET") {
       await handleGet(req, res, transports);
     } else if (method === "DELETE") {
@@ -517,6 +536,7 @@ async function handlePost(
   authContexts: Map<string, AuthContext>,
   authContext: AuthContext,
   publishWidgetEvent: PublishWidgetEvent | undefined,
+  brokerAssetOrigin: string,
   toolGroups?: ToolDefinition[][],
 ): Promise<void> {
   try {
@@ -563,7 +583,7 @@ async function handlePost(
       // avoid attribute injection from a hostile Host header.
       const encrypted = "encrypted" in req.socket && (req.socket as { encrypted?: boolean }).encrypted === true;
       const assetBaseUrl = resolveAssetBaseUrl(req.headers.host, req.headers["x-forwarded-proto"], encrypted);
-      const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, publishWidgetEvent, toolGroups);
+      const mcpServer = await createMcpServerInstance(grpcClients, authContext, assetBaseUrl, brokerAssetOrigin, publishWidgetEvent, toolGroups);
       await mcpServer.connect(transport);
       await transport.handleRequest(req, res, body);
       return;

--- a/packages/mcp/src/tool-scoping.test.ts
+++ b/packages/mcp/src/tool-scoping.test.ts
@@ -72,6 +72,7 @@ describe("SCOPED_TOOLS", () => {
       "persona_list", "persona_show",
       "schedule_list", "schedule_show",
       "session_attach", "session_send_input",
+      "show_hello_widget",
       "task_complete", "task_create", "task_list", "task_search", "task_show", "task_start",
       "workpad_read", "workpad_write",
     ]);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SERVER_PORT, DEFAULT_WEB_PORT, DEFAULT_MCP_PORT, DEFAULT_POWERLINE_PORT } from "@grackle-ai/common";
+import { DEFAULT_SERVER_PORT, DEFAULT_WEB_PORT, DEFAULT_MCP_PORT, DEFAULT_POWERLINE_PORT, DEFAULT_SANDBOX_PORT } from "@grackle-ai/common";
 
 /** Validated server configuration resolved from environment variables. */
 export interface ServerConfig {
@@ -8,6 +8,8 @@ export interface ServerConfig {
   webPort: number;
   /** MCP server port (GRACKLE_MCP_PORT). */
   mcpPort: number;
+  /** MCP Apps widget sandbox port (GRACKLE_SANDBOX_PORT). */
+  sandboxPort: number;
   /** PowerLine server port (GRACKLE_POWERLINE_PORT). */
   powerlinePort: number;
   /** Bind address for all servers (GRACKLE_HOST). */
@@ -57,6 +59,7 @@ export function resolveServerConfig(): ServerConfig {
     grpcPort: parsePort("GRACKLE_PORT", DEFAULT_SERVER_PORT),
     webPort: parsePort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
     mcpPort: parsePort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
+    sandboxPort: parsePort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
     powerlinePort: parsePort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT),
     host: process.env.GRACKLE_HOST || "127.0.0.1",
     skipLocalPowerline: parseFlag("GRACKLE_SKIP_LOCAL_POWERLINE"),

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -8,6 +8,13 @@ export interface ServerConfig {
   webPort: number;
   /** MCP server port (GRACKLE_MCP_PORT). */
   mcpPort: number;
+  /**
+   * Explicit browser-facing MCP origin (GRACKLE_MCP_ORIGIN), e.g.
+   * `https://mcp.example.com`. Used as the trusted asset/CSP origin for
+   * broker-captured MCP Apps widgets (so it never depends on the request `Host`).
+   * When unset, the broker derives it from the bind host + `mcpPort`.
+   */
+  mcpOrigin?: string;
   /** MCP Apps widget sandbox port (GRACKLE_SANDBOX_PORT). */
   sandboxPort: number;
   /**
@@ -67,6 +74,7 @@ export function resolveServerConfig(): ServerConfig {
     grpcPort: parsePort("GRACKLE_PORT", DEFAULT_SERVER_PORT),
     webPort: parsePort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
     mcpPort: parsePort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
+    ...(process.env.GRACKLE_MCP_ORIGIN ? { mcpOrigin: process.env.GRACKLE_MCP_ORIGIN } : {}),
     sandboxPort: parsePort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
     ...(process.env.GRACKLE_SANDBOX_ORIGIN ? { sandboxOrigin: process.env.GRACKLE_SANDBOX_ORIGIN } : {}),
     powerlinePort: parsePort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT),

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -10,6 +10,14 @@ export interface ServerConfig {
   mcpPort: number;
   /** MCP Apps widget sandbox port (GRACKLE_SANDBOX_PORT). */
   sandboxPort: number;
+  /**
+   * Explicit browser-facing sandbox origin (GRACKLE_SANDBOX_ORIGIN), e.g.
+   * `https://sandbox.example.com`. Set this when the SPA is served behind a
+   * reverse proxy / TLS, where the scheme + port the browser must use for the
+   * sandbox cannot be inferred from the page's own origin + `sandboxPort`.
+   * When unset, the SPA derives the origin from `window.location` + `sandboxPort`.
+   */
+  sandboxOrigin?: string;
   /** PowerLine server port (GRACKLE_POWERLINE_PORT). */
   powerlinePort: number;
   /** Bind address for all servers (GRACKLE_HOST). */
@@ -60,6 +68,7 @@ export function resolveServerConfig(): ServerConfig {
     webPort: parsePort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
     mcpPort: parsePort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
     sandboxPort: parsePort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
+    ...(process.env.GRACKLE_SANDBOX_ORIGIN ? { sandboxOrigin: process.env.GRACKLE_SANDBOX_ORIGIN } : {}),
     powerlinePort: parsePort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT),
     host: process.env.GRACKLE_HOST || "127.0.0.1",
     skipLocalPowerline: parseFlag("GRACKLE_SKIP_LOCAL_POWERLINE"),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,7 @@ import {
   logger, exec, detectLanIp,
   runWithTrace, isValidTraceId, wrapAsyncIterableWithTrace,
   importAccountsFromGhCli,
+  publishWidgetEvent,
 } from "@grackle-ai/core";
 import { createKnowledgePlugin, getKnowledgeReadinessCheck } from "@grackle-ai/plugin-knowledge";
 import { loadPlugins, type PluginContext } from "@grackle-ai/plugin-sdk";
@@ -27,7 +28,7 @@ import {
   startPairingCleanup,
   startOAuthCleanup,
 } from "@grackle-ai/auth";
-import { createWebServer, isWildcardAddress, type ReadinessResult } from "@grackle-ai/web-server";
+import { createWebServer, createSandboxServer, isWildcardAddress, type ReadinessResult } from "@grackle-ai/web-server";
 import { createRequire } from "node:module";
 import { initializeDatabase } from "./database-init.js";
 import { registerAllAdapters } from "./adapter-registry.js";
@@ -245,6 +246,7 @@ async function main(): Promise<void> {
     bindHost,
     connectRoutes: routes,
     pluginNames: loaded.pluginNames,
+    sandboxPort: config.sandboxPort,
     readinessCheck: (): ReadinessResult => {
       const checks: ReadinessResult["checks"] = {};
       try {
@@ -329,7 +331,7 @@ async function main(): Promise<void> {
         return t as unknown as ToolDefinition;
       })]
     : [];
-  const mcpServer = createMcpServer({ bindHost, mcpPort, grpcPort, apiKey, authorizationServerUrl: authServerUrl, toolGroups: pluginToolGroups });
+  const mcpServer = createMcpServer({ bindHost, mcpPort, grpcPort, apiKey, authorizationServerUrl: authServerUrl, toolGroups: pluginToolGroups, publishWidgetEvent });
 
   mcpServer.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
@@ -345,11 +347,28 @@ async function main(): Promise<void> {
     logger.info({ port: mcpPort, host: bindHost }, "MCP server on http://%s:%d/mcp", urlHost, mcpPort);
   });
 
+  // --- MCP Apps widget sandbox server (separate origin) ---
+  const sandboxPort = config.sandboxPort;
+  const sandboxServer = createSandboxServer({ bindHost, sandboxPort });
+  sandboxServer.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      logger.fatal({ port: sandboxPort }, "Port %d is already in use. Is another Grackle server running?", sandboxPort);
+    } else {
+      logger.fatal({ err }, "Sandbox server error");
+    }
+    process.exitCode = 1;
+    shutdown().catch(() => { process.exit(1); });
+  });
+  sandboxServer.listen(sandboxPort, bindHost, () => {
+    logger.info({ port: sandboxPort, host: bindHost }, "MCP Apps sandbox on http://%s:%d/sandbox.html", urlHost, sandboxPort);
+  });
+
   // --- Graceful shutdown ---
   shutdown = createShutdown({
     grpcServer,
     webServer,
     mcpServer,
+    sandboxServer,
     reconciliationManager,
     localPowerLineManager,
     pluginShutdown: loaded.shutdown,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -247,6 +247,7 @@ async function main(): Promise<void> {
     connectRoutes: routes,
     pluginNames: loaded.pluginNames,
     sandboxPort: config.sandboxPort,
+    ...(config.sandboxOrigin !== undefined ? { sandboxOrigin: config.sandboxOrigin } : {}),
     readinessCheck: (): ReadinessResult => {
       const checks: ReadinessResult["checks"] = {};
       try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -332,7 +332,7 @@ async function main(): Promise<void> {
         return t as unknown as ToolDefinition;
       })]
     : [];
-  const mcpServer = createMcpServer({ bindHost, mcpPort, grpcPort, apiKey, authorizationServerUrl: authServerUrl, toolGroups: pluginToolGroups, publishWidgetEvent });
+  const mcpServer = createMcpServer({ bindHost, mcpPort, grpcPort, apiKey, authorizationServerUrl: authServerUrl, toolGroups: pluginToolGroups, publishWidgetEvent, ...(config.mcpOrigin !== undefined ? { mcpOrigin: config.mcpOrigin } : {}) });
 
   mcpServer.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {

--- a/packages/server/src/shutdown.test.ts
+++ b/packages/server/src/shutdown.test.ts
@@ -54,6 +54,7 @@ function createMockContext(overrides?: Partial<ShutdownContext>): ShutdownContex
     grpcServer: { close: vi.fn((cb: (err?: Error) => void) => { cb(); }) },
     webServer: { close: vi.fn((cb: (err?: Error) => void) => { cb(); }) },
     mcpServer: { close: vi.fn((cb: (err?: Error) => void) => { cb(); }) },
+    sandboxServer: { close: vi.fn((cb: (err?: Error) => void) => { cb(); }) },
     reconciliationManager: { stop: vi.fn(async () => {}) },
     localPowerLineManager: { stop: vi.fn(async () => {}) },
     ...overrides,
@@ -145,6 +146,13 @@ describe("createShutdown", () => {
     const shutdown = createShutdown(ctx);
     await shutdown();
     expect(ctx.mcpServer.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes the MCP Apps sandbox server", async () => {
+    const ctx = createMockContext();
+    const shutdown = createShutdown(ctx);
+    await shutdown();
+    expect(ctx.sandboxServer.close).toHaveBeenCalledOnce();
   });
 
   it("handles server close errors gracefully", async () => {

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -19,6 +19,8 @@ export interface ShutdownContext {
   webServer: Closeable;
   /** The HTTP/1.1 MCP server. */
   mcpServer: Closeable;
+  /** The HTTP/1.1 MCP Apps widget sandbox server. */
+  sandboxServer: Closeable;
   /** The reconciliation manager (cron, orphan, lifecycle phases). */
   reconciliationManager: { stop: () => Promise<void> };
   /** The local PowerLine child-process manager, if running. */
@@ -79,6 +81,15 @@ export function createShutdown(context: ShutdownContext): () => Promise<void> {
       context.mcpServer.close((err?: Error) => {
         if (err) {
           logger.error({ err }, "Error while closing MCP server");
+        }
+        resolve();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      context.sandboxServer.close((err?: Error) => {
+        if (err) {
+          logger.error({ err }, "Error while closing sandbox server");
         }
         resolve();
       });

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -34,7 +34,7 @@ Components are grouped by area under `src/components/`:
 |----------|----------|
 | **Display primitives** | `Button`, `SplitButton`, `CopyButton`, `Tooltip`, `Breadcrumbs`, `ConfirmDialog`, `Skeleton`, `Spinner`, `SplashScreen`, `FloatingActionBar` |
 | **Event stream** | `EventStream`, `EventRenderer`, `EventHoverRow`, `SessionPicker`, `SessionAttemptSelector` |
-| **MCP Apps widgets** | `McpAppWidget` (host renderer for `ui://` widgets in a sandboxed iframe), `grackleHostStyleVariables`. `EventRenderer` renders `widget` events via `McpAppWidget` (lazy-loaded; pass `sandboxProxyUrl`). |
+| **MCP Apps widgets** | `widget` events render in a sandboxed iframe via `EventRenderer`/`EventStream` — pass `sandboxProxyUrl`. The host renderer `McpAppWidget` is loaded internally (lazy/code-split) and is **not** a value export; only its prop types (`McpAppWidgetProps`) and `grackleHostStyleVariables` are exported. |
 | **Tool cards** | `ToolCard`, `FileEditCard`, `FileReadCard`, `ShellCard`, `SearchCard`, `TodoCard`, `MetadataCard`, `AgentToolCard`, `GenericToolCard` |
 | **Layout** | `AppNav`, `Sidebar`, `StatusBar`, `BottomStatusBar` |
 | **Lists** | `TaskList`, `EnvironmentNav`, `FindingsNav` |

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -34,6 +34,7 @@ Components are grouped by area under `src/components/`:
 |----------|----------|
 | **Display primitives** | `Button`, `SplitButton`, `CopyButton`, `Tooltip`, `Breadcrumbs`, `ConfirmDialog`, `Skeleton`, `Spinner`, `SplashScreen`, `FloatingActionBar` |
 | **Event stream** | `EventStream`, `EventRenderer`, `EventHoverRow`, `SessionPicker`, `SessionAttemptSelector` |
+| **MCP Apps widgets** | `McpAppWidget` (host renderer for `ui://` widgets in a sandboxed iframe), `grackleHostStyleVariables`. `EventRenderer` renders `widget` events via `McpAppWidget` (lazy-loaded; pass `sandboxProxyUrl`). |
 | **Tool cards** | `ToolCard`, `FileEditCard`, `FileReadCard`, `ShellCard`, `SearchCard`, `TodoCard`, `MetadataCard`, `AgentToolCard`, `GenericToolCard` |
 | **Layout** | `AppNav`, `Sidebar`, `StatusBar`, `BottomStatusBar` |
 | **Lists** | `TaskList`, `EnvironmentNav`, `FindingsNav` |

--- a/packages/web-components/src/components/display/EventRenderer.stories.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.stories.tsx
@@ -170,6 +170,28 @@ export const MarkdownParagraphWrapping: Story = {
   },
 };
 
+/** Widget event renders the lazy-loaded MCP App host iframe. */
+export const WidgetEvent: Story = {
+  args: {
+    event: makeEvent({
+      eventType: "widget",
+      content: JSON.stringify({
+        resourceUri: "ui://grackle/hello-widget",
+        toolName: "show_hello_widget",
+        html: "<!doctype html><html><body><div class=\"card\">widget</div></body></html>",
+        toolInput: { message: "hi" },
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      }),
+    }),
+    // Different origin than Storybook (6006) so McpAppWidget's same-origin guard passes.
+    sandboxProxyUrl: "http://localhost:6007/sandbox.html",
+  },
+  play: async ({ canvas }) => {
+    // McpAppWidget is lazy-loaded behind Suspense; findByTestId waits for the chunk.
+    await expect(await canvas.findByTestId("mcp-app-widget")).toBeInTheDocument();
+  },
+};
+
 /** System context event renders as collapsible prompt. */
 export const SystemContext: Story = {
   args: {

--- a/packages/web-components/src/components/display/EventRenderer.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, type JSX } from "react";
+import { type ReactNode, useState, lazy, Suspense, type LazyExoticComponent, type ComponentType, type JSX } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import Markdown from "react-markdown";
 import rehypePrismPlus from "rehype-prism-plus/common";
@@ -7,8 +7,18 @@ import type { SessionEvent } from "../../hooks/types.js";
 import { formatTokens, formatCost } from "../../utils/format.js";
 import { ICON_SM } from "../../utils/iconSize.js";
 import { ToolCard } from "../tools/ToolCard.js";
+import type { McpAppWidgetProps } from "./McpAppWidget.js";
+import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CopyButton } from "./CopyButton.js";
 import styles from "./EventRenderer.module.scss";
+
+// Lazy-loaded (and intentionally NOT re-exported from the package barrel) so the
+// heavy ext-apps AppBridge is code-split into an async chunk loaded only when a
+// widget actually renders — keeps the main chat bundle under the chunk-size cap.
+const McpAppWidget: LazyExoticComponent<ComponentType<McpAppWidgetProps>> = lazy(() =>
+  import("./McpAppWidget.js").then((m) => ({ default: m.McpAppWidget })),
+);
 
 /** Props for the EventRenderer component. */
 interface Props {
@@ -17,6 +27,8 @@ interface Props {
   toolUseCtx?: { tool: string; args: unknown; detailedResult?: string };
   /** True when a tool_use completed but has no tool_result (e.g. Claude Code text-result pattern). */
   settled?: boolean;
+  /** Sandbox proxy origin URL for rendering MCP Apps widget events (different origin than the app). */
+  sandboxProxyUrl?: string;
 }
 
 // --- Individual event type renderers ---
@@ -187,10 +199,40 @@ function DefaultEvent({ content }: { content: string }): JSX.Element {
 // --- Main component ---
 
 /** Renders a single session event, dispatching to the appropriate type-specific renderer. */
-export function EventRenderer({ event, toolUseCtx, settled }: Props): JSX.Element {
+export function EventRenderer({ event, toolUseCtx, settled, sandboxProxyUrl }: Props): JSX.Element {
   const time = new Date(event.timestamp).toLocaleTimeString();
 
   switch (event.eventType) {
+    case "widget": {
+      // MCP Apps widget event (pushed by the broker). Self-contained: HTML +
+      // tool input/result. Renders in the cross-origin sandbox via McpAppWidget.
+      if (!sandboxProxyUrl) {
+        return <DefaultEvent content={event.content} />;
+      }
+      let payload: {
+        html?: string;
+        csp?: McpUiResourceCsp;
+        toolInput?: Record<string, unknown>;
+        toolResult?: CallToolResult;
+      } = {};
+      try {
+        payload = JSON.parse(event.content) as typeof payload;
+      } catch { /* malformed widget payload — fall back */ }
+      if (!payload.html) {
+        return <DefaultEvent content={event.content} />;
+      }
+      return (
+        <Suspense fallback={<DefaultEvent content="Loading widget..." />}>
+          <McpAppWidget
+            widgetHtml={payload.html}
+            sandboxProxyUrl={sandboxProxyUrl}
+            csp={payload.csp}
+            toolInput={payload.toolInput}
+            toolResult={payload.toolResult}
+          />
+        </Suspense>
+      );
+    }
     case "system": {
       // Detect system context events via the raw metadata marker
       if (event.raw) {

--- a/packages/web-components/src/components/display/EventStream.tsx
+++ b/packages/web-components/src/components/display/EventStream.tsx
@@ -88,6 +88,8 @@ interface EventStreamProps {
    * Receives the target session ID and the formatted envelope text.
    */
   onForward?: (sessionId: string, text: string) => Promise<void>;
+  /** Sandbox proxy origin URL for rendering MCP Apps widget events. */
+  sandboxProxyUrl?: string;
 }
 
 /**
@@ -104,6 +106,7 @@ export function EventStream({
   environments,
   personas,
   onForward,
+  sandboxProxyUrl,
 }: EventStreamProps): JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isReversed, setIsReversed] = useState(readStoredDirection);
@@ -303,7 +306,7 @@ export function EventStream({
                   onToggle={(shiftKey) => { selection.toggleEvent(originalIndex, shiftKey); }}
                   onCopied={() => { onShowToast?.("Copied to clipboard", "success"); }}
                 >
-                  <EventRenderer event={event} toolUseCtx={event.toolUseCtx} settled={event.settled} />
+                  <EventRenderer event={event} toolUseCtx={event.toolUseCtx} settled={event.settled} sandboxProxyUrl={sandboxProxyUrl} />
                 </EventHoverRow>
               </motion.div>
             );

--- a/packages/web-components/src/components/display/index.ts
+++ b/packages/web-components/src/components/display/index.ts
@@ -14,7 +14,9 @@ export { Spinner } from "./Spinner.js";
 export { SplashScreen } from "./SplashScreen.js";
 export { Tooltip } from "./Tooltip.js";
 export { SessionAttemptSelector } from "./SessionAttemptSelector.js";
-export { McpAppWidget } from "./McpAppWidget.js";
+// NOTE: McpAppWidget is intentionally NOT re-exported as a value — EventRenderer
+// lazy-imports it directly so the heavy ext-apps AppBridge stays code-split out of
+// the main chat bundle. Its prop types remain exported below for consumers.
 
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button.js";
 export type { TooltipProps, TooltipPlacement } from "./Tooltip.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -19,7 +19,7 @@ export { useDagLayout } from "./components/dag/useDagLayout.js";
 export {
   Breadcrumbs, Button, CopyButton, DemoBanner, SplitButton,
   EventRenderer, ConfirmDialog, Skeleton, SkeletonText, SkeletonCard,
-  Spinner, SplashScreen, Tooltip, McpAppWidget,
+  Spinner, SplashScreen, Tooltip,
 } from "./components/display/index.js";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/display/index.js";
 export type { TooltipProps, TooltipPlacement } from "./components/display/index.js";

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -39,7 +39,8 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@grackle-ai/auth": "workspace:*",
-    "@grackle-ai/web": "workspace:*"
+    "@grackle-ai/web": "workspace:*",
+    "@grackle-ai/web-components": "workspace:*"
   },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",

--- a/packages/web-server/src/index.ts
+++ b/packages/web-server/src/index.ts
@@ -1,3 +1,7 @@
 export { createWebServer } from "./web-server.js";
 export type { WebServerOptions, ReadinessResult, ReadinessCheck } from "./web-server.js";
 export { isWildcardAddress } from "./web-server.js";
+export { createSandboxServer } from "./sandbox-server.js";
+export type { SandboxServerOptions } from "./sandbox-server.js";
+export { buildCspHeader } from "./sandbox-csp.js";
+export type { SandboxCsp } from "./sandbox-csp.js";

--- a/packages/web-server/src/sandbox-csp.test.ts
+++ b/packages/web-server/src/sandbox-csp.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { buildCspHeader } from "./sandbox-csp.js";
+
+describe("buildCspHeader", () => {
+  it("locks down by default (no domains)", () => {
+    const csp = buildCspHeader(undefined);
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self' blob:");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    // No unsafe-inline / unsafe-eval in script-src.
+    expect(csp).not.toMatch(/script-src[^;]*unsafe-inline/);
+    expect(csp).not.toMatch(/script-src[^;]*unsafe-eval/);
+  });
+
+  it("widens script-src + connect-src with allowed domains", () => {
+    const csp = buildCspHeader({
+      resourceDomains: ["http://127.0.0.1:7435"],
+      connectDomains: ["http://127.0.0.1:7435"],
+    });
+    expect(csp).toContain("script-src 'self' blob: http://127.0.0.1:7435");
+    expect(csp).toContain("connect-src 'self' http://127.0.0.1:7435");
+  });
+
+  it("sanitizes domain entries that could break out of a directive", () => {
+    const csp = buildCspHeader({
+      resourceDomains: ["http://ok.example", "evil.com; script-src *", "has space", "has\"quote"],
+    });
+    expect(csp).toContain("http://ok.example");
+    expect(csp).not.toContain("evil.com");
+    expect(csp).not.toContain("has space");
+    expect(csp).not.toContain('has"quote');
+  });
+
+  it("allows inline styles (widgets use <style>) but not inline scripts", () => {
+    const csp = buildCspHeader(undefined);
+    expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/);
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+  });
+});

--- a/packages/web-server/src/sandbox-csp.test.ts
+++ b/packages/web-server/src/sandbox-csp.test.ts
@@ -33,6 +33,27 @@ describe("buildCspHeader", () => {
     expect(csp).not.toContain('has"quote');
   });
 
+  it("rejects non-origin sources (wildcards, scheme-only, paths)", () => {
+    const csp = buildCspHeader({
+      resourceDomains: [
+        "*",
+        "data:",
+        "blob:",
+        "https:",
+        "http://ok.example/some/path",
+        "http://ok.example?q=1",
+        "https://good.example",
+      ],
+    });
+    // Only the bare http(s) origin survives.
+    expect(csp).toContain("https://good.example");
+    expect(csp).not.toMatch(/script-src[^;]*\*/);
+    expect(csp).not.toMatch(/script-src[^;]*data:/);
+    expect(csp).not.toMatch(/script-src[^;]*blob: blob:/); // no duplicate scheme-only blob
+    expect(csp).not.toContain("/some/path");
+    expect(csp).not.toContain("?q=1");
+  });
+
   it("allows inline styles (widgets use <style>) but not inline scripts", () => {
     const csp = buildCspHeader(undefined);
     expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/);

--- a/packages/web-server/src/sandbox-csp.ts
+++ b/packages/web-server/src/sandbox-csp.ts
@@ -1,0 +1,51 @@
+/**
+ * Content-Security-Policy builder for the MCP Apps sandbox origin.
+ *
+ * Ported from the T1 Storybook sidecar (`@grackle-ai/web-components`
+ * `mcp-app-sandbox/serve.mjs`) — kept in TS here so the production sandbox server
+ * can unit-test it. The CSP locks down the inner widget: `script-src 'self' blob:`
+ * (no `unsafe-inline`/`unsafe-eval`), widened only by the per-resource domain
+ * allowlists supplied via the `?csp=` query param (`McpUiResourceCsp`).
+ */
+
+/** Subset of MCP Apps `McpUiResourceCsp` honored by the sandbox CSP. */
+export interface SandboxCsp {
+  resourceDomains?: unknown;
+  connectDomains?: unknown;
+  frameDomains?: unknown;
+  baseUriDomains?: unknown;
+}
+
+/** Reject domain entries containing characters that could break out of a CSP directive. */
+function sanitizeCspDomains(domains: unknown): string[] {
+  if (!Array.isArray(domains)) {
+    return [];
+  }
+  return (domains as unknown[]).filter(
+    (d): d is string => typeof d === "string" && !/[;\r\n'" ]/.test(d),
+  );
+}
+
+/**
+ * Build the `Content-Security-Policy` header value from an optional
+ * `McpUiResourceCsp`. Unknown/empty input yields the locked-down default.
+ */
+export function buildCspHeader(csp: SandboxCsp | undefined): string {
+  const resourceDomains: string = sanitizeCspDomains(csp?.resourceDomains).join(" ");
+  const connectDomains: string = sanitizeCspDomains(csp?.connectDomains).join(" ");
+  const frameDomains: string = sanitizeCspDomains(csp?.frameDomains).join(" ");
+  const baseUriDomains: string = sanitizeCspDomains(csp?.baseUriDomains).join(" ");
+  return [
+    "default-src 'self'",
+    `script-src 'self' blob: ${resourceDomains}`.trim(),
+    `style-src 'self' 'unsafe-inline' blob: data: ${resourceDomains}`.trim(),
+    `img-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `font-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `media-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `connect-src 'self' ${connectDomains}`.trim(),
+    `worker-src 'self' blob: ${resourceDomains}`.trim(),
+    frameDomains ? `frame-src ${frameDomains}` : "frame-src 'none'",
+    "object-src 'none'",
+    baseUriDomains ? `base-uri ${baseUriDomains}` : "base-uri 'none'",
+  ].join("; ");
+}

--- a/packages/web-server/src/sandbox-csp.ts
+++ b/packages/web-server/src/sandbox-csp.ts
@@ -16,14 +16,32 @@ export interface SandboxCsp {
   baseUriDomains?: unknown;
 }
 
-/** Reject domain entries containing characters that could break out of a CSP directive. */
+/**
+ * Keep only entries that are bare http(s) origins (e.g. `http://127.0.0.1:7435`).
+ *
+ * The `?csp=` param is host-supplied and may be attacker-influenced, so this is
+ * a strict allowlist: it rejects anything that is not a concrete http(s) origin
+ * — `*`, scheme-only sources (`data:`/`blob:`), wildcards, paths/queries, and
+ * any entry with characters that could break out of a CSP directive. This keeps
+ * it a true per-resource *domain* allowlist that cannot widen the widget's
+ * script/connect surface beyond explicit origins.
+ */
 function sanitizeCspDomains(domains: unknown): string[] {
   if (!Array.isArray(domains)) {
     return [];
   }
-  return (domains as unknown[]).filter(
-    (d): d is string => typeof d === "string" && !/[;\r\n'" ]/.test(d),
-  );
+  return (domains as unknown[]).filter((d): d is string => {
+    if (typeof d !== "string" || /[;\r\n'"* ]/.test(d)) {
+      return false;
+    }
+    try {
+      const url = new URL(d);
+      // Must be a bare origin (no path/query/fragment) over http(s).
+      return (url.protocol === "http:" || url.protocol === "https:") && url.origin === d;
+    } catch {
+      return false;
+    }
+  });
 }
 
 /**

--- a/packages/web-server/src/sandbox-server.test.ts
+++ b/packages/web-server/src/sandbox-server.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createSandboxServer } from "./sandbox-server.js";
+
+/** Make a GET request (with optional Host override) and return response details. */
+function request(
+  server: http.Server,
+  path: string,
+  hostHeader?: string,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo;
+    const headers: Record<string, string> = {};
+    if (hostHeader !== undefined) {
+      headers.Host = hostHeader;
+    }
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path, method: "GET", headers },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        res.on("end", () => resolve({ status: res.statusCode!, headers: res.headers, body }));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("createSandboxServer", () => {
+  let server: http.Server;
+
+  beforeEach(async () => {
+    server = createSandboxServer({ bindHost: "127.0.0.1", sandboxPort: 0 });
+    await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => { server.close(() => resolve()); });
+  });
+
+  it("serves sandbox.html with a locked-down CSP header by default", async () => {
+    const resp = await request(server, "/sandbox.html");
+    expect(resp.status).toBe(200);
+    expect(resp.headers["content-type"]).toContain("text/html");
+    const csp = resp.headers["content-security-policy"] as string;
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self' blob:");
+    expect(csp).not.toContain("unsafe-eval");
+  });
+
+  it("serves the same content at the root path", async () => {
+    const resp = await request(server, "/");
+    expect(resp.status).toBe(200);
+    expect(resp.headers["content-type"]).toContain("text/html");
+    expect(resp.headers["content-security-policy"]).toBeDefined();
+  });
+
+  it("widens the CSP from a ?csp= param of http(s) origins", async () => {
+    const csp = encodeURIComponent(JSON.stringify({
+      resourceDomains: ["http://127.0.0.1:7435"],
+      connectDomains: ["http://127.0.0.1:7435"],
+    }));
+    const resp = await request(server, `/sandbox.html?csp=${csp}`);
+    expect(resp.status).toBe(200);
+    const header = resp.headers["content-security-policy"] as string;
+    expect(header).toContain("script-src 'self' blob: http://127.0.0.1:7435");
+    expect(header).toContain("connect-src 'self' http://127.0.0.1:7435");
+  });
+
+  it("ignores an unparseable ?csp= param and falls back to the locked-down default", async () => {
+    const resp = await request(server, "/sandbox.html?csp=not-json");
+    expect(resp.status).toBe(200);
+    expect(resp.headers["content-security-policy"]).toContain("script-src 'self' blob:");
+  });
+
+  it("serves sandbox-relay.js as javascript", async () => {
+    const resp = await request(server, "/sandbox-relay.js");
+    expect(resp.status).toBe(200);
+    expect(resp.headers["content-type"]).toContain("javascript");
+    expect(resp.body.length).toBeGreaterThan(0);
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    const resp = await request(server, "/secrets");
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns 400 (not a crash) for a malformed Host header", async () => {
+    // A malformed Host makes `new URL` throw; the server must answer 400, not die.
+    const resp = await request(server, "/sandbox.html", "]");
+    expect(resp.status).toBe(400);
+    // Server is still alive for the next request.
+    const ok = await request(server, "/sandbox.html");
+    expect(ok.status).toBe(200);
+  });
+});

--- a/packages/web-server/src/sandbox-server.test.ts
+++ b/packages/web-server/src/sandbox-server.test.ts
@@ -48,6 +48,7 @@ describe("createSandboxServer", () => {
     expect(csp).toContain("default-src 'self'");
     expect(csp).toContain("script-src 'self' blob:");
     expect(csp).not.toContain("unsafe-eval");
+    expect(resp.headers["x-content-type-options"]).toBe("nosniff");
   });
 
   it("serves the same content at the root path", async () => {
@@ -79,6 +80,7 @@ describe("createSandboxServer", () => {
     const resp = await request(server, "/sandbox-relay.js");
     expect(resp.status).toBe(200);
     expect(resp.headers["content-type"]).toContain("javascript");
+    expect(resp.headers["x-content-type-options"]).toBe("nosniff");
     expect(resp.body.length).toBeGreaterThan(0);
   });
 

--- a/packages/web-server/src/sandbox-server.ts
+++ b/packages/web-server/src/sandbox-server.ts
@@ -23,6 +23,8 @@ const JS_HEADERS: Readonly<Record<string, string>> = {
   "Content-Type": "text/javascript; charset=utf-8",
   "Cache-Control": "no-cache, no-store, must-revalidate",
   "Access-Control-Allow-Origin": "*",
+  // This origin serves executable JS + security-sensitive HTML; prevent MIME sniffing.
+  "X-Content-Type-Options": "nosniff",
 };
 
 /**
@@ -72,6 +74,7 @@ export function createSandboxServer(options: SandboxServerOptions): http.Server 
         "Content-Security-Policy": buildCspHeader(csp),
         "Cache-Control": "no-cache, no-store, must-revalidate",
         "Access-Control-Allow-Origin": "*",
+        "X-Content-Type-Options": "nosniff",
       });
       res.end(sandboxHtml);
       return;

--- a/packages/web-server/src/sandbox-server.ts
+++ b/packages/web-server/src/sandbox-server.ts
@@ -38,7 +38,16 @@ export function createSandboxServer(options: SandboxServerOptions): http.Server 
   const sandboxRelay: string = readSandboxAsset("sandbox-relay.js");
 
   return http.createServer((req, res) => {
-    const url: URL = new URL(req.url ?? "/", `http://${req.headers.host ?? options.bindHost}`);
+    // A malformed request target or Host header makes `new URL` throw; never let
+    // that crash the server process — answer 400 and move on.
+    let url: URL;
+    try {
+      url = new URL(req.url ?? "/", `http://${req.headers.host ?? options.bindHost}`);
+    } catch {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Bad request");
+      return;
+    }
     const path: string = url.pathname;
     const isGet: boolean = req.method?.toUpperCase() === "GET";
 

--- a/packages/web-server/src/sandbox-server.ts
+++ b/packages/web-server/src/sandbox-server.ts
@@ -1,0 +1,74 @@
+import http from "node:http";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { buildCspHeader, type SandboxCsp } from "./sandbox-csp.js";
+
+const nodeRequire: NodeRequire = createRequire(import.meta.url);
+
+/** Options for the MCP Apps sandbox server. */
+export interface SandboxServerOptions {
+  /** Bind host (e.g. "127.0.0.1" or "0.0.0.0"). */
+  bindHost: string;
+  /** Port the sandbox origin listens on (GRACKLE_SANDBOX_PORT). */
+  sandboxPort: number;
+}
+
+/** Read a sandbox asset from the canonical copy in @grackle-ai/web-components. */
+function readSandboxAsset(subpath: string): string {
+  const assetPath: string = nodeRequire.resolve(`@grackle-ai/web-components/mcp-app-sandbox/${subpath}`);
+  return readFileSync(assetPath, "utf-8");
+}
+
+const JS_HEADERS: Readonly<Record<string, string>> = {
+  "Content-Type": "text/javascript; charset=utf-8",
+  "Cache-Control": "no-cache, no-store, must-revalidate",
+  "Access-Control-Allow-Origin": "*",
+};
+
+/**
+ * Create the MCP Apps widget sandbox server — a SEPARATE origin (different port
+ * than the web app) that serves the double-iframe proxy (`sandbox.html` +
+ * `sandbox-relay.js`) with a per-`?csp=` HTTP-header CSP. This is where the
+ * untrusted widget is rendered; being a distinct origin keeps `window.top`
+ * unreachable per the MCP Apps spec (SEP-1865). Assets are the canonical copies
+ * from `@grackle-ai/web-components` (no drift on the security-critical relay).
+ */
+export function createSandboxServer(options: SandboxServerOptions): http.Server {
+  const sandboxHtml: string = readSandboxAsset("sandbox.html");
+  const sandboxRelay: string = readSandboxAsset("sandbox-relay.js");
+
+  return http.createServer((req, res) => {
+    const url: URL = new URL(req.url ?? "/", `http://${req.headers.host ?? options.bindHost}`);
+    const path: string = url.pathname;
+    const isGet: boolean = req.method?.toUpperCase() === "GET";
+
+    if (isGet && path === "/sandbox-relay.js") {
+      res.writeHead(200, JS_HEADERS);
+      res.end(sandboxRelay);
+      return;
+    }
+
+    if (isGet && (path === "/" || path === "/sandbox.html")) {
+      let csp: SandboxCsp | undefined;
+      const cspParam: string | null = url.searchParams.get("csp");
+      if (cspParam) {
+        try {
+          csp = JSON.parse(cspParam) as SandboxCsp;
+        } catch {
+          // Ignore an unparseable csp param and fall back to the locked-down default.
+        }
+      }
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Security-Policy": buildCspHeader(csp),
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.end(sandboxHtml);
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Only sandbox.html and sandbox-relay.js are served on this port.");
+  });
+}

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -48,6 +48,8 @@ export interface WebServerOptions {
   readinessCheck?: () => ReadinessResult | Promise<ReadinessResult>;
   /** Names of loaded plugins, served at `GET /api/manifest`. */
   pluginNames?: string[];
+  /** MCP Apps widget sandbox port, served at `GET /api/manifest` for the SPA to derive the sandbox origin. */
+  sandboxPort?: number;
 }
 
 // ─── Static File Config ─────────────────────────────────────
@@ -283,7 +285,7 @@ export function isWildcardAddress(host: string): boolean {
  * @returns An `http.Server` ready to `.listen()`.
  */
 export function createWebServer(options: WebServerOptions): http.Server {
-  const { apiKey, webPort, bindHost, connectRoutes, webDistDir, readinessCheck, pluginNames } = options;
+  const { apiKey, webPort, bindHost, connectRoutes, webDistDir, readinessCheck, pluginNames, sandboxPort } = options;
   const distDir = webDistDir ?? resolveWebDistDir();
   const allowNetwork = isWildcardAddress(bindHost);
   const dialableHost = allowNetwork ? "127.0.0.1" : bindHost;
@@ -339,7 +341,10 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
     // --- Plugin manifest (no auth) ---
     if (rawPath === "/api/manifest") {
-      const manifest = { plugins: (pluginNames ?? []).map((name) => ({ name })) };
+      const manifest = {
+        plugins: (pluginNames ?? []).map((name) => ({ name })),
+        ...(sandboxPort !== undefined ? { sandboxPort } : {}),
+      };
       res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
       res.end(JSON.stringify(manifest));
       return;

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -50,6 +50,13 @@ export interface WebServerOptions {
   pluginNames?: string[];
   /** MCP Apps widget sandbox port, served at `GET /api/manifest` for the SPA to derive the sandbox origin. */
   sandboxPort?: number;
+  /**
+   * Explicit browser-facing sandbox origin (e.g. `https://sandbox.example.com`),
+   * served at `GET /api/manifest`. Takes precedence over `sandboxPort` on the
+   * SPA — set it when a reverse proxy / TLS makes the origin un-inferrable from
+   * `window.location` + `sandboxPort`.
+   */
+  sandboxOrigin?: string;
 }
 
 // ─── Static File Config ─────────────────────────────────────
@@ -285,7 +292,7 @@ export function isWildcardAddress(host: string): boolean {
  * @returns An `http.Server` ready to `.listen()`.
  */
 export function createWebServer(options: WebServerOptions): http.Server {
-  const { apiKey, webPort, bindHost, connectRoutes, webDistDir, readinessCheck, pluginNames, sandboxPort } = options;
+  const { apiKey, webPort, bindHost, connectRoutes, webDistDir, readinessCheck, pluginNames, sandboxPort, sandboxOrigin } = options;
   const distDir = webDistDir ?? resolveWebDistDir();
   const allowNetwork = isWildcardAddress(bindHost);
   const dialableHost = allowNetwork ? "127.0.0.1" : bindHost;
@@ -344,6 +351,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
       const manifest = {
         plugins: (pluginNames ?? []).map((name) => ({ name })),
         ...(sandboxPort !== undefined ? { sandboxPort } : {}),
+        ...(sandboxOrigin !== undefined ? { sandboxOrigin } : {}),
       };
       res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
       res.end(JSON.stringify(manifest));

--- a/packages/web/src/context/ManifestContext.tsx
+++ b/packages/web/src/context/ManifestContext.tsx
@@ -105,5 +105,11 @@ export function useSandboxProxyUrl(): string | undefined {
   if (sandboxPort === undefined || typeof window === "undefined") {
     return undefined;
   }
-  return `${window.location.protocol}//${window.location.hostname}:${sandboxPort}/sandbox.html`;
+  // Build via URL (not string interpolation) so IPv6 hosts are bracketed
+  // correctly — `location.hostname` returns `::1`, which would otherwise yield
+  // an invalid `http://::1:PORT/...`.
+  const url = new URL(window.location.origin);
+  url.port = String(sandboxPort);
+  url.pathname = "/sandbox.html";
+  return url.toString();
 }

--- a/packages/web/src/context/ManifestContext.tsx
+++ b/packages/web/src/context/ManifestContext.tsx
@@ -16,12 +16,15 @@ const ALL_KNOWN_PLUGINS: readonly string[] = ["core", "orchestration", "scheduli
 /** Shape of the manifest returned by `GET /api/manifest`. */
 interface ManifestResponse {
   plugins: Array<{ name: string }>;
+  sandboxPort?: number;
 }
 
 /** Value provided by ManifestContext. */
 export interface ManifestValue {
   /** Names of active plugins, in server load order. Empty while loading. */
   pluginNames: string[];
+  /** MCP Apps widget sandbox port (for deriving the sandbox origin). Undefined until loaded. */
+  sandboxPort: number | undefined;
   /** True while the manifest fetch is in flight. */
   loading: boolean;
   /** Set if the fetch failed (pluginNames will be the fail-open fallback). */
@@ -30,6 +33,7 @@ export interface ManifestValue {
 
 const ManifestContext: Context<ManifestValue> = createContext<ManifestValue>({
   pluginNames: [...ALL_KNOWN_PLUGINS],
+  sandboxPort: undefined,
   loading: false,
   error: undefined,
 });
@@ -42,6 +46,7 @@ const ManifestContext: Context<ManifestValue> = createContext<ManifestValue>({
  */
 export function ManifestProvider({ children }: { children: ReactNode }): JSX.Element {
   const [pluginNames, setPluginNames] = useState<string[]>([...ALL_KNOWN_PLUGINS]);
+  const [sandboxPort, setSandboxPort] = useState<number | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>(undefined);
 
@@ -58,6 +63,7 @@ export function ManifestProvider({ children }: { children: ReactNode }): JSX.Ele
       .then((data) => {
         if (!cancelled) {
           setPluginNames(data.plugins.map((p) => p.name));
+          setSandboxPort(data.sandboxPort);
           setLoading(false);
         }
       })
@@ -73,7 +79,7 @@ export function ManifestProvider({ children }: { children: ReactNode }): JSX.Ele
   }, []);
 
   return (
-    <ManifestContext.Provider value={{ pluginNames, loading, error }}>
+    <ManifestContext.Provider value={{ pluginNames, sandboxPort, loading, error }}>
       {children}
     </ManifestContext.Provider>
   );
@@ -86,4 +92,18 @@ export function ManifestProvider({ children }: { children: ReactNode }): JSX.Ele
  */
 export function useManifest(): ManifestValue {
   return useContext(ManifestContext);
+}
+
+/**
+ * Derive the MCP Apps sandbox proxy origin URL from the manifest's sandbox port.
+ * Returns `undefined` until the manifest loads (or if no sandbox port is set).
+ * The sandbox is a DIFFERENT origin (different port) than the web app, as the
+ * MCP Apps double-iframe spec requires.
+ */
+export function useSandboxProxyUrl(): string | undefined {
+  const { sandboxPort } = useManifest();
+  if (sandboxPort === undefined || typeof window === "undefined") {
+    return undefined;
+  }
+  return `${window.location.protocol}//${window.location.hostname}:${sandboxPort}/sandbox.html`;
 }

--- a/packages/web/src/context/ManifestContext.tsx
+++ b/packages/web/src/context/ManifestContext.tsx
@@ -17,6 +17,7 @@ const ALL_KNOWN_PLUGINS: readonly string[] = ["core", "orchestration", "scheduli
 interface ManifestResponse {
   plugins: Array<{ name: string }>;
   sandboxPort?: number;
+  sandboxOrigin?: string;
 }
 
 /** Value provided by ManifestContext. */
@@ -25,6 +26,12 @@ export interface ManifestValue {
   pluginNames: string[];
   /** MCP Apps widget sandbox port (for deriving the sandbox origin). Undefined until loaded. */
   sandboxPort: number | undefined;
+  /**
+   * Explicit browser-facing sandbox origin (e.g. `https://sandbox.example.com`),
+   * set server-side via GRACKLE_SANDBOX_ORIGIN for reverse-proxy / TLS
+   * deployments. Takes precedence over `sandboxPort`. Undefined until loaded.
+   */
+  sandboxOrigin: string | undefined;
   /** True while the manifest fetch is in flight. */
   loading: boolean;
   /** Set if the fetch failed (pluginNames will be the fail-open fallback). */
@@ -34,6 +41,7 @@ export interface ManifestValue {
 const ManifestContext: Context<ManifestValue> = createContext<ManifestValue>({
   pluginNames: [...ALL_KNOWN_PLUGINS],
   sandboxPort: undefined,
+  sandboxOrigin: undefined,
   loading: false,
   error: undefined,
 });
@@ -47,6 +55,7 @@ const ManifestContext: Context<ManifestValue> = createContext<ManifestValue>({
 export function ManifestProvider({ children }: { children: ReactNode }): JSX.Element {
   const [pluginNames, setPluginNames] = useState<string[]>([...ALL_KNOWN_PLUGINS]);
   const [sandboxPort, setSandboxPort] = useState<number | undefined>(undefined);
+  const [sandboxOrigin, setSandboxOrigin] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>(undefined);
 
@@ -64,6 +73,7 @@ export function ManifestProvider({ children }: { children: ReactNode }): JSX.Ele
         if (!cancelled) {
           setPluginNames(data.plugins.map((p) => p.name));
           setSandboxPort(data.sandboxPort);
+          setSandboxOrigin(data.sandboxOrigin);
           setLoading(false);
         }
       })
@@ -79,7 +89,7 @@ export function ManifestProvider({ children }: { children: ReactNode }): JSX.Ele
   }, []);
 
   return (
-    <ManifestContext.Provider value={{ pluginNames, sandboxPort, loading, error }}>
+    <ManifestContext.Provider value={{ pluginNames, sandboxPort, sandboxOrigin, loading, error }}>
       {children}
     </ManifestContext.Provider>
   );
@@ -95,19 +105,30 @@ export function useManifest(): ManifestValue {
 }
 
 /**
- * Derive the MCP Apps sandbox proxy origin URL from the manifest's sandbox port.
- * Returns `undefined` until the manifest loads (or if no sandbox port is set).
- * The sandbox is a DIFFERENT origin (different port) than the web app, as the
- * MCP Apps double-iframe spec requires.
+ * Derive the MCP Apps sandbox `sandbox.html` URL.
+ *
+ * Prefers an explicit server-configured `sandboxOrigin` (GRACKLE_SANDBOX_ORIGIN)
+ * for reverse-proxy / TLS deployments where the scheme + port cannot be inferred
+ * from the page's own origin. Otherwise derives the origin from
+ * `window.location` + `sandboxPort`. Returns `undefined` until the manifest
+ * loads (or if neither is set). The sandbox is a DIFFERENT origin than the web
+ * app, as the MCP Apps double-iframe spec requires.
  */
 export function useSandboxProxyUrl(): string | undefined {
-  const { sandboxPort } = useManifest();
-  if (sandboxPort === undefined || typeof window === "undefined") {
+  const { sandboxPort, sandboxOrigin } = useManifest();
+  if (typeof window === "undefined") {
     return undefined;
   }
-  // Build via URL (not string interpolation) so IPv6 hosts are bracketed
-  // correctly — `location.hostname` returns `::1`, which would otherwise yield
-  // an invalid `http://::1:PORT/...`.
+  // Explicit origin wins (handles HTTPS-proxy / non-derivable scheme + port).
+  if (sandboxOrigin !== undefined && sandboxOrigin !== "") {
+    return new URL("/sandbox.html", sandboxOrigin).toString();
+  }
+  if (sandboxPort === undefined) {
+    return undefined;
+  }
+  // Derive from the page origin + sandboxPort. Build via URL (not string
+  // interpolation) so IPv6 hosts are bracketed correctly — `location.hostname`
+  // returns `::1`, which would otherwise yield an invalid `http://::1:PORT/...`.
   const url = new URL(window.location.origin);
   url.port = String(sandboxPort);
   url.pathname = "/sandbox.html";

--- a/packages/web/src/context/ManifestContext.tsx
+++ b/packages/web/src/context/ManifestContext.tsx
@@ -120,8 +120,14 @@ export function useSandboxProxyUrl(): string | undefined {
     return undefined;
   }
   // Explicit origin wins (handles HTTPS-proxy / non-derivable scheme + port).
+  // Guard against a misconfigured/invalid origin so a bad env var can't crash
+  // rendering — fall through to the port-derived path on parse failure.
   if (sandboxOrigin !== undefined && sandboxOrigin !== "") {
-    return new URL("/sandbox.html", sandboxOrigin).toString();
+    try {
+      return new URL("/sandbox.html", sandboxOrigin).toString();
+    } catch {
+      // Invalid GRACKLE_SANDBOX_ORIGIN — ignore and fall back below.
+    }
   }
   if (sandboxPort === undefined) {
     return undefined;

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "rea
 import { useParams, Link } from "react-router";
 import { ROOT_TASK_ID } from "@grackle-ai/common";
 import { useGrackle } from "../context/GrackleContext.js";
+import { useSandboxProxyUrl } from "../context/ManifestContext.js";
 import {
   ChatInput, EventStream, SplitButton, StreamDetailPanel,
   groupConsecutiveTextEvents, pairToolEvents, useToast, CHAT_URL,
@@ -68,6 +69,7 @@ function StreamUnavailableState(): JSX.Element {
 /** Chat page — shows System session or a named IPC stream. */
 export function ChatPage(): JSX.Element {
   const { streamId } = useParams<{ streamId?: string }>();
+  const sandboxProxyUrl = useSandboxProxyUrl();
 
   const {
     tasks: { tasks, tasksLoading, startTask },
@@ -265,6 +267,7 @@ export function ChatPage(): JSX.Element {
         <EventStream
           events={groupedEvents}
           eventsDropped={eventsDropped}
+          sandboxProxyUrl={sandboxProxyUrl}
           emptyState={
             streamId === undefined
               ? <ChatEmptyState hasLocalEnvironment={!!localEnvironment} />

--- a/packages/web/src/pages/SessionPage.tsx
+++ b/packages/web/src/pages/SessionPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, type JSX } from "react";
 import { useParams } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
+import { useSandboxProxyUrl } from "../context/ManifestContext.js";
 import { Breadcrumbs, ChatInput, EventStream, SplitButton, buildSessionBreadcrumbs, formatCost, formatTokens, groupConsecutiveTextEvents, pairToolEvents, useToast } from "@grackle-ai/web-components";
 import type { Session } from "../hooks/useGrackleSocket.js";
 import { SessionShimmer } from "./SessionShimmer.js";
@@ -62,6 +63,7 @@ function SessionEmptyState({ session }: { session: Session | undefined }): JSX.E
 /** Page for viewing a session's event stream. */
 export function SessionPage(): JSX.Element {
   const { sessionId } = useParams<{ sessionId: string }>();
+  const sandboxProxyUrl = useSandboxProxyUrl();
   const {
     sessions: { events, eventsDropped, sessions, sessionsLoading, kill, stopGraceful, loadSessionEvents, sendInput, spawn },
     tasks: { startTask },
@@ -119,6 +121,7 @@ export function SessionPage(): JSX.Element {
         eventsDropped={eventsDropped}
         emptyState={<SessionEmptyState session={session} />}
         onShowToast={showToast}
+        sandboxProxyUrl={sandboxProxyUrl}
         sessions={sessions}
         currentSessionId={sessionId}
         environments={environments}

--- a/packages/web/src/pages/TaskPage.tsx
+++ b/packages/web/src/pages/TaskPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useParams, useLocation } from "react-router";
 import { ConnectError } from "@connectrpc/connect";
 import { useGrackle } from "../context/GrackleContext.js";
+import { useSandboxProxyUrl } from "../context/ManifestContext.js";
 import {
   Breadcrumbs, ChatInput, ConfirmDialog, EventStream, FindingsPanel,
   SessionAttemptSelector, TaskActionButtons, TaskEditPanel, TaskOverviewPanel,
@@ -19,6 +20,7 @@ type TaskTab = "overview" | "stream" | "findings";
 /** Task detail page with overview/stream/findings tabs. */
 export function TaskPage(): JSX.Element {
   const { taskId, workspaceId: routeWorkspaceId, environmentId: routeEnvironmentId } = useParams<{ taskId: string; workspaceId?: string; environmentId?: string }>();
+  const sandboxProxyUrl = useSandboxProxyUrl();
   const location = useLocation();
   const navigate = useAppNavigate();
   const { showToast } = useToast();
@@ -321,6 +323,7 @@ export function TaskPage(): JSX.Element {
             <EventStream
               events={groupedEvents}
               eventsDropped={eventsDropped}
+              sandboxProxyUrl={sandboxProxyUrl}
               emptyState={
                 !sessionId && task ? (
                   isTaskBlocked ? (

--- a/tests/e2e-tests/tests/fixtures.ts
+++ b/tests/e2e-tests/tests/fixtures.ts
@@ -76,7 +76,7 @@ interface TestFixtures {
 
 /** Extended Playwright test fixture that spawns a per-worker Grackle stack. */
 export const test = base.extend<TestFixtures, WorkerFixtures>({
-  // Worker-scoped: starts one Grackle stack per worker (4 ports + isolated DB).
+  // Worker-scoped: starts one Grackle stack per worker (5 ports + isolated DB).
   // Teardown kills processes and removes the temp directory when the worker exits.
   // Knowledge graph is only enabled for the "knowledge" project to avoid
   // Neo4j contention and reference-node sync overhead in other tests.

--- a/tests/e2e-tests/tests/server-manager.ts
+++ b/tests/e2e-tests/tests/server-manager.ts
@@ -2,7 +2,7 @@
  * Manages the lifecycle of an isolated Grackle server stack for E2E tests.
  *
  * Each call to {@link startGrackleStack} spawns a fully independent stack
- * (PowerLine + Server on 4 unique ports, with its own GRACKLE_HOME and SQLite DB).
+ * (PowerLine + Server on 5 unique ports, with its own GRACKLE_HOME and SQLite DB).
  * Multiple stacks can run in parallel for Playwright worker-level parallelism.
  */
 import { spawn, type ChildProcess } from "node:child_process";
@@ -28,6 +28,7 @@ export interface E2EState {
   serverPort: number;
   webPort: number;
   mcpPort: number;
+  sandboxPort: number;
 }
 
 /** Bind a TCP server to port 0 on 127.0.0.1, read the assigned port, close, and return it. */
@@ -162,7 +163,7 @@ export interface GrackleStackOptions {
 }
 
 /**
- * Start a fully isolated Grackle stack: PowerLine + Server on 4 unique ports
+ * Start a fully isolated Grackle stack: PowerLine + Server on 5 unique ports
  * with a dedicated GRACKLE_HOME and SQLite database.
  */
 export async function startGrackleStack(options: GrackleStackOptions = {}): Promise<E2EState> {
@@ -174,9 +175,11 @@ export async function startGrackleStack(options: GrackleStackOptions = {}): Prom
 
   const repoRoot = join(import.meta.dirname, "../../..");
 
-  // 2. Find available ports (guaranteed distinct)
-  const [powerlinePort, serverPort, webPort, mcpPort] = await findDistinctPorts(4);
-  console.log(`${tag} Ports: powerline=${powerlinePort}, server=${serverPort}, web=${webPort}, mcp=${mcpPort}`);
+  // 2. Find available ports (guaranteed distinct). The sandbox port must also be
+  // unique per worker — it defaults to 7436, which would collide across the
+  // parallel E2E stacks (the sandbox server is fatal on EADDRINUSE).
+  const [powerlinePort, serverPort, webPort, mcpPort, sandboxPort] = await findDistinctPorts(5);
+  console.log(`${tag} Ports: powerline=${powerlinePort}, server=${serverPort}, web=${webPort}, mcp=${mcpPort}, sandbox=${sandboxPort}`);
 
   // 3. Start PowerLine (no auth needed for E2E tests — local loopback only)
   const powerline: ChildProcess = spawn(
@@ -202,6 +205,7 @@ export async function startGrackleStack(options: GrackleStackOptions = {}): Prom
         GRACKLE_PORT: String(serverPort),
         GRACKLE_WEB_PORT: String(webPort),
         GRACKLE_MCP_PORT: String(mcpPort),
+        GRACKLE_SANDBOX_PORT: String(sandboxPort),
         GRACKLE_WEB_DIR: join(repoRoot, "packages/web/dist"),
         GRACKLE_SKIP_LOCAL_POWERLINE: "1",
         GRACKLE_SKIP_ROOT_AUTOSTART: "1",
@@ -225,6 +229,8 @@ export async function startGrackleStack(options: GrackleStackOptions = {}): Prom
   await waitForPort(webPort, POLL_TIMEOUT_MS);
   console.log(`${tag} Waiting for MCP on :${mcpPort}...`);
   await waitForPort(mcpPort, POLL_TIMEOUT_MS);
+  console.log(`${tag} Waiting for sandbox on :${sandboxPort}...`);
+  await waitForPort(sandboxPort, POLL_TIMEOUT_MS);
   console.log(`${tag} All servers ready`);
 
   // 6. Read the auto-generated API key (may not exist immediately after port opens)
@@ -258,6 +264,7 @@ export async function startGrackleStack(options: GrackleStackOptions = {}): Prom
     serverPort,
     webPort,
     mcpPort,
+    sandboxPort,
   };
 }
 


### PR DESCRIPTION
## Summary

Wires **T1** (#1236 host renderer) + **T2** (#1237 MCP server app-side) together so a widget renders inline in Grackle's chat when an agent calls a `ui://` widget tool. Part of epic #542.

**Architecture (backend-only capture; the frontend never touches the MCP server):** Grackle's in-process MCP server (the *broker*) captures widget tool calls, builds a self-contained widget event (resource HTML + tool input/result + CSP), and pushes it into the calling session's stream via a new `EVENT_TYPE_WIDGET`. The chat renders it with `McpAppWidget` in a cross-origin sandbox. This is SDK-independent (does not rely on the agent SDK preserving MCP `_meta`) and is the on-ramp to remote/proxied MCP Apps (the mcp-gateway direction).

```
agent → Grackle MCP broker (in-process) → publishWidgetEvent (log + streamHub)
      → SessionEvent type=WIDGET → web chat → McpAppWidget → sandbox origin :7436
```

### What's included
- **proto / common:** `EVENT_TYPE_WIDGET` + enum converters; `DEFAULT_SANDBOX_PORT` (7436).
- **core:** `publishWidgetEvent` — persists to the session log (replays on reload) + broadcasts live.
- **mcp:** broker capture in the CallTool handler (resourceUri + HTML + csp + input/result), injected via `createMcpServer`.
- **web-server:** production sandbox server on `GRACKLE_SANDBOX_PORT` (reuses the T1 sandbox assets + a shared CSP builder); `sandboxPort` surfaced via `/api/manifest`.
- **web:** `ManifestContext.sandboxPort` + `useSandboxProxyUrl`; `EventRenderer` `widget` case renders `McpAppWidget` (lazy/code-split); wired into Chat/Session/Task pages.

### Gates fixed to make widget tools reachable end-to-end
Verifying end-to-end surfaced three gates the widget tool (#1237) was never wired through:
1. **MCP ListTools UI gate** — when the broker is active, expose widget tools regardless of whether the agent's MCP client advertises `io.modelcontextprotocol/ui` (Grackle is the ui-capable host that renders in chat). Standalone MCP keeps spec-compliant client-capability gating.
2. **Scoped tool authz** — `show_hello_widget` added to `DEFAULT_SCOPED_MCP_TOOLS` / `ORCHESTRATOR_MCP_TOOLS` / `ALL_MCP_TOOL_NAMES`.
3. **Web-app CSP** — `frame-src` now allows the same-hostname sandbox origin (mirrors the existing `form-action` wildcard-port workaround; the framed sandbox is itself origin-isolated with its own locked CSP).

## Test plan
- [x] Unit: enum round-trip (common), `publishWidgetEvent` (core), broker capture + UI-gate (mcp), sandbox CSP (web-server), `WidgetEvent` story (web-components).
- [x] `mcp-tool-presets` + `security-headers` tests updated for the authz/CSP changes.
- [x] Full `rush build` clean (warnings-as-errors, no api-extractor drift).
- [x] **End-to-end (deterministic, no LLM):** a scoped `stub-mcp` agent calls `show_hello_widget` → broker captures it → widget event in the session stream → chat renders the widget in the cross-origin double-iframe sandbox with **live tool input/result** (screenshot below).
- [ ] CI: full storybook interaction + E2E suites.

## Screenshot — widget rendered inline in chat
![widget rendered](https://gist.githubusercontent.com/nick-pape/d126f8a5af27234721796338edf1cf4b/raw/009298bb41f32f7055e64923279b202a350bb7c3/widget-rendered.svg)

The "Grackle" card is the rendered MCP App widget; **Input** and **Result** were delivered into it via the AppBridge handshake.

Closes #1238