### PR TITLE
feat(web): Coordination network graph (List/Graph toggle)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1230-coordination-graph_2026-05-25-01-15.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1230-coordination-graph_2026-05-25-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Coordination tab: live bipartite network graph of agent sessions and IPC streams with a List/Graph toggle (web UI).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/streams/CoordinationGraph.module.scss
+++ b/packages/web-components/src/components/streams/CoordinationGraph.module.scss
@@ -131,6 +131,10 @@
   border-color: var(--accent-blue);
 }
 
+.pipe {
+  border-color: var(--accent-yellow);
+}
+
 .haloless {
   border-color: var(--border-subtle);
   box-shadow: none;

--- a/packages/web-components/src/components/streams/CoordinationGraph.module.scss
+++ b/packages/web-components/src/components/streams/CoordinationGraph.module.scss
@@ -1,0 +1,163 @@
+@use '../../styles/mixins' as *;
+
+// =============================================================================
+// Coordination graph - React Flow theme overrides + session/stream node styles
+// =============================================================================
+
+.graphContainer {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+
+  // React Flow theme overrides (mirrors DagView)
+  --xy-background-color: transparent;
+  --xy-node-border-radius: var(--radius-lg);
+  --xy-edge-stroke: var(--text-tertiary);
+  --xy-minimap-background: var(--bg-inset);
+  --xy-minimap-mask-background: var(--bg-overlay);
+  --xy-controls-button-background-color: var(--bg-elevated);
+  --xy-controls-button-background-color-hover: var(--bg-overlay);
+  --xy-controls-button-color: var(--text-secondary);
+  --xy-controls-button-color-hover: var(--text-primary);
+  --xy-controls-button-border-color: var(--border-subtle);
+  --xy-attribution-background-color: transparent;
+}
+
+.empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+// =============================================================================
+// Shared node internals
+// =============================================================================
+
+.nodeContent {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
+.nodeHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.nodeIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.nodeTitle {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nodeMeta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.nodeSubtle {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+}
+
+.countBadge {
+  @include surface-inset;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  padding: 1px var(--space-xs);
+}
+
+// =============================================================================
+// Session node
+// =============================================================================
+
+.sessionNode {
+  @include surface-card;
+  width: 200px;
+  min-height: 56px;
+  display: flex;
+  overflow: hidden;
+  cursor: default;
+  @include card-hover;
+}
+
+.sessionAccent {
+  width: 4px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+}
+
+.external {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+// =============================================================================
+// Stream hub node
+// =============================================================================
+
+.streamNode {
+  @include surface-card;
+  width: 180px;
+  min-height: 52px;
+  cursor: pointer;
+  @include card-hover;
+}
+
+.chatroom {
+  border-color: var(--accent-green);
+  box-shadow: 0 0 0 1px var(--accent-green), 0 0 12px rgba(34, 197, 94, 0.25);
+}
+
+.channel {
+  border-color: var(--accent-blue);
+}
+
+.haloless {
+  border-color: var(--border-subtle);
+  box-shadow: none;
+  opacity: 0.85;
+}
+
+.selected {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+}
+
+.kindBadge {
+  @include surface-inset;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  padding: 1px var(--space-xs);
+}
+
+// =============================================================================
+// Handles
+// =============================================================================
+
+.handle {
+  width: 6px !important;
+  height: 6px !important;
+  background: var(--text-tertiary) !important;
+  border: 1px solid var(--border-subtle) !important;
+}

--- a/packages/web-components/src/components/streams/CoordinationGraph.stories.tsx
+++ b/packages/web-components/src/components/streams/CoordinationGraph.stories.tsx
@@ -11,7 +11,7 @@ import { MOCK_SESSIONS } from "../../mocks/mockData.js";
  * ReactFlowProvider and a container with explicit dimensions. Node positions
  * are not reliably computed in the headless runner, so the play functions
  * assert on the stable container/empty test ids only; the bipartite/pipe/edge
- * logic is verified in useCoordinationLayout.test.ts.
+ * logic is verified in coordinationGraphModel.test.ts.
  */
 const meta: Meta<typeof CoordinationGraph> = {
   title: "Grackle/Streams/CoordinationGraph",

--- a/packages/web-components/src/components/streams/CoordinationGraph.stories.tsx
+++ b/packages/web-components/src/components/streams/CoordinationGraph.stories.tsx
@@ -1,0 +1,115 @@
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn } from "@storybook/test";
+import { ReactFlowProvider } from "@xyflow/react";
+import { CoordinationGraph } from "./CoordinationGraph.js";
+import { MOCK_STREAMS } from "../../mocks/mockStreamsData.js";
+import { MOCK_SESSIONS } from "../../mocks/mockData.js";
+
+/**
+ * CoordinationGraph uses @xyflow/react, which requires a parent
+ * ReactFlowProvider and a container with explicit dimensions. Node positions
+ * are not reliably computed in the headless runner, so the play functions
+ * assert on the stable container/empty test ids only; the bipartite/pipe/edge
+ * logic is verified in useCoordinationLayout.test.ts.
+ */
+const meta: Meta<typeof CoordinationGraph> = {
+  title: "Grackle/Streams/CoordinationGraph",
+  tags: ["autodocs"],
+  component: CoordinationGraph,
+  decorators: [
+    (Story) => (
+      <ReactFlowProvider>
+        <div
+          style={{
+            width: "800px",
+            height: "600px",
+            "--text-primary": "#e6e6e6",
+            "--text-secondary": "#b0b8c4",
+            "--text-tertiary": "#6b7a8d",
+            "--text-disabled": "#444",
+            "--accent-green": "#22c55e",
+            "--accent-yellow": "#eab308",
+            "--accent-red": "#ef4444",
+            "--accent-blue": "#3b82f6",
+            "--bg-elevated": "#252535",
+            "--bg-inset": "#1e1e2e",
+            "--bg-overlay": "rgba(0,0,0,0.4)",
+            "--border-subtle": "#33384a",
+          } as CSSProperties}
+        >
+          <Story />
+        </div>
+      </ReactFlowProvider>
+    ),
+  ],
+  args: {
+    streams: [],
+    sessions: MOCK_SESSIONS,
+    onSelectStream: fn(),
+    resolvedThemeId: "grackle-dark",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CoordinationGraph>;
+
+/** Pick mock streams by id, preserving their declared order. */
+function pick(ids: string[]): typeof MOCK_STREAMS {
+  return MOCK_STREAMS.filter((s) => ids.includes(s.id));
+}
+
+/** With no streams, the graph shows an empty placeholder. */
+export const EmptyState: Story = {
+  name: "Empty state",
+  args: { streams: [] },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph-empty")).toBeInTheDocument();
+  },
+};
+
+/** A self-echo chatroom renders as a hub with its participant sessions. */
+export const ChatroomHub: Story = {
+  name: "Chatroom hub",
+  args: { streams: pick(["stream-planning"]) },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph")).toBeInTheDocument();
+  },
+};
+
+/** A non-self-echo named stream renders as a channel hub. */
+export const ChannelHub: Story = {
+  name: "Channel hub",
+  args: { streams: pick(["stream-metrics"]) },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph")).toBeInTheDocument();
+  },
+};
+
+/** A two-party pipe collapses into a direct session-to-session edge (no hub). */
+export const PipeCollapsed: Story = {
+  name: "Pipe (collapsed)",
+  args: { streams: pick(["stream-pipe"]) },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph")).toBeInTheDocument();
+  },
+};
+
+/** A stream whose subscriber session is unknown (CLI/MCP) renders an external node. */
+export const OrphanExternal: Story = {
+  name: "Orphan / external",
+  args: { streams: pick(["stream-cli"]) },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph")).toBeInTheDocument();
+  },
+};
+
+/** The full topology including internal plumbing (lifecycle/pipe/stdin). */
+export const FullTopology: Story = {
+  name: "Full topology (internals shown)",
+  args: { streams: MOCK_STREAMS },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByTestId("coordination-graph")).toBeInTheDocument();
+  },
+};

--- a/packages/web-components/src/components/streams/CoordinationGraph.tsx
+++ b/packages/web-components/src/components/streams/CoordinationGraph.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useMemo, type JSX, type MouseEvent } from "react";
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  type Node,
+  type NodeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import type { Session, StreamData } from "../../hooks/types.js";
+import { resolveStatus, STATUS_CSS_VAR_MAP } from "../../utils/taskStatus.js";
+import {
+  SESSION_NODE_TYPE,
+  STREAM_NODE_TYPE,
+  useCoordinationLayout,
+  type CoordNodeData,
+} from "./useCoordinationLayout.js";
+import { SessionNode } from "./SessionNode.js";
+import { StreamNode } from "./StreamNode.js";
+import styles from "./CoordinationGraph.module.scss";
+
+/** Fallback node color for the MiniMap when a CSS variable is unavailable. */
+const MINIMAP_FALLBACK_COLOR: string = "#6b7a8d";
+
+/** Props for {@link CoordinationGraph}. */
+export interface CoordinationGraphProps {
+  /** Streams to visualize (already filtered for internals by the caller). */
+  streams: StreamData[];
+  /** All known sessions, used to resolve subscribers into nodes and colors. */
+  sessions: Session[];
+  /** Currently selected stream id (its hub node is highlighted). */
+  selectedStreamId?: string;
+  /** Called with a stream id when its hub node is clicked. */
+  onSelectStream: (streamId: string) => void;
+  /** Resolved theme id; recomputes MiniMap colors when the theme changes. */
+  resolvedThemeId: string;
+}
+
+/** Custom node type registry for the coordination graph. */
+const nodeTypes: NodeTypes = {
+  [SESSION_NODE_TYPE]: SessionNode,
+  [STREAM_NODE_TYPE]: StreamNode,
+};
+
+/**
+ * Live bipartite network graph of agent sessions and IPC streams. Sessions and
+ * stream "hubs" are dagre-laid-out (deterministic); two-party pipes collapse to
+ * direct edges. Read-only ("watch") - clicking a hub selects its stream.
+ */
+export function CoordinationGraph({
+  streams,
+  sessions,
+  selectedStreamId,
+  onSelectStream,
+  resolvedThemeId,
+}: CoordinationGraphProps): JSX.Element {
+  const layout = useCoordinationLayout(streams, sessions);
+
+  // Mark the selected stream hub so React Flow applies node selection styling.
+  const nodes = useMemo(
+    () =>
+      layout.nodes.map((node) => {
+        const data = node.data as CoordNodeData;
+        const selected = data.kind === "stream" && data.stream.id === selectedStreamId;
+        return selected ? { ...node, selected: true } : node;
+      }),
+    [layout.nodes, selectedStreamId],
+  );
+
+  /** Cached MiniMap colors, recomputed only when the theme changes. */
+  const statusColors = useMemo(() => {
+    const style = getComputedStyle(document.documentElement);
+    const colors: Record<string, string> = {};
+    for (const [status, varName] of Object.entries(STATUS_CSS_VAR_MAP)) {
+      colors[status] = style.getPropertyValue(varName).trim() || MINIMAP_FALLBACK_COLOR;
+    }
+    return colors;
+  }, [resolvedThemeId]);
+
+  const onNodeClick = useCallback(
+    (_event: MouseEvent, node: Node) => {
+      const data = node.data as CoordNodeData;
+      if (data.kind === "stream") {
+        onSelectStream(data.stream.id);
+      }
+    },
+    [onSelectStream],
+  );
+
+  const minimapNodeColor = useCallback(
+    (node: Node): string => {
+      const data = node.data as CoordNodeData;
+      if (data.kind === "session") {
+        return statusColors[resolveStatus(data.session.status)] || MINIMAP_FALLBACK_COLOR;
+      }
+      return MINIMAP_FALLBACK_COLOR;
+    },
+    [statusColors],
+  );
+
+  if (layout.nodes.length === 0) {
+    return (
+      <div className={styles.empty} data-testid="coordination-graph-empty">
+        No active streams to visualize
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.graphContainer} data-testid="coordination-graph">
+      <ReactFlow
+        nodes={nodes}
+        edges={layout.edges}
+        nodeTypes={nodeTypes}
+        onNodeClick={onNodeClick}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        minZoom={0.3}
+        maxZoom={2}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={24} size={1} color="var(--text-disabled)" />
+        <Controls showInteractive={false} />
+        <MiniMap
+          nodeColor={minimapNodeColor}
+          maskColor="var(--bg-overlay)"
+          style={{ background: "var(--bg-inset)" }}
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/packages/web-components/src/components/streams/CoordinationGraph.tsx
+++ b/packages/web-components/src/components/streams/CoordinationGraph.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { Session, StreamData } from "../../hooks/types.js";
-import { resolveStatus, STATUS_CSS_VAR_MAP } from "../../utils/taskStatus.js";
+import { SESSION_STATUS_VAR_NAMES, sessionStatusStyle } from "../../utils/sessionStatus.js";
 import {
   SESSION_NODE_TYPE,
   STREAM_NODE_TYPE,
@@ -69,12 +69,12 @@ export function CoordinationGraph({
     [layout.nodes, selectedStreamId],
   );
 
-  /** Cached MiniMap colors, recomputed only when the theme changes. */
-  const statusColors = useMemo(() => {
+  /** Theme-resolved colors for the session-status CSS vars (MiniMap needs concrete colors). */
+  const resolvedStatusColors = useMemo(() => {
     const style = getComputedStyle(document.documentElement);
     const colors: Record<string, string> = {};
-    for (const [status, varName] of Object.entries(STATUS_CSS_VAR_MAP)) {
-      colors[status] = style.getPropertyValue(varName).trim() || MINIMAP_FALLBACK_COLOR;
+    for (const varName of SESSION_STATUS_VAR_NAMES) {
+      colors[varName] = style.getPropertyValue(varName).trim() || MINIMAP_FALLBACK_COLOR;
     }
     return colors;
   }, [resolvedThemeId]);
@@ -93,11 +93,11 @@ export function CoordinationGraph({
     (node: Node): string => {
       const data = node.data as CoordNodeData;
       if (data.kind === "session") {
-        return statusColors[resolveStatus(data.session.status)] || MINIMAP_FALLBACK_COLOR;
+        return resolvedStatusColors[sessionStatusStyle(data.session.status, data.external).varName] ?? MINIMAP_FALLBACK_COLOR;
       }
       return MINIMAP_FALLBACK_COLOR;
     },
-    [statusColors],
+    [resolvedStatusColors],
   );
 
   if (layout.nodes.length === 0) {

--- a/packages/web-components/src/components/streams/CoordinationList.tsx
+++ b/packages/web-components/src/components/streams/CoordinationList.tsx
@@ -59,6 +59,8 @@ export interface CoordinationListProps {
   onSelectStream: (streamId: string) => void;
   /** Optional refresh callback. */
   onRefresh?: () => void;
+  /** Hide the header controls (Show internals + refresh) when the page renders them itself. */
+  hideHeaderControls?: boolean;
 }
 
 /** Read-only, task-grouped inventory of IPC streams. */
@@ -74,6 +76,7 @@ export function CoordinationList({
   selectedStreamId,
   onSelectStream,
   onRefresh,
+  hideHeaderControls = false,
 }: CoordinationListProps): JSX.Element {
   const groups = groupStreamsByTask(streams, sessions);
   const kindClass: Record<StreamKind, string> = {
@@ -87,28 +90,30 @@ export function CoordinationList({
     <div className={styles.container} data-testid="coordination-list">
       <div className={styles.header}>
         <span className={styles.title}>Coordination</span>
-        <div className={styles.headerActions}>
-          <label className={styles.internalsToggle}>
-            <input
-              type="checkbox"
-              checked={showInternals}
-              onChange={(e) => onToggleInternals(e.target.checked)}
-              data-testid="coordination-show-internals"
-            />
-            Show internals
-          </label>
-          {onRefresh && (
-            <button
-              type="button"
-              className={styles.refreshButton}
-              onClick={onRefresh}
-              aria-label="Refresh streams"
-              data-testid="coordination-refresh"
-            >
-              <RefreshCw size={ICON_SM} aria-hidden="true" />
-            </button>
-          )}
-        </div>
+        {!hideHeaderControls && (
+          <div className={styles.headerActions}>
+            <label className={styles.internalsToggle}>
+              <input
+                type="checkbox"
+                checked={showInternals}
+                onChange={(e) => onToggleInternals(e.target.checked)}
+                data-testid="coordination-show-internals"
+              />
+              Show internals
+            </label>
+            {onRefresh && (
+              <button
+                type="button"
+                className={styles.refreshButton}
+                onClick={onRefresh}
+                aria-label="Refresh streams"
+                data-testid="coordination-refresh"
+              >
+                <RefreshCw size={ICON_SM} aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {loading && streams.length === 0 && <div className={styles.state}>Loading{"…"}</div>}

--- a/packages/web-components/src/components/streams/SessionNode.tsx
+++ b/packages/web-components/src/components/streams/SessionNode.tsx
@@ -1,9 +1,38 @@
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps } from "@xyflow/react";
 import type { JSX } from "react";
-import { getStatusStyle } from "../../utils/taskStatus.js";
 import type { SessionNodeData } from "./useCoordinationLayout.js";
 import styles from "./CoordinationGraph.module.scss";
+
+/** Capitalize the first letter of a status string for display. */
+function capitalize(value: string): string {
+  return value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+/**
+ * Color + label for a session node. Sessions use a different status vocabulary
+ * than tasks (running / stopped / suspended / idle / hibernating / ...), so this
+ * maps them directly rather than reusing the task-status helper.
+ */
+function sessionStatusStyle(status: string, external: boolean): { color: string; label: string } {
+  if (external) {
+    return { color: "var(--text-tertiary)", label: "external" };
+  }
+  switch (status) {
+    case "running":
+      return { color: "var(--accent-green)", label: "Running" };
+    case "idle":
+    case "suspended":
+    case "hibernating":
+      return { color: "var(--accent-yellow)", label: capitalize(status) };
+    case "failed":
+    case "interrupted":
+      return { color: "var(--accent-red)", label: capitalize(status) };
+    default:
+      // stopped, completed, unknown, etc.
+      return { color: "var(--text-tertiary)", label: status.length > 0 ? capitalize(status) : "Unknown" };
+  }
+}
 
 /**
  * Custom React Flow node rendering an agent session as a status-colored card.
@@ -12,22 +41,19 @@ import styles from "./CoordinationGraph.module.scss";
  */
 export function SessionNode({ data }: NodeProps): JSX.Element {
   const { session, streamCount, external } = data as SessionNodeData;
-  const statusStyle = getStatusStyle(session.status);
+  const status = sessionStatusStyle(session.status, external);
   const className = external ? `${styles.sessionNode} ${styles.external}` : styles.sessionNode;
 
   return (
     <div className={className} data-testid={`coordination-node-session-${session.id}`}>
       <Handle type="target" position={Position.Left} className={styles.handle} />
-      <div className={styles.sessionAccent} style={{ backgroundColor: statusStyle.color }} />
+      <div className={styles.sessionAccent} style={{ backgroundColor: status.color }} />
       <div className={styles.nodeContent}>
         <div className={styles.nodeHeader}>
-          <span className={styles.nodeIcon} style={{ color: statusStyle.color }}>
-            {statusStyle.icon}
-          </span>
           <span className={styles.nodeTitle}>{external ? session.id : session.runtime}</span>
         </div>
         <div className={styles.nodeMeta}>
-          <span className={styles.nodeSubtle}>{external ? "external" : statusStyle.label}</span>
+          <span className={styles.nodeSubtle} style={{ color: status.color }}>{status.label}</span>
           {streamCount > 0 && <span className={styles.countBadge}>{streamCount}</span>}
         </div>
       </div>

--- a/packages/web-components/src/components/streams/SessionNode.tsx
+++ b/packages/web-components/src/components/streams/SessionNode.tsx
@@ -1,38 +1,9 @@
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps } from "@xyflow/react";
 import type { JSX } from "react";
+import { sessionStatusStyle } from "../../utils/sessionStatus.js";
 import type { SessionNodeData } from "./useCoordinationLayout.js";
 import styles from "./CoordinationGraph.module.scss";
-
-/** Capitalize the first letter of a status string for display. */
-function capitalize(value: string): string {
-  return value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
-}
-
-/**
- * Color + label for a session node. Sessions use a different status vocabulary
- * than tasks (running / stopped / suspended / idle / hibernating / ...), so this
- * maps them directly rather than reusing the task-status helper.
- */
-function sessionStatusStyle(status: string, external: boolean): { color: string; label: string } {
-  if (external) {
-    return { color: "var(--text-tertiary)", label: "external" };
-  }
-  switch (status) {
-    case "running":
-      return { color: "var(--accent-green)", label: "Running" };
-    case "idle":
-    case "suspended":
-    case "hibernating":
-      return { color: "var(--accent-yellow)", label: capitalize(status) };
-    case "failed":
-    case "interrupted":
-      return { color: "var(--accent-red)", label: capitalize(status) };
-    default:
-      // stopped, completed, unknown, etc.
-      return { color: "var(--text-tertiary)", label: status.length > 0 ? capitalize(status) : "Unknown" };
-  }
-}
 
 /**
  * Custom React Flow node rendering an agent session as a status-colored card.
@@ -42,18 +13,19 @@ function sessionStatusStyle(status: string, external: boolean): { color: string;
 export function SessionNode({ data }: NodeProps): JSX.Element {
   const { session, streamCount, external } = data as SessionNodeData;
   const status = sessionStatusStyle(session.status, external);
+  const color = `var(${status.varName})`;
   const className = external ? `${styles.sessionNode} ${styles.external}` : styles.sessionNode;
 
   return (
     <div className={className} data-testid={`coordination-node-session-${session.id}`}>
       <Handle type="target" position={Position.Left} className={styles.handle} />
-      <div className={styles.sessionAccent} style={{ backgroundColor: status.color }} />
+      <div className={styles.sessionAccent} style={{ backgroundColor: color }} />
       <div className={styles.nodeContent}>
         <div className={styles.nodeHeader}>
           <span className={styles.nodeTitle}>{external ? session.id : session.runtime}</span>
         </div>
         <div className={styles.nodeMeta}>
-          <span className={styles.nodeSubtle} style={{ color: status.color }}>{status.label}</span>
+          <span className={styles.nodeSubtle} style={{ color }}>{status.label}</span>
           {streamCount > 0 && <span className={styles.countBadge}>{streamCount}</span>}
         </div>
       </div>

--- a/packages/web-components/src/components/streams/SessionNode.tsx
+++ b/packages/web-components/src/components/streams/SessionNode.tsx
@@ -1,0 +1,37 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import type { JSX } from "react";
+import { getStatusStyle } from "../../utils/taskStatus.js";
+import type { SessionNodeData } from "./useCoordinationLayout.js";
+import styles from "./CoordinationGraph.module.scss";
+
+/**
+ * Custom React Flow node rendering an agent session as a status-colored card.
+ * Used by {@link CoordinationGraph}; handles flow left (target) to right (source)
+ * to match the bipartite LR layout.
+ */
+export function SessionNode({ data }: NodeProps): JSX.Element {
+  const { session, streamCount, external } = data as SessionNodeData;
+  const statusStyle = getStatusStyle(session.status);
+  const className = external ? `${styles.sessionNode} ${styles.external}` : styles.sessionNode;
+
+  return (
+    <div className={className} data-testid={`coordination-node-session-${session.id}`}>
+      <Handle type="target" position={Position.Left} className={styles.handle} />
+      <div className={styles.sessionAccent} style={{ backgroundColor: statusStyle.color }} />
+      <div className={styles.nodeContent}>
+        <div className={styles.nodeHeader}>
+          <span className={styles.nodeIcon} style={{ color: statusStyle.color }}>
+            {statusStyle.icon}
+          </span>
+          <span className={styles.nodeTitle}>{external ? session.id : session.runtime}</span>
+        </div>
+        <div className={styles.nodeMeta}>
+          <span className={styles.nodeSubtle}>{external ? "external" : statusStyle.label}</span>
+          {streamCount > 0 && <span className={styles.countBadge}>{streamCount}</span>}
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} className={styles.handle} />
+    </div>
+  );
+}

--- a/packages/web-components/src/components/streams/StreamNode.tsx
+++ b/packages/web-components/src/components/streams/StreamNode.tsx
@@ -5,13 +5,15 @@ import type { StreamNodeData } from "./useCoordinationLayout.js";
 import styles from "./CoordinationGraph.module.scss";
 
 /**
- * Custom React Flow node rendering an IPC stream hub (chatroom or channel).
- * Chatrooms get a halo; non-task-owned hubs render dimmed/haloless. Clicking the
- * node selects the stream (opens its detail panel) via {@link CoordinationGraph}.
+ * Custom React Flow node rendering an IPC stream hub (chatroom, channel, or a
+ * non-collapsible pipe). Chatrooms get a halo; non-task-owned hubs render
+ * dimmed/haloless. Clicking the node selects the stream (opens its detail panel)
+ * via {@link CoordinationGraph}.
  */
 export function StreamNode({ data, selected }: NodeProps): JSX.Element {
   const { stream, streamKind, ownership } = data as StreamNodeData;
-  const classNames = [styles.streamNode, streamKind === "chatroom" ? styles.chatroom : styles.channel];
+  const kindClass = streamKind === "chatroom" ? styles.chatroom : streamKind === "pipe" ? styles.pipe : styles.channel;
+  const classNames = [styles.streamNode, kindClass];
   if (ownership.kind !== "task") {
     classNames.push(styles.haloless);
   }

--- a/packages/web-components/src/components/streams/StreamNode.tsx
+++ b/packages/web-components/src/components/streams/StreamNode.tsx
@@ -1,0 +1,37 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import type { JSX } from "react";
+import type { StreamNodeData } from "./useCoordinationLayout.js";
+import styles from "./CoordinationGraph.module.scss";
+
+/**
+ * Custom React Flow node rendering an IPC stream hub (chatroom or channel).
+ * Chatrooms get a halo; non-task-owned hubs render dimmed/haloless. Clicking the
+ * node selects the stream (opens its detail panel) via {@link CoordinationGraph}.
+ */
+export function StreamNode({ data, selected }: NodeProps): JSX.Element {
+  const { stream, streamKind, ownership } = data as StreamNodeData;
+  const classNames = [styles.streamNode, streamKind === "chatroom" ? styles.chatroom : styles.channel];
+  if (ownership.kind !== "task") {
+    classNames.push(styles.haloless);
+  }
+  if (selected) {
+    classNames.push(styles.selected);
+  }
+
+  return (
+    <div className={classNames.join(" ")} data-testid={`coordination-node-stream-${stream.id}`}>
+      <Handle type="target" position={Position.Left} className={styles.handle} />
+      <div className={styles.nodeContent}>
+        <div className={styles.nodeHeader}>
+          <span className={styles.kindBadge}>{streamKind}</span>
+        </div>
+        <span className={styles.nodeTitle}>{stream.name}</span>
+        <span className={styles.nodeSubtle}>
+          {stream.subscriberCount} {stream.subscriberCount === 1 ? "subscriber" : "subscribers"}
+        </span>
+      </div>
+      <Handle type="source" position={Position.Right} className={styles.handle} />
+    </div>
+  );
+}

--- a/packages/web-components/src/components/streams/coordinationGraphModel.test.ts
+++ b/packages/web-components/src/components/streams/coordinationGraphModel.test.ts
@@ -116,8 +116,9 @@ describe("buildCoordinationGraph", () => {
     const edge = edges[0];
     expect(edge.source).toBe("session:a");
     expect(edge.target).toBe("session:b");
+    // Bidirectional pipes carry arrowheads on both ends (no implied direction).
     expect(edge.markerStart).toBeDefined();
-    expect(edge.markerEnd).toBeUndefined();
+    expect(edge.markerEnd).toBeDefined();
   });
 
   it("does not collapse a pipe with more than two subscribers (falls back to a hub)", () => {

--- a/packages/web-components/src/components/streams/coordinationGraphModel.test.ts
+++ b/packages/web-components/src/components/streams/coordinationGraphModel.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import type { Session, StreamData, StreamSubscriberData } from "../../hooks/types.js";
+import {
+  buildCoordinationGraph,
+  SESSION_NODE_TYPE,
+  STREAM_NODE_TYPE,
+  type CoordEdgeData,
+  type CoordNodeData,
+  type SessionNodeData,
+} from "./coordinationGraphModel.js";
+import type { Edge, Node } from "@xyflow/react";
+
+function makeSub(sessionId: string, permission: string = "rw", deliveryMode: string = "async"): StreamSubscriberData {
+  return { subscriptionId: `sub-${sessionId}`, sessionId, fd: 3, permission, deliveryMode, createdBySpawn: false };
+}
+
+function makeStream(over: Partial<StreamData> & { id: string; name: string }): StreamData {
+  return {
+    subscriberCount: over.subscribers?.length ?? 0,
+    messageBufferDepth: 0,
+    selfEcho: false,
+    subscribers: [],
+    ...over,
+  };
+}
+
+function makeSession(id: string, taskId?: string): Session {
+  return { id, environmentId: "env-1", runtime: "claude-code", status: "running", prompt: "", startedAt: "2026-01-01T00:00:00Z", taskId };
+}
+
+function sessionNodes(nodes: Node<CoordNodeData>[]): Node<CoordNodeData>[] {
+  return nodes.filter((n) => n.type === SESSION_NODE_TYPE);
+}
+
+function streamNodes(nodes: Node<CoordNodeData>[]): Node<CoordNodeData>[] {
+  return nodes.filter((n) => n.type === STREAM_NODE_TYPE);
+}
+
+function edgeById(edges: Edge<CoordEdgeData>[], id: string): Edge<CoordEdgeData> {
+  const edge = edges.find((e) => e.id === id);
+  if (!edge) {
+    throw new Error(`edge not found: ${id}`);
+  }
+  return edge;
+}
+
+describe("buildCoordinationGraph", () => {
+  it("returns empty for no streams", () => {
+    expect(buildCoordinationGraph([], [makeSession("s1")])).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("renders a chatroom as a hub with one participation edge per subscriber", () => {
+    const stream = makeStream({
+      id: "room1",
+      name: "planning",
+      selfEcho: true,
+      subscribers: [makeSub("s1", "rw"), makeSub("s2", "r")],
+    });
+    const { nodes, edges } = buildCoordinationGraph([stream], [makeSession("s1", "task-1"), makeSession("s2", "task-1")]);
+
+    expect(streamNodes(nodes)).toHaveLength(1);
+    expect(sessionNodes(nodes)).toHaveLength(2);
+    expect(edges).toHaveLength(2);
+  });
+
+  it("emits a single bidirectional edge for an rw subscriber (never two)", () => {
+    const stream = makeStream({ id: "room1", name: "planning", selfEcho: true, subscribers: [makeSub("s1", "rw")] });
+    const { edges } = buildCoordinationGraph([stream], [makeSession("s1")]);
+
+    expect(edges).toHaveLength(1);
+    const edge = edgeById(edges, "edge-part-room1-sub-s1");
+    expect(edge.source).toBe("session:s1");
+    expect(edge.target).toBe("stream:room1");
+    expect(edge.markerStart).toBeDefined();
+    expect(edge.markerEnd).toBeDefined();
+  });
+
+  it("orients a writer subscriber session -> hub and a reader hub -> session", () => {
+    const stream = makeStream({
+      id: "ch1",
+      name: "telemetry",
+      subscribers: [makeSub("w1", "w"), makeSub("r1", "r")],
+    });
+    const { edges } = buildCoordinationGraph([stream], [makeSession("w1"), makeSession("r1")]);
+
+    const writer = edgeById(edges, "edge-part-ch1-sub-w1");
+    expect(writer.source).toBe("session:w1");
+    expect(writer.target).toBe("stream:ch1");
+    expect(writer.markerStart).toBeUndefined();
+
+    const reader = edgeById(edges, "edge-part-ch1-sub-r1");
+    expect(reader.source).toBe("stream:ch1");
+    expect(reader.target).toBe("session:r1");
+  });
+
+  it("collapses a 2-party pipe into a direct writer -> reader edge with no hub node", () => {
+    const stream = makeStream({ id: "p1", name: "pipe:s1-s2", subscribers: [makeSub("s1", "w"), makeSub("s2", "r")] });
+    const { nodes, edges } = buildCoordinationGraph([stream], [makeSession("s1"), makeSession("s2")]);
+
+    expect(streamNodes(nodes)).toHaveLength(0);
+    expect(sessionNodes(nodes)).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+    const edge = edges[0];
+    expect(edge.data?.edgeKind).toBe("pipe");
+    expect(edge.source).toBe("session:s1");
+    expect(edge.target).toBe("session:s2");
+    expect(edge.markerEnd).toBeDefined();
+    expect(edge.markerStart).toBeUndefined();
+  });
+
+  it("draws a collapsed rw/rw pipe as bidirectional in deterministic order", () => {
+    const stream = makeStream({ id: "p2", name: "pipe:b-a", subscribers: [makeSub("b", "rw"), makeSub("a", "rw")] });
+    const { edges } = buildCoordinationGraph([stream], [makeSession("a"), makeSession("b")]);
+
+    expect(edges).toHaveLength(1);
+    const edge = edges[0];
+    expect(edge.source).toBe("session:a");
+    expect(edge.target).toBe("session:b");
+    expect(edge.markerStart).toBeDefined();
+    expect(edge.markerEnd).toBeUndefined();
+  });
+
+  it("does not collapse a pipe with more than two subscribers (falls back to a hub)", () => {
+    const stream = makeStream({
+      id: "p3",
+      name: "pipe:multi",
+      subscribers: [makeSub("s1"), makeSub("s2"), makeSub("s3")],
+    });
+    const { nodes } = buildCoordinationGraph([stream], [makeSession("s1"), makeSession("s2"), makeSession("s3")]);
+    expect(streamNodes(nodes)).toHaveLength(1);
+  });
+
+  it("synthesizes an external session node for an unknown subscriber id", () => {
+    const stream = makeStream({ id: "cli", name: "cli-inspector", subscribers: [makeSub("ext-1", "rw")] });
+    const { nodes } = buildCoordinationGraph([stream], []);
+
+    const sessNodes = sessionNodes(nodes);
+    expect(sessNodes).toHaveLength(1);
+    expect((sessNodes[0].data as SessionNodeData).external).toBe(true);
+  });
+
+  it("counts the streams each session participates in", () => {
+    const a = makeStream({ id: "room", name: "room", selfEcho: true, subscribers: [makeSub("s1", "rw"), makeSub("s2", "r")] });
+    const b = makeStream({ id: "chan", name: "metrics", subscribers: [makeSub("s1", "r")] });
+    const { nodes } = buildCoordinationGraph([a, b], [makeSession("s1"), makeSession("s2")]);
+
+    const s1 = sessionNodes(nodes).find((n) => n.id === "session:s1");
+    expect((s1?.data as SessionNodeData).streamCount).toBe(2);
+  });
+});

--- a/packages/web-components/src/components/streams/coordinationGraphModel.ts
+++ b/packages/web-components/src/components/streams/coordinationGraphModel.ts
@@ -1,0 +1,223 @@
+/**
+ * Pure bipartite graph model for the Coordination view: turns IPC streams and
+ * sessions into React Flow nodes and edges (chatroom/channel hubs, collapsed
+ * two-party pipes, edge direction from permission, external-session synthesis).
+ *
+ * No dagre and no React here — positions are placeholders, assigned later by
+ * {@link useCoordinationLayout}. Keeping this layer dagre-free makes the graph
+ * logic unit-testable (dagre's ESM build does not resolve under vitest).
+ *
+ * @module
+ */
+
+import { MarkerType, type Edge, type Node } from "@xyflow/react";
+import type { Session, StreamData, StreamSubscriberData } from "../../hooks/types.js";
+import { attributeStream, streamKind, type StreamKind, type StreamOwnership } from "../../utils/streamCoordination.js";
+
+/** React Flow node type id for session nodes. */
+export const SESSION_NODE_TYPE: string = "session";
+/** React Flow node type id for stream hub nodes. */
+export const STREAM_NODE_TYPE: string = "stream";
+/**
+ * React Flow edge type id used for all coordination edges. In Phase A this is
+ * the built-in `smoothstep`; Phase B swaps it for the animated `messageDot`.
+ */
+export const COORD_EDGE_TYPE: string = "smoothstep";
+
+/** Data attached to a session node. */
+export interface SessionNodeData extends Record<string, unknown> {
+  kind: "session";
+  /** The session, or a synthetic placeholder when the subscriber's session is unknown. */
+  session: Session;
+  /** Number of visible streams this session participates in. */
+  streamCount: number;
+  /** True when synthesized from a subscriber id not present in the sessions list (CLI/MCP). */
+  external: boolean;
+}
+
+/** Data attached to a stream hub node. */
+export interface StreamNodeData extends Record<string, unknown> {
+  kind: "stream";
+  stream: StreamData;
+  /** Display kind (`chatroom` or `channel`; pipes are collapsed and never become hubs). */
+  streamKind: StreamKind;
+  /** Ownership classification, used to decide whether the hub renders a task halo. */
+  ownership: StreamOwnership;
+}
+
+/** Union of node data shapes carried on the coordination graph. */
+export type CoordNodeData = SessionNodeData | StreamNodeData;
+
+/** Data attached to a coordination edge. */
+export interface CoordEdgeData extends Record<string, unknown> {
+  /** `participation` = session<->hub subscription; `pipe` = collapsed 2-party pipe. */
+  edgeKind: "participation" | "pipe";
+  /** The stream this edge represents (the hub stream, or the collapsed pipe). */
+  streamId: string;
+  /** Subscriber permission ("r" | "w" | "rw") for participation edges. */
+  permission: string;
+  /** Delivery mode ("sync" | "async" | "detach"). */
+  deliveryMode: string;
+  /**
+   * Transient pulse key, stamped by the graph when a new message arrives so the
+   * animated edge fires a one-shot dot (Phase B). Undefined otherwise.
+   */
+  pulseSeq?: string;
+}
+
+/** Nodes and edges for the coordination graph (positions assigned by the layout step). */
+export interface CoordinationLayoutResult {
+  nodes: Node<CoordNodeData>[];
+  edges: Edge<CoordEdgeData>[];
+}
+
+/** Prefix a session id to form its unique React Flow / dagre node id. */
+export function sessionNodeId(sessionId: string): string {
+  return `session:${sessionId}`;
+}
+
+/** Prefix a stream id to form its unique React Flow / dagre node id. */
+export function streamNodeId(streamId: string): string {
+  return `stream:${streamId}`;
+}
+
+/** Minimal placeholder session for a subscriber whose session is not in the list. */
+function syntheticSession(sessionId: string): Session {
+  return { id: sessionId, environmentId: "", runtime: "external", status: "external", prompt: "", startedAt: "" };
+}
+
+/** Edge stroke style derived from delivery mode (detach reads as dashed + dimmed). */
+function deliveryStyle(deliveryMode: string, stroke: string): Record<string, string | number> {
+  if (deliveryMode === "detach") {
+    return { stroke, strokeWidth: 1.5, strokeDasharray: "4 4", opacity: 0.6 };
+  }
+  return { stroke, strokeWidth: 1.5 };
+}
+
+/** Resolve a collapsed pipe's direction (writer -> reader), or mark it bidirectional. */
+function resolvePipeDirection(
+  a: StreamSubscriberData,
+  b: StreamSubscriberData,
+): { source: string; target: string; bidirectional: boolean } {
+  const aWrites = a.permission.includes("w");
+  const bWrites = b.permission.includes("w");
+  const aReads = a.permission.includes("r");
+  const bReads = b.permission.includes("r");
+  if (aWrites && !bWrites && bReads) {
+    return { source: a.sessionId, target: b.sessionId, bidirectional: false };
+  }
+  if (bWrites && !aWrites && aReads) {
+    return { source: b.sessionId, target: a.sessionId, bidirectional: false };
+  }
+  // Ambiguous (both rw, both w, etc.) — pick a deterministic order, no direction.
+  const ordered = [a.sessionId, b.sessionId].sort();
+  return { source: ordered[0], target: ordered[1], bidirectional: true };
+}
+
+/**
+ * Build the bipartite coordination graph (nodes + edges) from streams and
+ * sessions. Node positions are placeholders ({@link useCoordinationLayout} runs
+ * dagre to assign real positions). Sessions with no visible streams are omitted.
+ *
+ * `showInternals` filtering is the caller's responsibility — the streams passed
+ * in are assumed already filtered (the page calls `loadStreams(includeInternal)`).
+ */
+export function buildCoordinationGraph(streams: StreamData[], sessions: Session[]): CoordinationLayoutResult {
+  if (streams.length === 0) {
+    return { nodes: [], edges: [] };
+  }
+
+  const sessionsById = new Map(sessions.map((s) => [s.id, s]));
+  const sessionNodeData = new Map<string, SessionNodeData>();
+  const streamNodeData = new Map<string, StreamNodeData>();
+  const edges: Edge<CoordEdgeData>[] = [];
+
+  /** Register a session node once, returning its (mutable) data. */
+  const ensureSessionNode = (sessionId: string): SessionNodeData => {
+    let data = sessionNodeData.get(sessionId);
+    if (!data) {
+      const session = sessionsById.get(sessionId);
+      data = {
+        kind: "session",
+        session: session ?? syntheticSession(sessionId),
+        streamCount: 0,
+        external: session === undefined,
+      };
+      sessionNodeData.set(sessionId, data);
+    }
+    return data;
+  };
+
+  for (const stream of streams) {
+    const kind = streamKind(stream);
+
+    // Collapse a 2-party pipe into a single direct session->session edge.
+    if (kind === "pipe" && stream.subscribers.length === 2 && stream.subscribers[0].sessionId !== stream.subscribers[1].sessionId) {
+      const [a, b] = stream.subscribers;
+      ensureSessionNode(a.sessionId).streamCount += 1;
+      ensureSessionNode(b.sessionId).streamCount += 1;
+      const { source, target, bidirectional } = resolvePipeDirection(a, b);
+      edges.push({
+        id: `edge-pipe-${stream.id}`,
+        source: sessionNodeId(source),
+        target: sessionNodeId(target),
+        type: COORD_EDGE_TYPE,
+        data: { edgeKind: "pipe", streamId: stream.id, permission: "rw", deliveryMode: a.deliveryMode },
+        style: { stroke: "var(--accent-yellow)", strokeWidth: 1.5, strokeDasharray: "6 3" },
+        markerEnd: bidirectional ? undefined : { type: MarkerType.ArrowClosed },
+        markerStart: bidirectional ? { type: MarkerType.ArrowClosed } : undefined,
+        animated: false,
+      });
+      continue;
+    }
+
+    // Otherwise render a hub node with one participation edge per subscriber.
+    streamNodeData.set(stream.id, { kind: "stream", stream, streamKind: kind, ownership: attributeStream(stream, sessions) });
+
+    for (const sub of stream.subscribers) {
+      ensureSessionNode(sub.sessionId).streamCount += 1;
+      const hub = streamNodeId(stream.id);
+      const sess = sessionNodeId(sub.sessionId);
+      const writes = sub.permission.includes("w");
+      const reads = sub.permission.includes("r");
+
+      let source: string;
+      let target: string;
+      let bidirectional = false;
+      if (writes && reads) {
+        source = sess;
+        target = hub;
+        bidirectional = true;
+      } else if (reads) {
+        source = hub;
+        target = sess;
+      } else {
+        // writer (or unknown) — session feeds the hub
+        source = sess;
+        target = hub;
+      }
+
+      edges.push({
+        id: `edge-part-${stream.id}-${sub.subscriptionId}`,
+        source,
+        target,
+        type: COORD_EDGE_TYPE,
+        data: { edgeKind: "participation", streamId: stream.id, permission: sub.permission, deliveryMode: sub.deliveryMode },
+        style: deliveryStyle(sub.deliveryMode, "var(--text-tertiary)"),
+        markerEnd: { type: MarkerType.ArrowClosed },
+        markerStart: bidirectional ? { type: MarkerType.ArrowClosed } : undefined,
+        animated: false,
+      });
+    }
+  }
+
+  const nodes: Node<CoordNodeData>[] = [];
+  for (const [sessionId, data] of sessionNodeData) {
+    nodes.push({ id: sessionNodeId(sessionId), type: SESSION_NODE_TYPE, position: { x: 0, y: 0 }, data });
+  }
+  for (const [streamId, data] of streamNodeData) {
+    nodes.push({ id: streamNodeId(streamId), type: STREAM_NODE_TYPE, position: { x: 0, y: 0 }, data });
+  }
+
+  return { nodes, edges };
+}

--- a/packages/web-components/src/components/streams/coordinationGraphModel.ts
+++ b/packages/web-components/src/components/streams/coordinationGraphModel.ts
@@ -12,7 +12,7 @@
 
 import { MarkerType, type Edge, type Node } from "@xyflow/react";
 import type { Session, StreamData, StreamSubscriberData } from "../../hooks/types.js";
-import { attributeStream, streamKind, type StreamKind, type StreamOwnership } from "../../utils/streamCoordination.js";
+import { attributeStreamWithMap, streamKind, type StreamKind, type StreamOwnership } from "../../utils/streamCoordination.js";
 
 /** React Flow node type id for session nodes. */
 export const SESSION_NODE_TYPE: string = "session";
@@ -94,23 +94,23 @@ function deliveryStyle(deliveryMode: string, stroke: string): Record<string, str
   return { stroke, strokeWidth: 1.5 };
 }
 
-/** Resolve a collapsed pipe's direction (writer -> reader), or mark it bidirectional. */
+/** Resolve a collapsed pipe's direction (writer -> reader subscriber), or mark it bidirectional. */
 function resolvePipeDirection(
   a: StreamSubscriberData,
   b: StreamSubscriberData,
-): { source: string; target: string; bidirectional: boolean } {
+): { source: StreamSubscriberData; target: StreamSubscriberData; bidirectional: boolean } {
   const aWrites = a.permission.includes("w");
   const bWrites = b.permission.includes("w");
   const aReads = a.permission.includes("r");
   const bReads = b.permission.includes("r");
   if (aWrites && !bWrites && bReads) {
-    return { source: a.sessionId, target: b.sessionId, bidirectional: false };
+    return { source: a, target: b, bidirectional: false };
   }
   if (bWrites && !aWrites && aReads) {
-    return { source: b.sessionId, target: a.sessionId, bidirectional: false };
+    return { source: b, target: a, bidirectional: false };
   }
   // Ambiguous (both rw, both w, etc.) — pick a deterministic order, no direction.
-  const ordered = [a.sessionId, b.sessionId].sort();
+  const ordered = [a, b].sort((x, y) => x.sessionId.localeCompare(y.sessionId));
   return { source: ordered[0], target: ordered[1], bidirectional: true };
 }
 
@@ -156,15 +156,23 @@ export function buildCoordinationGraph(streams: StreamData[], sessions: Session[
       const [a, b] = stream.subscribers;
       ensureSessionNode(a.sessionId).streamCount += 1;
       ensureSessionNode(b.sessionId).streamCount += 1;
-      const { source, target, bidirectional } = resolvePipeDirection(a, b);
+      const { source: srcSub, target: tgtSub, bidirectional } = resolvePipeDirection(a, b);
       edges.push({
         id: `edge-pipe-${stream.id}`,
-        source: sessionNodeId(source),
-        target: sessionNodeId(target),
+        source: sessionNodeId(srcSub.sessionId),
+        target: sessionNodeId(tgtSub.sessionId),
         type: COORD_EDGE_TYPE,
-        data: { edgeKind: "pipe", streamId: stream.id, permission: "rw", deliveryMode: a.deliveryMode },
+        // Derive metadata from the deterministically-resolved writer so the
+        // collapsed edge does not depend on arbitrary subscriber order.
+        data: {
+          edgeKind: "pipe",
+          streamId: stream.id,
+          permission: bidirectional ? "rw" : srcSub.permission,
+          deliveryMode: srcSub.deliveryMode,
+        },
         style: { stroke: "var(--accent-yellow)", strokeWidth: 1.5, strokeDasharray: "6 3" },
-        markerEnd: bidirectional ? undefined : { type: MarkerType.ArrowClosed },
+        // Bidirectional pipes get arrowheads on both ends; directed pipes only at the reader.
+        markerEnd: { type: MarkerType.ArrowClosed },
         markerStart: bidirectional ? { type: MarkerType.ArrowClosed } : undefined,
         animated: false,
       });
@@ -172,7 +180,7 @@ export function buildCoordinationGraph(streams: StreamData[], sessions: Session[
     }
 
     // Otherwise render a hub node with one participation edge per subscriber.
-    streamNodeData.set(stream.id, { kind: "stream", stream, streamKind: kind, ownership: attributeStream(stream, sessions) });
+    streamNodeData.set(stream.id, { kind: "stream", stream, streamKind: kind, ownership: attributeStreamWithMap(stream, sessionsById) });
 
     for (const sub of stream.subscribers) {
       ensureSessionNode(sub.sessionId).streamCount += 1;

--- a/packages/web-components/src/components/streams/coordinationGraphModel.ts
+++ b/packages/web-components/src/components/streams/coordinationGraphModel.ts
@@ -39,7 +39,11 @@ export interface SessionNodeData extends Record<string, unknown> {
 export interface StreamNodeData extends Record<string, unknown> {
   kind: "stream";
   stream: StreamData;
-  /** Display kind (`chatroom` or `channel`; pipes are collapsed and never become hubs). */
+  /**
+   * Display kind. Two-party pipes are collapsed into a direct edge and never
+   * become hubs; a `pipe` stream that cannot collapse (e.g. not exactly two
+   * distinct sessions) still renders as a hub with kind `pipe`.
+   */
   streamKind: StreamKind;
   /** Ownership classification, used to decide whether the hub renders a task halo. */
   ownership: StreamOwnership;

--- a/packages/web-components/src/components/streams/index.ts
+++ b/packages/web-components/src/components/streams/index.ts
@@ -10,3 +10,15 @@ export { StreamDetailPanel } from "./StreamDetailPanel.js";
 export type { StreamDetailPanelProps } from "./StreamDetailPanel.js";
 export { StreamTranscript } from "./StreamTranscript.js";
 export type { StreamTranscriptProps } from "./StreamTranscript.js";
+export { CoordinationGraph } from "./CoordinationGraph.js";
+export type { CoordinationGraphProps } from "./CoordinationGraph.js";
+export { SessionNode } from "./SessionNode.js";
+export { StreamNode } from "./StreamNode.js";
+export { buildCoordinationGraph, useCoordinationLayout } from "./useCoordinationLayout.js";
+export type {
+  CoordEdgeData,
+  CoordNodeData,
+  CoordinationLayoutResult,
+  SessionNodeData,
+  StreamNodeData,
+} from "./useCoordinationLayout.js";

--- a/packages/web-components/src/components/streams/useCoordinationLayout.ts
+++ b/packages/web-components/src/components/streams/useCoordinationLayout.ts
@@ -1,0 +1,93 @@
+/**
+ * Dagre positioning layer for the Coordination graph. Takes the pure
+ * {@link buildCoordinationGraph} model (dagre-free, unit-testable) and assigns
+ * deterministic node positions via a left-to-right bipartite dagre layout.
+ *
+ * @module
+ */
+
+import { useMemo } from "react";
+import dagre from "@dagrejs/dagre";
+import type { Node } from "@xyflow/react";
+import type { Session, StreamData } from "../../hooks/types.js";
+import {
+  buildCoordinationGraph,
+  STREAM_NODE_TYPE,
+  type CoordNodeData,
+  type CoordinationLayoutResult,
+} from "./coordinationGraphModel.js";
+
+export {
+  buildCoordinationGraph,
+  sessionNodeId,
+  streamNodeId,
+  COORD_EDGE_TYPE,
+  SESSION_NODE_TYPE,
+  STREAM_NODE_TYPE,
+} from "./coordinationGraphModel.js";
+export type {
+  CoordEdgeData,
+  CoordNodeData,
+  CoordinationLayoutResult,
+  SessionNodeData,
+  StreamNodeData,
+} from "./coordinationGraphModel.js";
+
+/** Width of a session node (pixels). */
+const SESSION_NODE_WIDTH: number = 200;
+/** Height of a session node (pixels). */
+const SESSION_NODE_HEIGHT: number = 64;
+/** Width of a stream hub node (pixels). */
+const STREAM_NODE_WIDTH: number = 180;
+/** Height of a stream hub node (pixels). */
+const STREAM_NODE_HEIGHT: number = 56;
+/** Separation between sibling nodes within a rank (pixels). */
+const NODE_SEPARATION: number = 40;
+/** Separation between rank levels (pixels). */
+const RANK_SEPARATION: number = 70;
+
+/** Node dimensions for dagre, keyed by node type. */
+function nodeDimensions(type: string | undefined): { width: number; height: number } {
+  if (type === STREAM_NODE_TYPE) {
+    return { width: STREAM_NODE_WIDTH, height: STREAM_NODE_HEIGHT };
+  }
+  return { width: SESSION_NODE_WIDTH, height: SESSION_NODE_HEIGHT };
+}
+
+/** Assign dagre positions to a pure coordination graph model. */
+function layoutGraph(model: CoordinationLayoutResult): CoordinationLayoutResult {
+  if (model.nodes.length === 0) {
+    return model;
+  }
+
+  const graph = new dagre.graphlib.Graph({ multigraph: true });
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({ rankdir: "LR", nodesep: NODE_SEPARATION, ranksep: RANK_SEPARATION });
+
+  for (const node of model.nodes) {
+    const { width, height } = nodeDimensions(node.type);
+    graph.setNode(node.id, { width, height });
+  }
+  for (const edge of model.edges) {
+    graph.setEdge(edge.source, edge.target, {}, edge.id);
+  }
+
+  dagre.layout(graph);
+
+  const nodes: Node<CoordNodeData>[] = model.nodes.map((node) => {
+    const pos = graph.node(node.id) as { x: number; y: number };
+    const { width, height } = nodeDimensions(node.type);
+    return { ...node, position: { x: pos.x - width / 2, y: pos.y - height / 2 } };
+  });
+
+  return { nodes, edges: model.edges };
+}
+
+/**
+ * Build and lay out the coordination graph, memoized on its inputs. Sessions
+ * with no visible streams are intentionally omitted — the graph shows
+ * coordination, not the full session inventory.
+ */
+export function useCoordinationLayout(streams: StreamData[], sessions: Session[]): CoordinationLayoutResult {
+  return useMemo(() => layoutGraph(buildCoordinationGraph(streams, sessions)), [streams, sessions]);
+}

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -87,8 +87,8 @@ export type { ScheduleManagerProps } from "./components/schedules/ScheduleManage
 export { SettingsNav } from "./components/settings/SettingsNav.js";
 
 // Streams (Coordination tab)
-export { CoordinationList, StreamDetailPanel, StreamTranscript } from "./components/streams/index.js";
-export type { CoordinationListProps, StreamDetailPanelProps, StreamTranscriptProps } from "./components/streams/index.js";
+export { CoordinationGraph, CoordinationList, StreamDetailPanel, StreamTranscript } from "./components/streams/index.js";
+export type { CoordinationGraphProps, CoordinationListProps, StreamDetailPanelProps, StreamTranscriptProps } from "./components/streams/index.js";
 
 // Tools
 export { ToolCard } from "./components/tools/ToolCard.js";

--- a/packages/web-components/src/utils/sessionStatus.ts
+++ b/packages/web-components/src/utils/sessionStatus.ts
@@ -1,0 +1,51 @@
+/**
+ * Session-status display mapping. Sessions use a different status vocabulary than
+ * tasks (running / stopped / suspended / idle / hibernating / ...), so this maps
+ * a session status to a theme CSS-variable name and a human label. Shared by
+ * `SessionNode` (card accent + label) and `CoordinationGraph` (MiniMap color) so
+ * the two stay consistent.
+ *
+ * @module
+ */
+
+/** Capitalize the first letter of a status string for display. */
+function capitalize(value: string): string {
+  return value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+/** A session-status visual: a theme CSS-variable name plus a display label. */
+export interface SessionStatusStyle {
+  /** Theme CSS variable name, e.g. `--accent-green`. */
+  varName: string;
+  /** Human-readable status label. */
+  label: string;
+}
+
+/** Theme CSS-variable names this mapping can produce (for batch color resolution). */
+export const SESSION_STATUS_VAR_NAMES: readonly string[] = [
+  "--accent-green",
+  "--accent-yellow",
+  "--accent-red",
+  "--text-tertiary",
+];
+
+/** Map a session status (and external flag) to its visual style. */
+export function sessionStatusStyle(status: string, external: boolean): SessionStatusStyle {
+  if (external) {
+    return { varName: "--text-tertiary", label: "external" };
+  }
+  switch (status) {
+    case "running":
+      return { varName: "--accent-green", label: "Running" };
+    case "idle":
+    case "suspended":
+    case "hibernating":
+      return { varName: "--accent-yellow", label: capitalize(status) };
+    case "failed":
+    case "interrupted":
+      return { varName: "--accent-red", label: capitalize(status) };
+    default:
+      // stopped, completed, unknown, etc.
+      return { varName: "--text-tertiary", label: status.length > 0 ? capitalize(status) : "Unknown" };
+  }
+}

--- a/packages/web-components/src/utils/sessionStatus.ts
+++ b/packages/web-components/src/utils/sessionStatus.ts
@@ -32,7 +32,7 @@ export const SESSION_STATUS_VAR_NAMES: readonly string[] = [
 /** Map a session status (and external flag) to its visual style. */
 export function sessionStatusStyle(status: string, external: boolean): SessionStatusStyle {
   if (external) {
-    return { varName: "--text-tertiary", label: "external" };
+    return { varName: "--text-tertiary", label: "External" };
   }
   switch (status) {
     case "running":

--- a/packages/web-components/src/utils/streamCoordination.ts
+++ b/packages/web-components/src/utils/streamCoordination.ts
@@ -50,11 +50,14 @@ export function isInternalStream(stream: StreamData): boolean {
  * - else (no subscriber session resolvable — e.g. CLI/MCP-created) → `external`.
  */
 export function attributeStream(stream: StreamData, sessions: readonly Session[]): StreamOwnership {
-  return attributeWithMap(stream, new Map(sessions.map((s) => [s.id, s])));
+  return attributeStreamWithMap(stream, new Map(sessions.map((s) => [s.id, s])));
 }
 
-/** Attribution against a precomputed session map — avoids rebuilding it per stream. */
-function attributeWithMap(stream: StreamData, sessionsById: ReadonlyMap<string, Session>): StreamOwnership {
+/**
+ * Attribute a stream to its owning task against a precomputed session map —
+ * avoids rebuilding the map per stream when attributing many streams at once.
+ */
+export function attributeStreamWithMap(stream: StreamData, sessionsById: ReadonlyMap<string, Session>): StreamOwnership {
   let sawKnownSession = false;
   for (const sub of stream.subscribers) {
     const session = sessionsById.get(sub.sessionId);
@@ -87,7 +90,7 @@ export function groupStreamsByTask(streams: readonly StreamData[], sessions: rea
   const orphans: StreamData[] = [];
 
   for (const stream of streams) {
-    const ownership = attributeWithMap(stream, sessionsById);
+    const ownership = attributeStreamWithMap(stream, sessionsById);
     if (ownership.kind === "task") {
       const existing = taskGroups.get(ownership.taskId);
       if (existing) {

--- a/packages/web/src/pages/CoordinationPage.module.scss
+++ b/packages/web/src/pages/CoordinationPage.module.scss
@@ -9,3 +9,32 @@
   height: 100%;
   overflow: hidden;
 }
+
+// List / Graph view toggle
+.viewToggle {
+  display: flex;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.toggleButton {
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.toggleButton:hover {
+  color: var(--text-primary);
+}
+
+.toggleActive {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border-color: var(--accent-blue);
+}

--- a/packages/web/src/pages/CoordinationPage.module.scss
+++ b/packages/web/src/pages/CoordinationPage.module.scss
@@ -10,13 +10,49 @@
   overflow: hidden;
 }
 
-// List / Graph view toggle
-.viewToggle {
+// Toolbar: List/Graph toggle + shared stream controls (apply to both views)
+.toolbar {
   display: flex;
-  gap: var(--space-xs);
+  align-items: center;
+  gap: var(--space-md);
   padding: var(--space-sm) var(--space-md);
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
+}
+
+.viewToggle {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.toolbarControls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.internalsToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.refreshButton {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs) var(--space-md);
+  cursor: pointer;
+}
+
+.refreshButton:hover {
+  color: var(--text-primary);
 }
 
 .toggleButton {

--- a/packages/web/src/pages/CoordinationPage.tsx
+++ b/packages/web/src/pages/CoordinationPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { useGrackle } from "../context/GrackleContext.js";
-import { CoordinationList, StreamDetailPanel } from "@grackle-ai/web-components";
+import { CoordinationGraph, CoordinationList, StreamDetailPanel, useThemeContext } from "@grackle-ai/web-components";
 import styles from "./CoordinationPage.module.scss";
 
 /**
  * Coordination page — a read-only inventory of IPC streams, grouped by the task
  * that owns them. Internal plumbing (lifecycle/pipe/stdin) is hidden behind a
- * "Show internals" toggle. Selecting a stream opens its detail drawer.
+ * "Show internals" toggle. Selecting a stream opens its detail drawer. A
+ * List/Graph toggle switches between the inventory and a live network graph.
  */
 export function CoordinationPage(): JSX.Element {
   const {
@@ -14,7 +15,9 @@ export function CoordinationPage(): JSX.Element {
     sessions: { sessions },
     tasks: { tasks },
   } = useGrackle();
+  const { resolvedThemeId } = useThemeContext();
 
+  const [viewMode, setViewMode] = useState<"list" | "graph">("list");
   const [showInternals, setShowInternals] = useState(false);
   const [selectedStreamId, setSelectedStreamId] = useState<string | undefined>(undefined);
   const [transcriptLoading, setTranscriptLoading] = useState(false);
@@ -56,19 +59,49 @@ export function CoordinationPage(): JSX.Element {
 
   return (
     <div className={styles.container} data-testid="coordination-page">
-      <CoordinationList
-        streams={streams}
-        sessions={sessions}
-        tasks={tasks}
-        loading={streamsLoading}
-        loadError={streamsLoadError}
-        loadedOnce={streamsLoadedOnce}
-        showInternals={showInternals}
-        onToggleInternals={setShowInternals}
-        selectedStreamId={selectedStreamId}
-        onSelectStream={setSelectedStreamId}
-        onRefresh={handleRefresh}
-      />
+      <div className={styles.viewToggle} role="group" aria-label="Coordination view" data-testid="coordination-view-toggle">
+        <button
+          type="button"
+          className={viewMode === "list" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
+          aria-pressed={viewMode === "list"}
+          data-testid="coordination-view-list"
+          onClick={() => setViewMode("list")}
+        >
+          List
+        </button>
+        <button
+          type="button"
+          className={viewMode === "graph" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
+          aria-pressed={viewMode === "graph"}
+          data-testid="coordination-view-graph"
+          onClick={() => setViewMode("graph")}
+        >
+          Graph
+        </button>
+      </div>
+      {viewMode === "list" ? (
+        <CoordinationList
+          streams={streams}
+          sessions={sessions}
+          tasks={tasks}
+          loading={streamsLoading}
+          loadError={streamsLoadError}
+          loadedOnce={streamsLoadedOnce}
+          showInternals={showInternals}
+          onToggleInternals={setShowInternals}
+          selectedStreamId={selectedStreamId}
+          onSelectStream={setSelectedStreamId}
+          onRefresh={handleRefresh}
+        />
+      ) : (
+        <CoordinationGraph
+          streams={streams}
+          sessions={sessions}
+          selectedStreamId={selectedStreamId}
+          onSelectStream={setSelectedStreamId}
+          resolvedThemeId={resolvedThemeId}
+        />
+      )}
       {selectedStream && (
         <StreamDetailPanel
           stream={selectedStream}

--- a/packages/web/src/pages/CoordinationPage.tsx
+++ b/packages/web/src/pages/CoordinationPage.tsx
@@ -59,25 +59,47 @@ export function CoordinationPage(): JSX.Element {
 
   return (
     <div className={styles.container} data-testid="coordination-page">
-      <div className={styles.viewToggle} role="group" aria-label="Coordination view" data-testid="coordination-view-toggle">
-        <button
-          type="button"
-          className={viewMode === "list" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
-          aria-pressed={viewMode === "list"}
-          data-testid="coordination-view-list"
-          onClick={() => setViewMode("list")}
-        >
-          List
-        </button>
-        <button
-          type="button"
-          className={viewMode === "graph" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
-          aria-pressed={viewMode === "graph"}
-          data-testid="coordination-view-graph"
-          onClick={() => setViewMode("graph")}
-        >
-          Graph
-        </button>
+      <div className={styles.toolbar}>
+        <div className={styles.viewToggle} role="group" aria-label="Coordination view" data-testid="coordination-view-toggle">
+          <button
+            type="button"
+            className={viewMode === "list" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
+            aria-pressed={viewMode === "list"}
+            data-testid="coordination-view-list"
+            onClick={() => setViewMode("list")}
+          >
+            List
+          </button>
+          <button
+            type="button"
+            className={viewMode === "graph" ? `${styles.toggleButton} ${styles.toggleActive}` : styles.toggleButton}
+            aria-pressed={viewMode === "graph"}
+            data-testid="coordination-view-graph"
+            onClick={() => setViewMode("graph")}
+          >
+            Graph
+          </button>
+        </div>
+        <div className={styles.toolbarControls}>
+          <label className={styles.internalsToggle}>
+            <input
+              type="checkbox"
+              checked={showInternals}
+              onChange={(e) => setShowInternals(e.target.checked)}
+              data-testid="coordination-show-internals"
+            />
+            Show internals
+          </label>
+          <button
+            type="button"
+            className={styles.refreshButton}
+            onClick={handleRefresh}
+            aria-label="Refresh streams"
+            data-testid="coordination-refresh"
+          >
+            Refresh
+          </button>
+        </div>
       </div>
       {viewMode === "list" ? (
         <CoordinationList
@@ -92,6 +114,7 @@ export function CoordinationPage(): JSX.Element {
           selectedStreamId={selectedStreamId}
           onSelectStream={setSelectedStreamId}
           onRefresh={handleRefresh}
+          hideHeaderControls
         />
       ) : (
         <CoordinationGraph

--- a/tests/e2e-tests/tests/coordination.spec.ts
+++ b/tests/e2e-tests/tests/coordination.spec.ts
@@ -20,6 +20,28 @@ test.describe("Coordination tab", { tag: ["@session"] }, () => {
     await expect(toggle).not.toBeChecked();
   });
 
+  test("List/Graph toggle switches the Coordination view", async ({ appPage }) => {
+    const page = appPage;
+
+    await page.getByTestId("sidebar-tab-coordination").click();
+    await expect(page.getByTestId("coordination-page")).toBeVisible();
+
+    // Defaults to the list view.
+    await expect(page.getByTestId("coordination-list")).toBeVisible();
+    await expect(page.getByTestId("coordination-view-graph")).toBeVisible();
+
+    // Switching to Graph hides the list and shows the graph (or its empty state).
+    await page.getByTestId("coordination-view-graph").click();
+    await expect(page.getByTestId("coordination-list")).toHaveCount(0);
+    await expect(
+      page.getByTestId("coordination-graph").or(page.getByTestId("coordination-graph-empty")),
+    ).toBeVisible();
+
+    // Switching back restores the list.
+    await page.getByTestId("coordination-view-list").click();
+    await expect(page.getByTestId("coordination-list")).toBeVisible();
+  });
+
   test("Root has no stream inventory (that lives on Coordination)", async ({ appPage }) => {
     const page = appPage;
 

--- a/tests/e2e-tests/tests/coordination.spec.ts
+++ b/tests/e2e-tests/tests/coordination.spec.ts
@@ -37,6 +37,9 @@ test.describe("Coordination tab", { tag: ["@session"] }, () => {
       page.getByTestId("coordination-graph").or(page.getByTestId("coordination-graph-empty")),
     ).toBeVisible();
 
+    // Stream controls are page-level, so they remain available in Graph mode.
+    await expect(page.getByTestId("coordination-show-internals")).toBeVisible();
+
     // Switching back restores the list.
     await page.getByTestId("coordination-view-list").click();
     await expect(page.getByTestId("coordination-list")).toBeVisible();


### PR DESCRIPTION
## Summary
- Adds **Feature 2** of #1230: a live bipartite **network graph** of agent sessions and IPC streams on the Coordination tab, with a page-level **List/Graph toggle**.
- Reuses the Task DAG stack (`@xyflow/react` + dagre) for a **deterministic** layout. Chatroom/channel streams render as hubs; 2-party pipes collapse to a direct edge; edge direction comes from `permission` (rw = a single bidirectional edge, never two); unknown subscribers render as external nodes; clicking a hub opens the existing stream detail panel.
- Pure-presentational components (`CoordinationGraph`, `SessionNode`, `StreamNode`) over a dagre-free, unit-tested graph model (`coordinationGraphModel`) with a separate dagre positioning layer.
- The live channel + room transcripts (Feature 1) shipped in #1275; this is the graph. **Animated message dots are Phase B** (separate follow-up).

## Test plan
- [x] `vitest` — 183 pass incl. 9 new graph-model tests (pipe collapse, rw single-edge, writer/reader direction, external synthesis, stream counts)
- [x] `rush build -t @grackle-ai/web` — clean, zero warnings
- [ ] Storybook interaction stories (empty / chatroom / channel / collapsed-pipe / orphan / full-topology) — validated in CI*
- [ ] E2E `coordination.spec.ts` List/Graph toggle test — validated in CI*

\*The Storybook interaction runner and E2E did not run cleanly in my local multi-worktree checkout (a jest-haste-map duplicate-mock collision from scanning sibling worktrees); CI runs them in a clean single checkout.

## Notes
- No proto/server/core changes — pure frontend; no overlap with the AHP/#1276 work.
- Visual states are documented by the Storybook stories; live screenshots deferred (a populated graph needs a multi-session stack with active streams).

Part of #1230