### PR TITLE
fix(web-server): return 413 for oversized request bodies

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1263-oversized-body-413_2026-05-23-15-07.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1263-oversized-body-413_2026-05-23-15-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix: oversized HTTP request bodies now return a clean 413 (with Connection: close) instead of a connection reset",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-server/src/web-server.test.ts
+++ b/packages/web-server/src/web-server.test.ts
@@ -42,6 +42,34 @@ function request(
   });
 }
 
+/** POST a raw body to the test server. */
+function postBody(
+  server: http.Server,
+  path: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path,
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
+      },
+      (res) => {
+        let b = "";
+        res.on("data", (chunk: Buffer) => { b += chunk.toString(); });
+        res.on("end", () => resolve({ status: res.statusCode!, body: b }));
+      },
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
 describe("createWebServer", () => {
   let server: http.Server;
 
@@ -68,6 +96,19 @@ describe("createWebServer", () => {
 
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ status: "ok" });
+  });
+
+  it("returns 413 for an oversized request body (not a connection reset)", async () => {
+    const oversized = JSON.stringify({ client_name: "x".repeat(20_000) });
+    const res = await postBody(server, "/register", oversized);
+    expect(res.status).toBe(413);
+  });
+
+  it("reads a normal-size body (small POST reaches the route)", async () => {
+    // A small but invalid body proves readBody resolved and the route ran
+    // (redirect_uris missing -> 400 invalid_request, not a body-size failure).
+    const res = await postBody(server, "/register", JSON.stringify({}));
+    expect(res.status).toBe(400);
   });
 
   it("returns 200 with default readiness at /readyz when no check provided", async () => {

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -228,31 +228,36 @@ function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalSize: number = 0;
-    let aborted: boolean = false;
+    let settled: boolean = false;
+    const settle = (action: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      action();
+    };
     req.on("data", (chunk: Buffer) => {
-      if (aborted) {
+      if (settled) {
         return;
       }
       totalSize += chunk.length;
       if (totalSize > MAX_BODY_SIZE) {
-        // Signal overflow WITHOUT destroying the socket, so the route handler can
-        // still send a 413 (with `Connection: close`) before the socket closes.
-        // Destroying here would reset the connection and the caller could never
-        // write a response.
-        aborted = true;
-        reject(new PayloadTooLargeError("Body too large"));
+        // Apply backpressure (stop reading) and signal overflow WITHOUT destroying
+        // the socket here, so the route can still send a 413. The socket is torn
+        // down once that response flushes (see `respondPayloadTooLarge`). Pausing
+        // prevents an attacker from streaming an arbitrarily large body at speed.
+        req.pause();
+        settle(() => reject(new PayloadTooLargeError("Body too large")));
         return;
       }
       chunks.push(chunk);
     });
-    req.on("end", () => {
-      if (!aborted) {
-        resolve(Buffer.concat(chunks).toString("utf8"));
-      }
-    });
-    // Once the promise has settled, a later socket-close ECONNRESET is absorbed
-    // here (a second reject is a no-op) — no unhandled error.
-    req.on("error", reject);
+    req.on("end", () => settle(() => resolve(Buffer.concat(chunks).toString("utf8"))));
+    req.on("error", (err: Error) => settle(() => reject(err)));
+    // If the client disconnects mid-upload, `close` fires without `end`/`error`;
+    // reject so the awaiting handler can't hang. After a normal `end`, the promise
+    // is already settled and this is a no-op.
+    req.on("close", () => settle(() => reject(new Error("connection closed before request body was fully read"))));
   });
 }
 
@@ -262,7 +267,10 @@ function readBody(req: http.IncomingMessage): Promise<string> {
  * `Connection: close` lets Node flush the response and tear down the socket
  * whose request body was not fully consumed, discarding the unsent upload.
  */
-function respondPayloadTooLarge(res: http.ServerResponse): void {
+function respondPayloadTooLarge(req: http.IncomingMessage, res: http.ServerResponse): void {
+  // Tear down the (paused, half-read) request once the 413 has flushed, so the
+  // client can't keep streaming an oversized body after we've responded.
+  res.once("finish", () => { req.destroy(); });
   res.writeHead(413, { "Content-Type": "application/json", "Connection": "close" });
   res.end(JSON.stringify({ error: "payload too large" }));
 }
@@ -490,7 +498,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
         }));
       } catch (err) {
         if (err instanceof PayloadTooLargeError) {
-          respondPayloadTooLarge(res);
+          respondPayloadTooLarge(req, res);
           return;
         }
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -644,7 +652,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
         res.end();
       } catch (err) {
         if (err instanceof PayloadTooLargeError) {
-          respondPayloadTooLarge(res);
+          respondPayloadTooLarge(req, res);
           return;
         }
         res.writeHead(400);
@@ -714,7 +722,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
         res.end(JSON.stringify({ error: "unsupported_grant_type" }));
       } catch (err) {
         if (err instanceof PayloadTooLargeError) {
-          respondPayloadTooLarge(res);
+          respondPayloadTooLarge(req, res);
           return;
         }
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -778,7 +786,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
         raw = await readBody(req);
       } catch (err) {
         if (err instanceof PayloadTooLargeError) {
-          respondPayloadTooLarge(res);
+          respondPayloadTooLarge(req, res);
         } else {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "could not read body" }));

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -221,24 +221,50 @@ const MAX_BODY_SIZE: number = 16_384;
  * @param req - The incoming HTTP request.
  * @returns The raw body as a UTF-8 string.
  */
+/** Thrown by {@link readBody} when a request body exceeds {@link MAX_BODY_SIZE}. */
+class PayloadTooLargeError extends Error {}
+
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalSize: number = 0;
+    let aborted: boolean = false;
     req.on("data", (chunk: Buffer) => {
+      if (aborted) {
+        return;
+      }
       totalSize += chunk.length;
       if (totalSize > MAX_BODY_SIZE) {
-        req.destroy();
-        reject(new Error("Body too large"));
+        // Signal overflow WITHOUT destroying the socket, so the route handler can
+        // still send a 413 (with `Connection: close`) before the socket closes.
+        // Destroying here would reset the connection and the caller could never
+        // write a response.
+        aborted = true;
+        reject(new PayloadTooLargeError("Body too large"));
         return;
       }
       chunks.push(chunk);
     });
     req.on("end", () => {
-      resolve(Buffer.concat(chunks).toString("utf8"));
+      if (!aborted) {
+        resolve(Buffer.concat(chunks).toString("utf8"));
+      }
     });
+    // Once the promise has settled, a later socket-close ECONNRESET is absorbed
+    // here (a second reject is a no-op) — no unhandled error.
     req.on("error", reject);
   });
+}
+
+/**
+ * Send a `413 Payload Too Large` response and close the (half-read) connection.
+ *
+ * `Connection: close` lets Node flush the response and tear down the socket
+ * whose request body was not fully consumed, discarding the unsent upload.
+ */
+function respondPayloadTooLarge(res: http.ServerResponse): void {
+  res.writeHead(413, { "Content-Type": "application/json", "Connection": "close" });
+  res.end(JSON.stringify({ error: "payload too large" }));
 }
 
 /**
@@ -462,7 +488,11 @@ export function createWebServer(options: WebServerOptions): http.Server {
           redirect_uris: client.redirectUris,
           client_name: client.clientName,
         }));
-      } catch {
+      } catch (err) {
+        if (err instanceof PayloadTooLargeError) {
+          respondPayloadTooLarge(res);
+          return;
+        }
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "invalid_request" }));
       }
@@ -612,7 +642,11 @@ export function createWebServer(options: WebServerOptions): http.Server {
           Location: redirectUrl,
         });
         res.end();
-      } catch {
+      } catch (err) {
+        if (err instanceof PayloadTooLargeError) {
+          respondPayloadTooLarge(res);
+          return;
+        }
         res.writeHead(400);
         res.end("Bad Request");
       }
@@ -678,7 +712,11 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "unsupported_grant_type" }));
-      } catch {
+      } catch (err) {
+        if (err instanceof PayloadTooLargeError) {
+          respondPayloadTooLarge(res);
+          return;
+        }
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "invalid_request" }));
       }
@@ -738,9 +776,13 @@ export function createWebServer(options: WebServerOptions): http.Server {
       let raw: string;
       try {
         raw = await readBody(req);
-      } catch {
-        res.writeHead(413, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "body too large" }));
+      } catch (err) {
+        if (err instanceof PayloadTooLargeError) {
+          respondPayloadTooLarge(res);
+        } else {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "could not read body" }));
+        }
         return;
       }
       let parsed: { message?: unknown; from?: unknown; idempotency_key?: unknown };

--- a/tests/e2e-tests/tests/channel-webhook.spec.ts
+++ b/tests/e2e-tests/tests/channel-webhook.spec.ts
@@ -40,6 +40,14 @@ test.describe("Channel webhook ingestion", { tag: ["@channel"] }, () => {
     // The stub agent echoes the injected input back into the session stream.
     await expect(page.getByText("You said: hello from webhook", { exact: true })).toBeVisible({ timeout: 10_000 });
 
+    // An oversized body (>16 KB) is rejected with a clean 413, not a connection reset.
+    const tooBig = await fetch(grant.ingressUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "x".repeat(20_000) }),
+    });
+    expect(tooBig.status).toBe(413);
+
     // Revoke the grant — the same URL must now be rejected.
     await client.core.revokeChannelGrant({ grantId: grant.grantId });
     const rejected = await fetch(grant.ingressUrl, {


### PR DESCRIPTION
## Summary
- `readBody()` destroyed the socket (`req.destroy()`) on body-size overflow *before* any handler could write a response, so oversized (>16 KB) requests surfaced as a **connection reset** (curl `000`) instead of a status.
- Now `readBody()` rejects a typed `PayloadTooLargeError` **without** destroying the socket; each POST route (`/hook`, `/register`, `/authorize`, `/token`) catches it and replies **`413`** with `Connection: close` (which cleanly closes the half-read keep-alive socket; Node discards the unsent upload). The 16 KB cap / DoS protection is preserved.

## Test plan
- [x] `rush build -t @grackle-ai/web-server` clean (no warnings; `PayloadTooLargeError` stays internal, so no API-report change)
- [x] web-server integration tests: oversized body → **413**, small body → route runs (400 invalid_request) — real HTTP server via `createWebServer`
- [x] Extended `channel-webhook` E2E: `>16 KB` body to `/hook` → **413** (runs in CI)
- [ ] CI: full suite

Closes #1263