### PR TITLE
Self-host web fonts via @fontsource to satisfy CSP (#1252)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1252-self-host-fonts_2026-05-25-14-02.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1252-self-host-fonts_2026-05-25-14-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Self-host web fonts (Fira Code, JetBrains Mono, DM Sans) via @fontsource-variable so they load under the strict CSP instead of being blocked as external @import stylesheets (#1252).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1095,6 +1095,15 @@ importers:
       '@dagrejs/dagre':
         specifier: ^2.0.4
         version: 2.0.4
+      '@fontsource-variable/dm-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/fira-code':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@grackle-ai/common':
         specifier: workspace:*
         version: link:../common
@@ -3016,6 +3025,15 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource-variable/dm-sans@5.2.8':
+    resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
+
+  '@fontsource-variable/fira-code@5.2.7':
+    resolution: {integrity: sha512-J2bxN7fz5rd8WpQYyau4o19WqTzxoTqaNj9jhsv4p21GSu1Rf34tbqsxqjyDCR+wDMHM3SajyFqtq+5uvRUQ7w==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -13132,6 +13150,12 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fontsource-variable/dm-sans@5.2.8': {}
+
+  '@fontsource-variable/fira-code@5.2.7': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@hapi/address@5.1.1':
     dependencies:

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -41,6 +41,9 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.0",
+    "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource-variable/fira-code": "^5.2.7",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@grackle-ai/common": "workspace:*",
     "@modelcontextprotocol/ext-apps": "1.7.2",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/web-components/src/styles/fonts.test.ts
+++ b/packages/web-components/src/styles/fonts.test.ts
@@ -22,8 +22,10 @@ describe("self-hosted fonts (#1252)", () => {
   const themeScss: string = readStyle("./theme.scss");
 
   it("does not import any external font stylesheets in global.scss", () => {
-    // No `@import url('https://...')` — these violate `style-src 'self'`.
-    expect(globalScss).not.toMatch(/@import\s+url\(\s*['"]?https?:/i);
+    // No external `@import` — these violate `style-src 'self'`. Matches both the
+    // `@import url('https://...')` form and the bare `@import 'https://...'` /
+    // `@import "https://..."` forms SCSS also allows.
+    expect(globalScss).not.toMatch(/@import\s+(?:url\(\s*)?['"]?https?:/i);
   });
 
   it("imports all three font families from @fontsource-variable", () => {

--- a/packages/web-components/src/styles/fonts.test.ts
+++ b/packages/web-components/src/styles/fonts.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Guards the self-hosted-fonts fix (#1252).
+ *
+ * The web fonts (Fira Code, JetBrains Mono, DM Sans) must be served from
+ * `'self'` via the bundled `@fontsource-variable` packages — never re-introduced
+ * as external `@import url('https://...')` stylesheets, which the app's strict
+ * Content-Security-Policy (`style-src 'self'`, `font-src 'self'`) blocks. These
+ * cheap source-level assertions catch a silent regression without needing a
+ * browser.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** Reads a sibling stylesheet in this directory as UTF-8 text. */
+function readStyle(fileName: string): string {
+  return readFileSync(fileURLToPath(new URL(fileName, import.meta.url)), "utf-8");
+}
+
+describe("self-hosted fonts (#1252)", () => {
+  const globalScss: string = readStyle("./global.scss");
+  const themeScss: string = readStyle("./theme.scss");
+
+  it("does not import any external font stylesheets in global.scss", () => {
+    // No `@import url('https://...')` — these violate `style-src 'self'`.
+    expect(globalScss).not.toMatch(/@import\s+url\(\s*['"]?https?:/i);
+  });
+
+  it("imports all three font families from @fontsource-variable", () => {
+    for (const pkg of [
+      "@fontsource-variable/fira-code",
+      "@fontsource-variable/jetbrains-mono",
+      "@fontsource-variable/dm-sans",
+    ]) {
+      expect(globalScss).toContain(pkg);
+    }
+  });
+
+  it("wires the variable family names into the font-family stacks", () => {
+    // @fontsource-variable registers families suffixed with " Variable"; the
+    // CSS vars must list those names first or the fonts load but never apply.
+    expect(themeScss).toContain("'DM Sans Variable'");
+    expect(themeScss).toContain("'Fira Code Variable'");
+    expect(themeScss).toContain("'JetBrains Mono Variable'");
+  });
+});

--- a/packages/web-components/src/styles/global.scss
+++ b/packages/web-components/src/styles/global.scss
@@ -7,9 +7,15 @@
 
 @use './theme.scss';
 @use './prism-theme.scss';
-@import url('https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/fira_code.css');
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,700;1,9..40,400&display=swap');
+// Self-hosted fonts (#1252): bundled via @fontsource-variable so they load from
+// 'self' under the app's strict CSP (style-src/font-src 'self') instead of the
+// external Google Fonts / jsDelivr stylesheets the CSP blocked. Each package's
+// @font-face set is split by unicode-range, so the browser only downloads the
+// subset(s) it actually renders (latin for the English UI).
+@use '@fontsource-variable/fira-code';
+@use '@fontsource-variable/jetbrains-mono';
+@use '@fontsource-variable/dm-sans';
+@use '@fontsource-variable/dm-sans/wght-italic';
 
 // =============================================================================
 // Suppress transitions during theme changes (T3 pattern)

--- a/packages/web-components/src/styles/theme.scss
+++ b/packages/web-components/src/styles/theme.scss
@@ -256,8 +256,11 @@
   // ---------------------------------------------------------------------------
   // Typography
   // ---------------------------------------------------------------------------
-  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
+  // Self-hosted via @fontsource-variable (see global.scss). The variable
+  // packages register family names suffixed with " Variable", so those must come
+  // first in each stack; the unsuffixed names remain as fallbacks.
+  --font-sans: 'DM Sans Variable', 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'Fira Code Variable', 'JetBrains Mono Variable', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
   --font-ui: var(--font-mono);
   --font-size-xs: 11px;
   --font-size-sm: 12px;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 
 const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8"));
 
+/** Font file extensions that must never be inlined as `data:` URIs (see below). */
+const FONT_FILE_PATTERN = /\.(?:woff2?|ttf|otf|eot)$/i;
+
 export default defineConfig({
   base: process.env.VITE_BASE_URL || "/",
   plugins: [react()],
@@ -14,6 +17,15 @@ export default defineConfig({
   },
   build: {
     chunkSizeWarningLimit: 800,
+    // Never inline font files as base64 `data:` URIs. Vite inlines assets under
+    // ~4 KB by default, which would emit small self-hosted font subsets (e.g.
+    // JetBrains Mono's tiny cyrillic-ext subset) as `data:font/woff2;base64,...`.
+    // The app's strict CSP sets `font-src 'self'`, which blocks `data:` fonts —
+    // so fonts must always be emitted as separate `/assets/*.woff2` files served
+    // from 'self' (#1252). Returning `undefined` for non-fonts keeps Vite's
+    // default size-based inlining for every other asset type.
+    assetsInlineLimit: (filePath: string): boolean | undefined =>
+      FONT_FILE_PATTERN.test(filePath) ? false : undefined,
     rollupOptions: {
       output: {
         manualChunks: {

--- a/tests/e2e-tests/tests/fonts.spec.ts
+++ b/tests/e2e-tests/tests/fonts.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "./fixtures.js";
+
+/**
+ * Guards the self-hosted-fonts fix (#1252).
+ *
+ * The web fonts (Fira Code, JetBrains Mono, DM Sans) are bundled via
+ * `@fontsource-variable` and must load from `'self'` under the app's strict CSP
+ * (`style-src 'self' 'unsafe-inline'`, `font-src 'self'`). Two ways this can
+ * silently regress, both caught here:
+ *   1. Re-introducing external `@import url('https://...')` font stylesheets
+ *      (blocked by `style-src`).
+ *   2. Letting Vite inline a small font subset as a `data:` URI (blocked by
+ *      `font-src 'self'` — fonts must stay separate `/assets/*.woff2` files).
+ */
+
+/** Hosts the fonts used to be loaded from before self-hosting (#1252). */
+const EXTERNAL_FONT_HOSTS = ["fonts.googleapis.com", "fonts.gstatic.com", "cdn.jsdelivr.net"];
+
+test.describe("Self-hosted fonts (#1252)", { tag: ["@webui", "@smoke"] }, () => {
+  test("loads all font faces from 'self' with no CSP violations", async ({ page }) => {
+    const cspErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && /Content Security Policy/i.test(msg.text())) {
+        cspErrors.push(msg.text());
+      }
+    });
+
+    // The app holds a WebSocket + streaming RPCs open, so the network never goes
+    // idle — wait on the document load event, not "networkidle".
+    await page.goto("/");
+    await page.evaluate(() => document.fonts.ready);
+
+    // Force every declared @font-face to actually load. A font blocked by CSP
+    // (e.g. an inlined `data:` subset) fails, leaving its FontFace in "error".
+    const erroredFonts = await page.evaluate(async () => {
+      await Promise.allSettled([...document.fonts].map((face) => face.load()));
+      return [...document.fonts]
+        .filter((face) => face.status === "error")
+        .map((face) => face.family);
+    });
+    // Let any CSP-violation console events from the loads flush through.
+    await page.waitForTimeout(250);
+
+    expect(erroredFonts, "no font face should fail to load under CSP").toEqual([]);
+    expect(cspErrors, "app load should produce no CSP violations").toEqual([]);
+
+    // The primary self-hosted families must be available.
+    const available = await page.evaluate(() => ({
+      firaCode: document.fonts.check("16px 'Fira Code Variable'"),
+      dmSans: document.fonts.check("16px 'DM Sans Variable'"),
+    }));
+    expect(available.firaCode).toBe(true);
+    expect(available.dmSans).toBe(true);
+  });
+
+  test("declares no external or data: @font-face sources", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => document.fonts.ready);
+
+    const fontFaceSources = await page.evaluate(() => {
+      const sources: string[] = [];
+      for (const sheet of document.styleSheets) {
+        let rules: CSSRuleList;
+        try {
+          rules = sheet.cssRules;
+        } catch {
+          continue; // skip cross-origin sheets we can't read
+        }
+        for (const rule of rules) {
+          if (rule instanceof CSSFontFaceRule) {
+            sources.push(rule.style.getPropertyValue("src"));
+          }
+        }
+      }
+      return sources;
+    });
+
+    // We should actually have self-hosted @font-face rules in the bundle.
+    expect(fontFaceSources.length).toBeGreaterThan(0);
+    for (const src of fontFaceSources) {
+      expect(src, "fonts must not be inlined as data: URIs").not.toContain("data:");
+      for (const host of EXTERNAL_FONT_HOSTS) {
+        expect(src, `fonts must not be loaded from ${host}`).not.toContain(host);
+      }
+    }
+  });
+});

--- a/tests/e2e-tests/tests/fonts.spec.ts
+++ b/tests/e2e-tests/tests/fonts.spec.ts
@@ -24,6 +24,15 @@ test.describe("Self-hosted fonts (#1252)", { tag: ["@webui", "@smoke"] }, () => 
         cspErrors.push(msg.text());
       }
     });
+    // Network-layer guard: catches any request to an external font host even if
+    // it comes from a cross-origin stylesheet whose rules we can't read.
+    const externalFontRequests: string[] = [];
+    page.on("request", (request) => {
+      const url = request.url();
+      if (EXTERNAL_FONT_HOSTS.some((host) => url.includes(host))) {
+        externalFontRequests.push(url);
+      }
+    });
 
     // The app holds a WebSocket + streaming RPCs open, so the network never goes
     // idle — wait on the document load event, not "networkidle".
@@ -43,6 +52,7 @@ test.describe("Self-hosted fonts (#1252)", { tag: ["@webui", "@smoke"] }, () => 
 
     expect(erroredFonts, "no font face should fail to load under CSP").toEqual([]);
     expect(cspErrors, "app load should produce no CSP violations").toEqual([]);
+    expect(externalFontRequests, "no font should be requested from an external host").toEqual([]);
 
     // The primary self-hosted families must be available.
     const available = await page.evaluate(() => ({
@@ -69,6 +79,10 @@ test.describe("Self-hosted fonts (#1252)", { tag: ["@webui", "@smoke"] }, () => 
         for (const rule of rules) {
           if (rule instanceof CSSFontFaceRule) {
             sources.push(rule.style.getPropertyValue("src"));
+          } else if (rule instanceof CSSImportRule) {
+            // `@import 'https://...'` lives in our same-origin sheet, so its
+            // href is readable here even when the imported sheet is cross-origin.
+            sources.push(rule.href);
           }
         }
       }


### PR DESCRIPTION
## Summary
- The UI declared **Fira Code**, **JetBrains Mono**, and **DM Sans** via external `@import url('https://...')` stylesheets (Google Fonts / jsDelivr) that the app's strict CSP (`style-src 'self'`, `font-src 'self'`) blocked — so the UI silently fell back to system fonts and logged a CSP error per font on every page.
- Bundle the three families via `@fontsource-variable` (served from `'self'`) and remove the external `@import`s from `global.scss`. **No CSP change** — it stays strict.
- Rewire `--font-sans` / `--font-mono` to the `'* Variable'` family names the fontsource packages register (otherwise the fonts load but never apply — the bug-behind-the-bug).
- Stop Vite inlining small font subsets as `data:` URIs (`assetsInlineLimit`), which `font-src 'self'` *also* blocks; fonts now always emit as `/assets/*.woff2`.

## Verification
Built + ran against a live server (Playwright):
- **0** CSP console errors on load (was 3).
- Fonts served only from `'self'` (`/assets/*.woff2`); **no** requests to `fonts.googleapis.com` / `fonts.gstatic.com` / `cdn.jsdelivr.net`.
- `document.fonts` confirms `Fira Code Variable` + `DM Sans Variable` loaded; body `font-family` resolves to the rewired chain. (JetBrains Mono is a fallback for Fira Code, so it correctly stays unloaded.)
- `unicode-range` gating means only the `latin` subsets download for the English UI.

## Test plan
- [x] `web-components` unit test (`fonts.test.ts`): no external `@import`, fontsource imported, `* Variable` names wired.
- [x] E2E spec (`fonts.spec.ts`): app loads with no CSP violations; no `@font-face` uses a `data:` URI or external host.
- [x] `security-headers.test.ts` unchanged — CSP `style-src`/`font-src` stay strict (`'self'`), no relaxation.
- [x] `rush build` clean (no warnings).

Closes #1252