### PR TITLE
feat: native turn framing (AHP HR2)

### DIFF
--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -42,6 +42,7 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
     raw: string;
     toolCallId: string;
     diagnostic: boolean;
+    turnId: string;
 };
 
 // @public

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -56,13 +56,14 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
     raw: string;
     toolCallId: string;
     diagnostic: boolean;
+    turnId: string;
 };
 
 // @public
 const AgentEventSchema: GenMessage<AgentEvent>;
 
 // @public
-export type AgentEventType = "text" | "tool_use" | "tool_result" | "error" | "status" | "system" | "runtime_session_id" | "usage";
+export type AgentEventType = "text" | "tool_use" | "tool_result" | "error" | "status" | "system" | "runtime_session_id" | "usage" | "turn_started" | "turn_complete" | "input_needed";
 
 // @public
 export const ALL_MCP_TOOL_NAMES: ReadonlySet<string>;
@@ -698,12 +699,15 @@ export type EventType = AgentEventType | "user_input" | "signal";
 // @public
 enum EventType_2 {
     ERROR = 4,
+    INPUT_NEEDED = 16,
     SIGNAL = 10,
     STATUS = 5,
     SYSTEM = 6,
     TEXT = 1,
     TOOL_RESULT = 3,
     TOOL_USE = 2,
+    TURN_COMPLETE = 15,
+    TURN_STARTED = 14,
     UNSPECIFIED = 0,
     USAGE = 11,
     USER_INPUT = 9,
@@ -2467,6 +2471,7 @@ type SessionEvent = Message<"grackle.SessionEvent"> & {
     raw: string;
     toolCallId: string;
     diagnostic: boolean;
+    turnId: string;
 };
 
 // @public

--- a/common/api/runtime-sdk.public.api.md
+++ b/common/api/runtime-sdk.public.api.md
@@ -16,6 +16,7 @@ export interface AgentEvent {
     // (undocumented)
     timestamp: string;
     toolCallId?: string;
+    turnId?: string;
     // Warning: (ae-forgotten-export) The symbol "AgentEventType" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -79,6 +80,7 @@ export abstract class BaseAgentSession implements AgentSession {
     protected readonly branch?: string;
     protected buildInitialPrompt(): string;
     drainBufferedEvents(): AgentEvent[];
+    protected emit(event: AgentEvent): void;
     // (undocumented)
     protected readonly eventQueue: AsyncQueue<AgentEvent>;
     protected abstract executeFollowUp(text: string): Promise<void>;

--- a/common/changes/@grackle-ai/cli/nick-pape-1286-turn-framing_2026-05-25-18-07.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1286-turn-framing_2026-05-25-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@grackle-ai/cli",
+      "comment": "Native turn framing (AHP HR2): session events now carry a turn_id and explicit turn_started/turn_complete/input_needed event types, anchored on the real prompt/sendInput, replacing the overloaded waiting_input signal. Producer-side, behind the existing wire; behavior-preserving.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/enum-converters.test.ts
+++ b/packages/common/src/enum-converters.test.ts
@@ -13,3 +13,14 @@ describe("EventType converters — widget", () => {
     expect(eventTypeToString(999 as EventType)).toBe("");
   });
 });
+
+describe("EventType converters — turn framing (AHP HR2)", () => {
+  it("round-trips turn_started / turn_complete / input_needed", () => {
+    expect(eventTypeToEnum("turn_started")).toBe(EventType.TURN_STARTED);
+    expect(eventTypeToEnum("turn_complete")).toBe(EventType.TURN_COMPLETE);
+    expect(eventTypeToEnum("input_needed")).toBe(EventType.INPUT_NEEDED);
+    expect(eventTypeToString(EventType.TURN_STARTED)).toBe("turn_started");
+    expect(eventTypeToString(EventType.TURN_COMPLETE)).toBe("turn_complete");
+    expect(eventTypeToString(EventType.INPUT_NEEDED)).toBe("input_needed");
+  });
+});

--- a/packages/common/src/enum-converters.ts
+++ b/packages/common/src/enum-converters.ts
@@ -27,6 +27,9 @@ const eventTypeToEnumMap: Record<string, EventType> = Object.assign(Object.creat
   "signal": EventType.SIGNAL,
   "usage": EventType.USAGE,
   "widget": EventType.WIDGET,
+  "turn_started": EventType.TURN_STARTED,
+  "turn_complete": EventType.TURN_COMPLETE,
+  "input_needed": EventType.INPUT_NEEDED,
 });
 
 const eventTypeToStringMap: Record<number, string> = {
@@ -41,6 +44,9 @@ const eventTypeToStringMap: Record<number, string> = {
   [EventType.SIGNAL]: "signal",
   [EventType.USAGE]: "usage",
   [EventType.WIDGET]: "widget",
+  [EventType.TURN_STARTED]: "turn_started",
+  [EventType.TURN_COMPLETE]: "turn_complete",
+  [EventType.INPUT_NEEDED]: "input_needed",
 };
 
 /** Convert a string event type to its proto enum value. */

--- a/packages/common/src/proto/grackle/grackle_types.proto
+++ b/packages/common/src/proto/grackle/grackle_types.proto
@@ -36,6 +36,9 @@ enum EventType {
   EVENT_TYPE_USAGE = 11;
   reserved 12; // was EVENT_TYPE_ESCALATION (removed — orchestration is MCP-only, AHP HR7)
   EVENT_TYPE_WIDGET = 13;
+  EVENT_TYPE_TURN_STARTED = 14;  // AHP HR2: a turn opened (content = the user message)
+  EVENT_TYPE_TURN_COMPLETE = 15; // AHP HR2: a turn finished (session idle)
+  EVENT_TYPE_INPUT_NEEDED = 16;  // AHP HR2: turn blocked awaiting user input (plumb-only; no producer yet)
 }
 
 enum TaskStatus {
@@ -307,6 +310,7 @@ message SessionEvent {
   string raw = 5; // JSON, optional original payload
   string tool_call_id = 6; // stable runtime tool-call id (pairs tool_use↔tool_result); "" when N/A (AHP HR3)
   bool diagnostic = 7; // true = runtime lifecycle/diagnostic; tee to telemetry sinks (may be excluded from SessionState in a later HR step); AHP HR7
+  string turn_id = 8; // turn this event belongs to; "" for out-of-band/liveness events (startup, status, worktree setup, kill); set by host turn framing (AHP HR2)
 }
 
 message SessionEventList {

--- a/packages/common/src/proto/grackle/powerline/powerline.proto
+++ b/packages/common/src/proto/grackle/powerline/powerline.proto
@@ -65,6 +65,7 @@ message AgentEvent {
   string raw = 5; // JSON, optional
   string tool_call_id = 6; // stable runtime tool-call id (pairs tool_use↔tool_result); "" when N/A (AHP HR3)
   bool diagnostic = 7; // true = runtime lifecycle/diagnostic; tee to telemetry sinks (may be excluded from SessionState in a later HR step); AHP HR7
+  string turn_id = 8; // turn this event belongs to; "" for out-of-band/liveness events (startup, status, worktree setup, kill); set by host turn framing (AHP HR2)
 }
 
 message SessionInfo {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -63,7 +63,10 @@ export type AgentEventType =
   | "status"
   | "system"
   | "runtime_session_id"
-  | "usage";
+  | "usage"
+  | "turn_started"
+  | "turn_complete"
+  | "input_needed";
 
 /** Discriminator for all session events, including user input and signals. */
 export type EventType = AgentEventType | "user_input" | "signal";

--- a/packages/core/src/event-processor.test.ts
+++ b/packages/core/src/event-processor.test.ts
@@ -1203,3 +1203,51 @@ describe("event-processor diagnostic flag + OTLP tee (AHP HR7)", () => {
     expect(emitDiagnostic).not.toHaveBeenCalled();
   });
 });
+
+describe("turn_id threading (AHP HR2)", () => {
+  beforeEach(() => {
+    sqlite.exec("DROP TABLE IF EXISTS findings");
+    sqlite.exec("DROP TABLE IF EXISTS tasks");
+    sqlite.exec("DROP TABLE IF EXISTS sessions");
+    sqlite.exec("DROP TABLE IF EXISTS workspaces");
+    applySchema();
+    vi.clearAllMocks();
+  });
+
+  it("threads turn_id from AgentEvent through to the SessionEvent written to the log", async () => {
+    sessionStore.createSession("sess-turn", "env1", "stub", "test prompt", "stub-model", "/tmp/turn-log");
+
+    const turnStartedEvent = create(powerline.AgentEventSchema, {
+      sessionId: "sess-turn",
+      type: "turn_started",
+      timestamp: new Date().toISOString(),
+      content: "test prompt",
+      turnId: "test-turn-id-abc",
+    });
+
+    // A liveness status event with no turnId should be written with empty turn_id.
+    const doneEvent = create(powerline.AgentEventSchema, {
+      sessionId: "sess-turn",
+      type: "status",
+      timestamp: new Date().toISOString(),
+      content: "waiting_input",
+    });
+
+    await waitForProcessing([turnStartedEvent, doneEvent], {
+      sessionId: "sess-turn",
+      logPath: "/tmp/turn-log",
+    });
+
+    const writeEventCalls = vi.mocked(logWriter.writeEvent).mock.calls;
+
+    const turnStartedSessionEvent = writeEventCalls.find(
+      ([, ev]) => ev.type === grackle.EventType.TURN_STARTED,
+    )?.[1];
+    expect(turnStartedSessionEvent?.turnId).toBe("test-turn-id-abc");
+
+    const statusSessionEvent = writeEventCalls.find(
+      ([, ev]) => ev.type === grackle.EventType.STATUS,
+    )?.[1];
+    expect(statusSessionEvent?.turnId).toBeFalsy();
+  });
+});

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -175,6 +175,7 @@ export function processEventStream(
           raw: event.raw,
           toolCallId: event.toolCallId,
           diagnostic: event.diagnostic,
+          turnId: event.turnId,
         });
         await logWriter.writeEvent(logPath, sessionEvent);
         streamHub.publish(sessionEvent);

--- a/packages/core/src/log-writer.ts
+++ b/packages/core/src/log-writer.ts
@@ -52,6 +52,7 @@ export async function writeEvent(logPath: string, event: grackle.SessionEvent): 
     raw: event.raw || undefined,
     tool_call_id: event.toolCallId || undefined,
     diagnostic: event.diagnostic || undefined,
+    turn_id: event.turnId || undefined,
   });
 
   const ok = ws.write(line + "\n");
@@ -89,6 +90,8 @@ export interface LogEntry {
   tool_call_id?: string;
   /** True for runtime lifecycle/diagnostic events (AHP HR7). Absent on substantive events. */
   diagnostic?: boolean;
+  /** Turn this event belongs to (AHP HR2). Absent for out-of-band/liveness events. */
+  turn_id?: string;
 }
 
 /** Number of bytes to read from the tail of a log file when searching for the last text entry. */

--- a/packages/core/src/session-recovery.ts
+++ b/packages/core/src/session-recovery.ts
@@ -81,6 +81,7 @@ export async function recoverSuspendedSessions(
             content: event.content,
             raw: event.raw,
             toolCallId: event.toolCallId,
+            turnId: event.turnId,
           });
           await logWriter.writeEvent(logPath, sessionEvent);
           drainedCount++;

--- a/packages/powerline/src/grpc-server.ts
+++ b/packages/powerline/src/grpc-server.ts
@@ -27,6 +27,7 @@ function toProtoEvent(sessionId: string, event: AgentEvent): powerline.AgentEven
     raw: event.raw ? JSON.stringify(event.raw) : "",
     toolCallId: event.toolCallId ?? "",
     diagnostic: event.diagnostic ?? false,
+    turnId: event.turnId ?? "",
   });
 }
 

--- a/packages/powerline/src/runtimes/stub-mcp.test.ts
+++ b/packages/powerline/src/runtimes/stub-mcp.test.ts
@@ -72,28 +72,34 @@ describe("StubMcpRuntime", () => {
     expect(types).toEqual([
       "system",
       "runtime_session_id",
+      "turn_started",   // initial turn (AHP HR2)
       "text",
       "tool_use",
       "tool_result",
+      "turn_complete",  // initial turn (AHP HR2)
       "status",     // waiting_input
       "status",     // running
+      "turn_started",   // follow-up turn (AHP HR2)
       "text",       // user reply echo
+      "turn_complete",  // follow-up turn (AHP HR2)
       "status",     // waiting_input (idle after processing input)
     ]);
 
     // Verify content
     expect(events[0].content).toBe("Stub runtime initialized");
     expect(events[1].content).toBe("stub-mcp-lifecycle-1");
-    expect(events[2].content).toBe("Echo: test prompt");
-    expect(JSON.parse(events[3].content)).toEqual({
+    expect(events[2].type).toBe("turn_started");
+    expect(events[3].content).toBe("Echo: test prompt");
+    expect(JSON.parse(events[4].content)).toEqual({
       tool: "echo",
       args: { message: "test prompt" },
     });
-    expect(events[4].content).toBe('Tool output: "test prompt"');
-    expect(events[5].content).toBe("waiting_input");
-    expect(events[6].content).toBe("running");
-    expect(events[7].content).toBe("You said: user reply");
-    expect(events[8].content).toBe("waiting_input");
+    expect(events[5].content).toBe('Tool output: "test prompt"');
+    expect(events[6].type).toBe("turn_complete");
+    expect(events[7].content).toBe("waiting_input");
+    expect(events[8].content).toBe("running");
+    expect(events[10].content).toBe("You said: user reply");
+    expect(events[12].content).toBe("waiting_input");
 
     // Verify timestamps are ISO strings
     for (const event of events) {

--- a/packages/powerline/src/runtimes/stub.test.ts
+++ b/packages/powerline/src/runtimes/stub.test.ts
@@ -85,28 +85,46 @@ describe("StubRuntime", () => {
     expect(types).toEqual([
       "system",
       "runtime_session_id",
+      "turn_started",   // initial turn (AHP HR2)
       "text",
       "tool_use",
       "tool_result",
+      "turn_complete",  // initial turn (AHP HR2)
       "status",     // waiting_input
       "status",     // running
+      "turn_started",   // follow-up turn (AHP HR2)
       "text",       // user reply echo
+      "turn_complete",  // follow-up turn (AHP HR2)
       "status",     // waiting_input (stub goes idle, not completed)
     ]);
 
     // Verify content
     expect(events[0].content).toBe("Stub runtime initialized");
     expect(events[1].content).toBe("stub-lifecycle-1");
-    expect(events[2].content).toBe("Echo: test prompt");
-    expect(JSON.parse(events[3].content)).toEqual({
+    expect(events[2].type).toBe("turn_started");
+    expect(events[2].content).toBe("test prompt");
+    expect(events[3].content).toBe("Echo: test prompt");
+    expect(JSON.parse(events[4].content)).toEqual({
       tool: "echo",
       args: { message: "test prompt" },
     });
-    expect(events[4].content).toBe('Tool output: "test prompt"');
-    expect(events[5].content).toBe("waiting_input");
-    expect(events[6].content).toBe("running");
-    expect(events[7].content).toBe("You said: user reply");
-    expect(events[8].content).toBe("waiting_input");
+    expect(events[5].content).toBe('Tool output: "test prompt"');
+    expect(events[6].type).toBe("turn_complete");
+    expect(events[7].content).toBe("waiting_input");
+    expect(events[8].content).toBe("running");
+    expect(events[9].type).toBe("turn_started");
+    expect(events[9].content).toBe("user reply");
+    expect(events[10].content).toBe("You said: user reply");
+    expect(events[11].type).toBe("turn_complete");
+    expect(events[12].content).toBe("waiting_input");
+
+    // Turn framing (AHP HR2): content shares its turn's id; the two turns differ.
+    expect(events[2].turnId).toBeTruthy();
+    expect(events[3].turnId).toBe(events[2].turnId);
+    expect(events[6].turnId).toBe(events[2].turnId);
+    expect(events[9].turnId).toBeTruthy();
+    expect(events[9].turnId).not.toBe(events[2].turnId);
+    expect(events[10].turnId).toBe(events[9].turnId);
 
     // Verify timestamps are ISO strings
     for (const event of events) {

--- a/packages/powerline/src/runtimes/stub.ts
+++ b/packages/powerline/src/runtimes/stub.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
 import type { AgentRuntime, AgentSession, AgentEvent, SpawnOptions, ResumeOptions } from "@grackle-ai/runtime-sdk";
 import { SESSION_STATUS } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
@@ -94,7 +95,11 @@ export class StubSession implements AgentSession {
 
     yield { type: "system", timestamp: ts(), content: "Stub runtime initialized" };
     yield { type: "runtime_session_id", timestamp: ts(), content: this.runtimeSessionId };
-    yield { type: "text", timestamp: ts(), content: `Echo: ${this.prompt}` };
+
+    // Initial turn (AHP HR2), anchored on the prompt.
+    const initialTurnId = randomUUID();
+    yield { type: "turn_started", timestamp: ts(), content: this.prompt, turnId: initialTurnId };
+    yield { type: "text", timestamp: ts(), content: `Echo: ${this.prompt}`, turnId: initialTurnId };
 
     if (this.killed as boolean) { yield { type: "status", timestamp: ts(), content: this.killReason }; return; }
 
@@ -102,7 +107,7 @@ export class StubSession implements AgentSession {
       // Real MCP tool call when both broker and workspace context are available
       const mcpEvents = await this.performMcpToolCall(ts, "task_list", {});
       for (const event of mcpEvents) {
-        yield event;
+        yield { ...event, turnId: initialTurnId };
       }
     } else {
       // Fallback: fake echo tool events
@@ -111,6 +116,7 @@ export class StubSession implements AgentSession {
         timestamp: ts(),
         content: JSON.stringify({ tool: "echo", args: { message: this.prompt } }),
         toolCallId: "stub-echo",
+        turnId: initialTurnId,
       };
 
       yield {
@@ -118,12 +124,14 @@ export class StubSession implements AgentSession {
         timestamp: ts(),
         content: `Tool output: "${this.prompt}"`,
         toolCallId: "stub-echo",
+        turnId: initialTurnId,
       };
     }
 
     if (this.killed as boolean) { yield { type: "status", timestamp: ts(), content: this.killReason }; return; }
 
-    // Wait for user input
+    // Initial turn complete; wait for user input.
+    yield { type: "turn_complete", timestamp: ts(), content: "", turnId: initialTurnId };
     this.status = SESSION_STATUS.IDLE;
     yield { type: "status", timestamp: ts(), content: "waiting_input" };
 
@@ -141,9 +149,12 @@ export class StubSession implements AgentSession {
 
     this.status = SESSION_STATUS.RUNNING;
     yield { type: "status", timestamp: ts(), content: "running" };
-    yield { type: "text", timestamp: ts(), content: `You said: ${input}` };
+    const followUpTurnId = randomUUID();
+    yield { type: "turn_started", timestamp: ts(), content: input, turnId: followUpTurnId };
+    yield { type: "text", timestamp: ts(), content: `You said: ${input}`, turnId: followUpTurnId };
 
     // Agent finished turn — go idle, not "completed"
+    yield { type: "turn_complete", timestamp: ts(), content: "", turnId: followUpTurnId };
     this.status = SESSION_STATUS.IDLE;
     yield { type: "status", timestamp: ts(), content: "waiting_input" };
   }

--- a/packages/runtime-acp/src/acp.ts
+++ b/packages/runtime-acp/src/acp.ts
@@ -283,7 +283,7 @@ class AcpSession extends BaseAgentSession {
     // OTLP collector when the sink is enabled (AHP HR7). Deliberately omit the
     // raw CLI args — they are arbitrary user-controllable input that can carry
     // secrets — and keep only low-sensitivity structural info (command, pid, cwd).
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: ts(),
       content: `Spawned ${this.config.command} (pid: ${String(this.child.pid)}, cwd: ${spawnCwd})`,
@@ -293,7 +293,7 @@ class AcpSession extends BaseAgentSession {
     // Register exit/error handlers immediately to catch early termination
     this.child.on("error", (err: Error) => {
       if (!this.killed) {
-        this.eventQueue.push({
+        this.emit({
           type: "error",
           timestamp: ts(),
           content: `Failed to spawn ${this.config.command}: ${err.message}`,
@@ -303,7 +303,7 @@ class AcpSession extends BaseAgentSession {
 
     this.child.on("exit", (code: number | null, signal: string | null) => {
       if (!this.killed) {
-        this.eventQueue.push({
+        this.emit({
           type: "error",
           timestamp: ts(),
           content: `Agent process exited unexpectedly (code: ${String(code)}, signal: ${String(signal)})`,
@@ -334,13 +334,13 @@ class AcpSession extends BaseAgentSession {
                   const delta = data.cost_millicents - this.lastReportedCost;
                   this.lastReportedCost = data.cost_millicents;
                   if (delta <= 0) { continue; }
-                  this.eventQueue.push({ ...event, content: JSON.stringify({ ...data, cost_millicents: delta }) });
+                  this.emit({ ...event, content: JSON.stringify({ ...data, cost_millicents: delta }) });
                   this.messageCount++;
                   continue;
                 }
               } catch { /* fall through to normal push */ }
             }
-            this.eventQueue.push(event);
+            this.emit(event);
             this.messageCount++;
           }
         },
@@ -368,7 +368,7 @@ class AcpSession extends BaseAgentSession {
       throw new Error(`ACP initialize failed: ${message}`);
     }
 
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: ts(),
       content: "ACP connection initialized",
@@ -385,7 +385,7 @@ class AcpSession extends BaseAgentSession {
     if (envVarMethodId) {
       try {
         await this.connection.authenticate({ methodId: envVarMethodId });
-        this.eventQueue.push({
+        this.emit({
           type: "system",
           timestamp: ts(),
           content: `ACP authenticated via ${envVarMethodId}`,
@@ -401,7 +401,7 @@ class AcpSession extends BaseAgentSession {
     if (this.resumeSessionId) {
       this.acpSessionId = this.resumeSessionId;
       this.setRuntimeSessionId(this.resumeSessionId);
-      this.eventQueue.push({
+      this.emit({
         type: "system",
         timestamp: ts(),
         content: `ACP session resuming (id: ${this.runtimeSessionId})`,
@@ -426,7 +426,7 @@ class AcpSession extends BaseAgentSession {
     this.acpSessionId = sessionResult.sessionId as string;
     this.setRuntimeSessionId(this.acpSessionId || "");
 
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: ts(),
       content: `ACP session created (id: ${this.runtimeSessionId})`,

--- a/packages/runtime-claude-code/src/claude-code.ts
+++ b/packages/runtime-claude-code/src/claude-code.ts
@@ -479,7 +479,7 @@ class ClaudeCodeSession extends BaseAgentSession {
       // Check for result errors
       if (msg.type === "result" && msg.is_error) {
         const errorMsg = (msg.result as string) || "Claude Code returned an error";
-        this.eventQueue.push({ type: "error", timestamp: ts(), content: errorMsg, raw: msg });
+        this.emit({ type: "error", timestamp: ts(), content: errorMsg, raw: msg });
       }
 
       // Extract usage data from successful result messages
@@ -563,14 +563,14 @@ class ClaudeCodeSession extends BaseAgentSession {
           this.pendingToolUseIds.set(raw.id, raw.name as string || "");
         }
       }
-      this.eventQueue.push(event);
+      this.emit(event);
     }
   }
 
   /** Emit synthetic tool_result events for all pending tool_use IDs and clear the map. */
   private flushPendingToolResults(ts: () => string): void {
     for (const [id] of this.pendingToolUseIds) {
-      this.eventQueue.push({
+      this.emit({
         type: "tool_result",
         timestamp: ts(),
         content: "",
@@ -624,7 +624,7 @@ class ClaudeCodeSession extends BaseAgentSession {
       if (msg.type === "result" && msg.is_error) {
         this.flushPendingToolResults(ts);
         const errorMsg = (msg.result as string) || "Claude Code returned an error";
-        this.eventQueue.push({ type: "error", timestamp: ts(), content: errorMsg, raw: msg });
+        this.emit({ type: "error", timestamp: ts(), content: errorMsg, raw: msg });
         continue;
       }
 

--- a/packages/runtime-codex/src/codex.ts
+++ b/packages/runtime-codex/src/codex.ts
@@ -168,7 +168,7 @@ class CodexSession extends BaseAgentSession {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.codexInstance = new Codex(codexOptions);
 
-    this.eventQueue.push({ type: "system", timestamp: ts(), content: "Codex instance created", diagnostic: true });
+    this.emit({ type: "system", timestamp: ts(), content: "Codex instance created", diagnostic: true });
 
     // ── Thread options ──
     this.threadOptions = {
@@ -196,7 +196,7 @@ class CodexSession extends BaseAgentSession {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.thread = this.codexInstance.startThread(this.threadOptions);
 
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: new Date().toISOString(),
       content: `Codex thread started (model: ${this.model || "default"})`,
@@ -250,7 +250,7 @@ class CodexSession extends BaseAgentSession {
           if (threadId) {
             this.setRuntimeSessionId(threadId);
           }
-          this.eventQueue.push({
+          this.emit({
             type: "system",
             timestamp: ts(),
             content: `Codex thread initialized (id: ${this.runtimeSessionId})`,
@@ -273,7 +273,7 @@ class CodexSession extends BaseAgentSession {
 
           if (type === "command_execution") {
             messageCount++;
-            this.eventQueue.push({
+            this.emit({
               type: "tool_use",
               timestamp: ts(),
               content: JSON.stringify({ tool: "command_execution", args: { command: item.command || "" } }),
@@ -285,7 +285,7 @@ class CodexSession extends BaseAgentSession {
             // Codex SDK: file_change has `changes` array with `{path, ...}` entries (no top-level `file`)
             const changes = (item.changes ?? []) as Array<Record<string, unknown>>;
             const filePaths = changes.map((c) => c.path ?? "").join(", ");
-            this.eventQueue.push({
+            this.emit({
               type: "tool_use",
               timestamp: ts(),
               content: JSON.stringify({ tool: "file_change", args: { file: filePaths, changes } }),
@@ -295,7 +295,7 @@ class CodexSession extends BaseAgentSession {
           } else if (type === "mcp_tool_call") {
             messageCount++;
             // Codex SDK: uses `server` and `tool` (not `serverName`/`toolName`)
-            this.eventQueue.push({
+            this.emit({
               type: "tool_use",
               timestamp: ts(),
               content: JSON.stringify({ tool: `mcp__${String(item.server || "unknown")}__${String(item.tool || "unknown")}`, args: item.arguments || {} }),
@@ -321,7 +321,7 @@ class CodexSession extends BaseAgentSession {
             // Codex SDK: `aggregated_output` (not `output`), `exit_code` (not `exitCode`)
             const output = (item.aggregated_output ?? "") as string;
             const exitCode = item.exit_code as number | undefined;
-            this.eventQueue.push({
+            this.emit({
               type: "tool_result",
               timestamp: ts(),
               content: exitCode !== undefined ? `[exit ${exitCode}] ${output}` : output,
@@ -333,7 +333,7 @@ class CodexSession extends BaseAgentSession {
             // Codex SDK: file_change completed has `changes` array and `status` (no `file`/`patch`)
             const changes = (item.changes ?? []) as Array<Record<string, unknown>>;
             const filePaths = changes.map((c) => c.path ?? "").join(", ");
-            this.eventQueue.push({
+            this.emit({
               type: "tool_result",
               timestamp: ts(),
               content: JSON.stringify({ file: filePaths, changes, status: item.status || "completed" }),
@@ -344,7 +344,7 @@ class CodexSession extends BaseAgentSession {
             messageCount++;
             // Codex SDK: `text` (not `content`) for the message body
             const content = (item.text ?? "") as string;
-            this.eventQueue.push({
+            this.emit({
               type: "text",
               timestamp: ts(),
               content,
@@ -360,7 +360,7 @@ class CodexSession extends BaseAgentSession {
             const errorStr = errorObj
               ? (typeof errorObj.message === "string" ? errorObj.message : JSON.stringify(errorObj))
               : "";
-            this.eventQueue.push({
+            this.emit({
               type: "tool_result",
               timestamp: ts(),
               content: errorStr || resultStr || "",
@@ -371,7 +371,7 @@ class CodexSession extends BaseAgentSession {
             messageCount++;
             // Codex SDK: only `text` exists (no `summary` field)
             const text = (item.text ?? "") as string;
-            this.eventQueue.push({
+            this.emit({
               type: "text",
               timestamp: ts(),
               content: `[reasoning] ${text}`,
@@ -397,7 +397,7 @@ class CodexSession extends BaseAgentSession {
           if (this.maxTurns > 0 && this.turnCount >= this.maxTurns) {
             logger.info({ turnCount: this.turnCount, maxTurns: this.maxTurns }, "Codex max turns reached — going idle");
             this.status = SESSION_STATUS.IDLE;
-            this.eventQueue.push({ type: "status", timestamp: ts(), content: "waiting_input" });
+            this.emit({ type: "status", timestamp: ts(), content: "waiting_input" });
             if (this.activeStream && typeof this.activeStream.abort === "function") {
               this.activeStream.abort();
             }
@@ -408,13 +408,13 @@ class CodexSession extends BaseAgentSession {
         case "turn.failed": {
           const error = (event as Record<string, unknown>).error as Record<string, unknown> | undefined;
           const message = (error?.message ?? "Turn failed") as string;
-          this.eventQueue.push({ type: "error", timestamp: ts(), content: message, raw: event });
+          this.emit({ type: "error", timestamp: ts(), content: message, raw: event });
           break;
         }
 
         case "error": {
           const message = ((event as Record<string, unknown>).message ?? "Unknown error") as string;
-          this.eventQueue.push({ type: "error", timestamp: ts(), content: message, raw: event });
+          this.emit({ type: "error", timestamp: ts(), content: message, raw: event });
           break;
         }
 

--- a/packages/runtime-copilot/src/copilot.ts
+++ b/packages/runtime-copilot/src/copilot.ts
@@ -167,7 +167,7 @@ export class CopilotSession extends BaseAgentSession {
     this.copilotClient = new copilotSdk.CopilotClient(clientOptions);
     await this.copilotClient.start();
 
-    this.eventQueue.push({ type: "system", timestamp: ts(), content: "Copilot CLI server connected", diagnostic: true });
+    this.emit({ type: "system", timestamp: ts(), content: "Copilot CLI server connected", diagnostic: true });
 
     // ── Build session config ──
     // onPermissionRequest is REQUIRED by the SDK — use approveAll for headless operation
@@ -216,7 +216,7 @@ export class CopilotSession extends BaseAgentSession {
 
     this.setRuntimeSessionId((this.copilotSession.sessionId as string | undefined) || this.id);
 
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: ts(),
       content: `Copilot session created (model: ${this.model}, session: ${this.runtimeSessionId})`,
@@ -233,7 +233,7 @@ export class CopilotSession extends BaseAgentSession {
       const deltaContent = (data?.deltaContent ?? "") as string;
       if (deltaContent) {
         this.currentMessageCount++;
-        this.eventQueue.push({
+        this.emit({
           type: "text",
           timestamp: ts(),
           content: deltaContent,
@@ -260,7 +260,7 @@ export class CopilotSession extends BaseAgentSession {
       const toolName = (data?.toolName ?? "unknown") as string;
       const toolArgs = data?.arguments ?? {};
       this.currentMessageCount++;
-      this.eventQueue.push({
+      this.emit({
         type: "tool_use",
         timestamp: ts(),
         content: JSON.stringify({ tool: toolName, args: toolArgs }),
@@ -289,7 +289,7 @@ export class CopilotSession extends BaseAgentSession {
         output = JSON.stringify(result);
       }
       this.currentMessageCount++;
-      this.eventQueue.push({
+      this.emit({
         type: "tool_result",
         timestamp: ts(),
         content: output,
@@ -320,7 +320,7 @@ export class CopilotSession extends BaseAgentSession {
     this.copilotSession.on("session.error", (event: Record<string, unknown>) => {
       const data = event.data as Record<string, unknown> | undefined;
       const message = (data?.message ?? String(event)) as string;
-      this.eventQueue.push({ type: "error", timestamp: ts(), content: message, raw: event });
+      this.emit({ type: "error", timestamp: ts(), content: message, raw: event });
       this.idleReject?.(new Error(message));
     });
   }

--- a/packages/runtime-genaiscript/src/genaiscript.ts
+++ b/packages/runtime-genaiscript/src/genaiscript.ts
@@ -5,6 +5,7 @@ import { join, dirname } from "node:path";
 import { tmpdir, homedir } from "node:os";
 import { createInterface } from "node:readline";
 import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
 import type { AgentRuntime, AgentSession, AgentEvent, SpawnOptions, ResumeOptions } from "@grackle-ai/runtime-sdk";
 import { logger, ensureRuntimeInstalled } from "@grackle-ai/runtime-sdk";
 import { SESSION_STATUS } from "@grackle-ai/common";
@@ -67,6 +68,7 @@ class GenAIScriptSession implements AgentSession {
   public status: SessionStatus = SESSION_STATUS.RUNNING;
 
   private scriptContent: string;
+  private prompt: string;
   private mcpBroker: { url: string; token: string } | undefined;
   private child: ChildProcess | null = null;
   private killed: boolean = false;
@@ -77,6 +79,7 @@ class GenAIScriptSession implements AgentSession {
     this.id = opts.sessionId;
     this.runtimeSessionId = `genaiscript-${opts.sessionId}`;
     this.scriptContent = opts.scriptContent || "";
+    this.prompt = opts.prompt;
     this.mcpBroker = opts.mcpBroker;
   }
 
@@ -113,6 +116,10 @@ class GenAIScriptSession implements AgentSession {
       logger.info({ sessionId: this.id, scriptPath, genaiscriptBin }, "genaiscript: spawning");
 
       yield { type: "system", timestamp: ts(), content: "Starting GenAIScript...", diagnostic: true };
+
+      // GenAIScript is one-shot: wrap the whole run in a single turn (AHP HR2).
+      const turnId = randomUUID();
+      yield { type: "turn_started", timestamp: ts(), content: this.prompt, turnId };
 
       this.child = spawnProcess(process.execPath, [genaiscriptBin, ...args], {
         stdio: ["ignore", "pipe", "pipe"],
@@ -173,7 +180,7 @@ class GenAIScriptSession implements AgentSession {
         const outputTokens = result.usage.completion;
         const costMillicents = Math.round((result.usage.cost ?? 0) * 100_000);
         if (inputTokens > 0 || outputTokens > 0 || costMillicents > 0) {
-          yield { type: "usage", timestamp: ts(), content: JSON.stringify({
+          yield { type: "usage", timestamp: ts(), turnId, content: JSON.stringify({
             input_tokens: inputTokens, output_tokens: outputTokens, cost_millicents: costMillicents,
           }) };
         }
@@ -183,7 +190,7 @@ class GenAIScriptSession implements AgentSession {
 
       // Yield the script's output text — this is the LLM response or script result
       if (result?.text) {
-        yield { type: "text", timestamp: ts(), content: result.text };
+        yield { type: "text", timestamp: ts(), content: result.text, turnId };
       }
 
       // Yield any annotations (warnings/errors from the script)
@@ -195,12 +202,14 @@ class GenAIScriptSession implements AgentSession {
             type: severity === "error" ? "error" : "text",
             timestamp: ts(),
             content: `[${severity}] ${message}`,
+            turnId,
           };
         }
       }
 
       // Final status — GenAIScript is a one-shot runtime, so it goes IDLE when done
       if (exitCode === 0 || result?.status === "success") {
+        yield { type: "turn_complete", timestamp: ts(), content: "", turnId };
         this.status = SESSION_STATUS.IDLE;
         yield { type: "status", timestamp: ts(), content: "waiting_input" };
       } else {

--- a/packages/runtime-sdk/src/base-session.test.ts
+++ b/packages/runtime-sdk/src/base-session.test.ts
@@ -51,6 +51,9 @@ class TestSession extends BaseAgentSession {
   /** When true, emit a `text` content event per turn (to exercise turn_id stamping). */
   public emitContentPerTurn: boolean = false;
 
+  /** When true, runInitialQuery throws — simulates a mid-turn failure after beginTurn. */
+  public throwOnInitialQuery: boolean = false;
+
   /** If set, executeFollowUp will throw on calls matching this predicate. */
   public throwOnInput?: (text: string) => boolean;
 
@@ -77,6 +80,9 @@ class TestSession extends BaseAgentSession {
   // setupForResume uses the base class default implementation
 
   protected async runInitialQuery(_prompt: string): Promise<number> {
+    if (this.throwOnInitialQuery) {
+      throw new Error("simulated initial-query failure");
+    }
     if (this.emitContentPerTurn) {
       this.emit({ type: "text", timestamp: new Date().toISOString(), content: "initial-response" });
     }
@@ -266,6 +272,34 @@ describe("BaseAgentSession turn framing (AHP HR2)", () => {
     expect(started.turnId).toBeTruthy();
 
     session.kill();
+  });
+
+  it("terminal failure mid-turn emits turn-less error and failed status (AHP HR2)", async () => {
+    // throwOnInitialQuery causes the runSession() internal catch to fire while a
+    // turn is open (beginTurn fires before runInitialQuery throws).
+    const { session, nextEvent } = spawnSession({ prompt: "fail-early" });
+    session.throwOnInitialQuery = true;
+
+    const events: AgentEvent[] = [];
+    let e: AgentEvent | undefined;
+    while ((e = await nextEvent()) !== undefined) {
+      events.push(e);
+    }
+
+    const turnStarted = events.find((ev) => ev.type === "turn_started");
+    const error = events.find((ev) => ev.type === "error");
+    const failed = events.find((ev) => ev.type === "status" && ev.content === "failed");
+
+    // The turn WAS opened (beginTurn fires before the failing query).
+    expect(turnStarted).toBeDefined();
+    expect(turnStarted!.turnId).toBeTruthy();
+
+    // Terminal events are turn-less — currentTurnId is cleared in the catch,
+    // mirroring kill() (AHP HR2).
+    expect(error).toBeDefined();
+    expect(error!.turnId).toBeFalsy();
+    expect(failed).toBeDefined();
+    expect(failed!.turnId).toBeFalsy();
   });
 });
 

--- a/packages/runtime-sdk/src/base-session.test.ts
+++ b/packages/runtime-sdk/src/base-session.test.ts
@@ -245,16 +245,25 @@ describe("BaseAgentSession turn framing (AHP HR2)", () => {
     await drainUntilStatus(nextEvent, "waiting_input");
     session.emitContentPerTurn = true;
 
+    const gate = session.addGate();
     session.sendInput("buffered");
-    // Let the follow-up turn run and buffer (we stop consuming the stream).
-    await new Promise((r) => setTimeout(r, 30));
+
+    // Draining to "running" is deterministic: processInputLoop pushes running,
+    // then beginTurn (turn_started), then the text event synchronously in the
+    // same microtask — all before the generator can yield "running". So by the
+    // time drainUntilStatus returns, turn_started and text are buffered in the
+    // queue, waiting behind the suspended generator.
+    await drainUntilStatus(nextEvent, "running");
+
     const drained = session.drainBufferedEvents();
 
     const started = drained.find((x) => x.type === "turn_started" && x.content === "buffered");
     expect(started?.turnId).toBeTruthy();
     expect(drained.find((x) => x.type === "text")?.turnId).toBe(started?.turnId);
-    expect(drained.find((x) => x.type === "turn_complete")?.turnId).toBe(started?.turnId);
+    // turn_complete is not yet emitted (executeFollowUp is gated).
+    expect(drained.some((x) => x.type === "turn_complete")).toBe(false);
 
+    gate.resolve();
     session.kill();
   });
 

--- a/packages/runtime-sdk/src/base-session.test.ts
+++ b/packages/runtime-sdk/src/base-session.test.ts
@@ -48,6 +48,9 @@ class TestSession extends BaseAgentSession {
   /** Track executeFollowUp calls for assertions. */
   public followUpCalls: string[] = [];
 
+  /** When true, emit a `text` content event per turn (to exercise turn_id stamping). */
+  public emitContentPerTurn: boolean = false;
+
   /** If set, executeFollowUp will throw on calls matching this predicate. */
   public throwOnInput?: (text: string) => boolean;
 
@@ -74,6 +77,9 @@ class TestSession extends BaseAgentSession {
   // setupForResume uses the base class default implementation
 
   protected async runInitialQuery(_prompt: string): Promise<number> {
+    if (this.emitContentPerTurn) {
+      this.emit({ type: "text", timestamp: new Date().toISOString(), content: "initial-response" });
+    }
     return 1;
   }
 
@@ -86,6 +92,9 @@ class TestSession extends BaseAgentSession {
       throw new Error(`Simulated error for: ${text}`);
     }
     this.followUpCalls.push(text);
+    if (this.emitContentPerTurn) {
+      this.emit({ type: "text", timestamp: new Date().toISOString(), content: `response-to-${text}` });
+    }
     const gate = this.gates.shift();
     if (gate) {
       await gate.promise;
@@ -149,6 +158,116 @@ function spawnSession(opts?: Partial<CreateSessionOptions>): {
 
   return { session, nextEvent };
 }
+
+// ─── Turn framing (AHP HR2) ──────────────────────────────────────
+
+describe("BaseAgentSession turn framing (AHP HR2)", () => {
+  it("initial turn: turn_started carries the raw prompt and brackets content; turn_complete on idle", async () => {
+    const { session, nextEvent } = spawnSession({ prompt: "do the thing" });
+    session.emitContentPerTurn = true;
+
+    const events = await drainUntilStatus(nextEvent, "waiting_input");
+    const started = events.find((e) => e.type === "turn_started");
+    const text = events.find((e) => e.type === "text");
+    const complete = events.find((e) => e.type === "turn_complete");
+
+    expect(started).toBeDefined();
+    expect(started!.content).toBe("do the thing");
+    expect(started!.turnId).toBeTruthy();
+    expect(text!.turnId).toBe(started!.turnId);
+    expect(complete!.turnId).toBe(started!.turnId);
+    // Ordering: turn_started → content → turn_complete.
+    expect(events.indexOf(started!)).toBeLessThan(events.indexOf(text!));
+    expect(events.indexOf(text!)).toBeLessThan(events.indexOf(complete!));
+    // Liveness / out-of-band events are turn-less.
+    const startup = events.find((e) => e.type === "system");
+    const waiting = events.find((e) => e.type === "status" && e.content === "waiting_input");
+    expect(startup!.turnId).toBeFalsy();
+    expect(waiting!.turnId).toBeFalsy();
+
+    session.kill();
+  });
+
+  it("follow-up turn: turn_started carries the input text with a distinct turn id", async () => {
+    const { session, nextEvent } = spawnSession();
+    session.emitContentPerTurn = true;
+    const initial = await drainUntilStatus(nextEvent, "waiting_input");
+    const initialTurnId = initial.find((e) => e.type === "turn_started")!.turnId;
+
+    session.sendInput("follow up");
+    await drainUntilStatus(nextEvent, "running");
+    const after = await drainUntilStatus(nextEvent, "waiting_input");
+
+    const started = after.find((e) => e.type === "turn_started")!;
+    const text = after.find((e) => e.type === "text")!;
+    const complete = after.find((e) => e.type === "turn_complete")!;
+    expect(started.content).toBe("follow up");
+    expect(started.turnId).toBeTruthy();
+    expect(started.turnId).not.toBe(initialTurnId);
+    expect(text.turnId).toBe(started.turnId);
+    expect(complete.turnId).toBe(started.turnId);
+
+    session.kill();
+  });
+
+  it("kill mid-turn emits no turn_complete and a turn-less final status", async () => {
+    const { session, nextEvent } = spawnSession();
+    session.emitContentPerTurn = true;
+    const gate = session.addGate();
+    await drainUntilStatus(nextEvent, "waiting_input");
+
+    session.sendInput("blocked");
+    await drainUntilStatus(nextEvent, "running");
+    // executeFollowUp has emitted turn_started + text and is now awaiting the gate.
+    session.kill("killed");
+
+    const rest: AgentEvent[] = [];
+    let e: AgentEvent | undefined;
+    while ((e = await nextEvent()) !== undefined) {
+      rest.push(e);
+    }
+    expect(rest.some((x) => x.type === "turn_complete")).toBe(false);
+    const killStatus = rest.find((x) => x.type === "status" && x.content === "killed");
+    expect(killStatus).toBeDefined();
+    expect(killStatus!.turnId).toBeFalsy();
+
+    gate.resolve();
+  });
+
+  it("drainBufferedEvents preserves turn_id on un-consumed events", async () => {
+    const { session, nextEvent } = spawnSession();
+    await drainUntilStatus(nextEvent, "waiting_input");
+    session.emitContentPerTurn = true;
+
+    session.sendInput("buffered");
+    // Let the follow-up turn run and buffer (we stop consuming the stream).
+    await new Promise((r) => setTimeout(r, 30));
+    const drained = session.drainBufferedEvents();
+
+    const started = drained.find((x) => x.type === "turn_started" && x.content === "buffered");
+    expect(started?.turnId).toBeTruthy();
+    expect(drained.find((x) => x.type === "text")?.turnId).toBe(started?.turnId);
+    expect(drained.find((x) => x.type === "turn_complete")?.turnId).toBe(started?.turnId);
+
+    session.kill();
+  });
+
+  it("resumed sessions open no initial turn; the first input is turn 1", async () => {
+    const { session, nextEvent } = spawnSession({ resumeSessionId: "prev-session" });
+    const events = await drainUntilStatus(nextEvent, "waiting_input");
+    expect(events.some((e) => e.type === "turn_started")).toBe(false);
+
+    session.emitContentPerTurn = true;
+    session.sendInput("first after resume");
+    await drainUntilStatus(nextEvent, "running");
+    const after = await drainUntilStatus(nextEvent, "waiting_input");
+    const started = after.find((e) => e.type === "turn_started")!;
+    expect(started.content).toBe("first after resume");
+    expect(started.turnId).toBeTruthy();
+
+    session.kill();
+  });
+});
 
 // ─── Existing tests: input serialization ─────────────────────────
 
@@ -260,7 +379,10 @@ describe("BaseAgentSession input serialization", () => {
 
     expect(session.status).toBe("stopped");
 
-    // kill() emits a final "killed" status event before closing the stream
+    // The in-flight turn's turn_started is buffered before kill (AHP HR2); a
+    // killed turn emits no turn_complete. Then the final "killed" status.
+    const turnStarted = await nextEvent();
+    expect(turnStarted!.type).toBe("turn_started");
     const killedEvent = await nextEvent();
     expect(killedEvent).toBeDefined();
     expect(killedEvent!.type).toBe("status");
@@ -397,10 +519,11 @@ describe("sendInput before SDK ready", () => {
     // Now resolve setup so the session can proceed
     session.resolveSetup();
 
-    // The pending nextEvent resolves with the waiting_input status
+    // The pending nextEvent resolves with the initial turn_started (AHP HR2);
+    // the session then goes idle.
     const waitingEvent = await pendingFirstEvent;
-    expect(waitingEvent?.type).toBe("status");
-    expect(waitingEvent?.content).toBe("waiting_input");
+    expect(waitingEvent?.type).toBe("turn_started");
+    await drainUntilStatus(nextEvent, "waiting_input");
 
     // The early message should be queued and processed as the first follow-up
     await drainUntilStatus(nextEvent, "running");
@@ -435,10 +558,11 @@ describe("sendInput before SDK ready", () => {
     // Resolve setup
     session.resolveSetup();
 
-    // The pending nextEvent resolves with waiting_input
+    // The pending nextEvent resolves with the initial turn_started (AHP HR2);
+    // the session then goes idle.
     const waitingEvent = await pendingFirstEvent;
-    expect(waitingEvent?.type).toBe("status");
-    expect(waitingEvent?.content).toBe("waiting_input");
+    expect(waitingEvent?.type).toBe("turn_started");
+    await drainUntilStatus(nextEvent, "waiting_input");
 
     // All 3 should be processed in FIFO order
     for (const _expected of ["alpha", "bravo", "charlie"]) {

--- a/packages/runtime-sdk/src/base-session.ts
+++ b/packages/runtime-sdk/src/base-session.ts
@@ -234,6 +234,9 @@ export abstract class BaseAgentSession implements AgentSession {
     // Drive the session in the background; events are pushed to the queue
     // and yielded from this generator.
     this.runSession().catch((err) => {
+      // A failed turn never completes — drop the turn id so terminal events are
+      // turn-less (AHP HR2), mirroring kill().
+      this.currentTurnId = undefined;
       this.emit({ type: "error", timestamp: ts(), content: String(err) });
       this.emit({ type: "status", timestamp: ts(), content: "failed" });
       this.status = SESSION_STATUS.STOPPED;
@@ -287,6 +290,9 @@ export abstract class BaseAgentSession implements AgentSession {
     } catch (err) {
       this.killed = true;
       this.status = SESSION_STATUS.STOPPED;
+      // A failed turn never completes — drop the turn id so terminal events are
+      // turn-less (AHP HR2), mirroring kill().
+      this.currentTurnId = undefined;
       this.emit({ type: "error", timestamp: ts(), content: String(err) });
       this.emit({ type: "status", timestamp: ts(), content: "failed" });
       this.inputQueue.close();
@@ -346,6 +352,9 @@ export abstract class BaseAgentSession implements AgentSession {
       const ts = new Date().toISOString();
       logger.error({ err }, `Input loop crashed in ${this.runtimeDisplayName} session`);
       this.status = SESSION_STATUS.STOPPED;
+      // A failed turn never completes — drop the turn id so terminal events are
+      // turn-less (AHP HR2), mirroring kill().
+      this.currentTurnId = undefined;
       this.emit({ type: "error", timestamp: ts, content: String(err) });
       this.emit({ type: "status", timestamp: ts, content: "failed" });
       this.inputQueue.close();

--- a/packages/runtime-sdk/src/base-session.ts
+++ b/packages/runtime-sdk/src/base-session.ts
@@ -5,6 +5,7 @@ import { AsyncQueue } from "./async-queue.js";
 import { resolveWorkingDirectory, resolveMcpServers } from "./runtime-utils.js";
 import type { ResolvedMcpConfig } from "./runtime-utils.js";
 import { logger } from "./logger.js";
+import { randomUUID } from "node:crypto";
 
 /**
  * Abstract base class for agent sessions that use the eventQueue + waiting_input lifecycle.
@@ -30,6 +31,8 @@ export abstract class BaseAgentSession implements AgentSession {
   protected readonly eventQueue: AsyncQueue<AgentEvent> = new AsyncQueue<AgentEvent>();
   private readonly inputQueue: AsyncQueue<string> = new AsyncQueue<string>();
   protected killed: boolean = false;
+  /** Id of the in-progress turn (AHP HR2); undefined between turns and for out-of-band events. */
+  private currentTurnId: string | undefined = undefined;
   protected readonly prompt: string;
   protected readonly model: string;
   protected readonly maxTurns: number;
@@ -81,7 +84,7 @@ export abstract class BaseAgentSession implements AgentSession {
    * and call `super.setupForResume()` to preserve the system event.
    */
   protected async setupForResume(): Promise<void> {
-    this.eventQueue.push({
+    this.emit({
       type: "system",
       timestamp: new Date().toISOString(),
       content: `Session resumed (id: ${this.resumeSessionId})`,
@@ -154,7 +157,7 @@ export abstract class BaseAgentSession implements AgentSession {
     if (inputTokens === 0 && outputTokens === 0 && costMillicents === 0) {
       return;
     }
-    this.eventQueue.push({
+    this.emit({
       type: "usage",
       timestamp: new Date().toISOString(),
       content: JSON.stringify({
@@ -173,12 +176,52 @@ export abstract class BaseAgentSession implements AgentSession {
     const wasEmpty = !this.runtimeSessionId;
     this.runtimeSessionId = id;
     if (wasEmpty && id) {
-      this.eventQueue.push({
+      this.emit({
         type: "runtime_session_id",
         timestamp: new Date().toISOString(),
         content: id,
       });
     }
+  }
+
+  // ─── Turn framing (AHP HR2) ───────────────────────────────
+
+  /**
+   * Emit an event onto the session stream, stamping the active turn id (AHP HR2).
+   * Out-of-turn / liveness events (status, startup, kill) are emitted while
+   * `currentTurnId` is unset and therefore carry no turn id. All runtimes and
+   * the base class push through this single chokepoint.
+   */
+  protected emit(event: AgentEvent): void {
+    if (this.currentTurnId !== undefined && event.turnId === undefined) {
+      event.turnId = this.currentTurnId;
+    }
+    this.eventQueue.push(event);
+  }
+
+  /** Open a turn anchored on the real user message (AHP HR2). */
+  private beginTurn(userMessage: string): void {
+    this.currentTurnId = randomUUID();
+    this.emit({
+      type: "turn_started",
+      timestamp: new Date().toISOString(),
+      content: userMessage,
+      turnId: this.currentTurnId,
+    });
+  }
+
+  /** Close the in-progress turn, if any (AHP HR2). */
+  private endTurn(): void {
+    if (this.currentTurnId === undefined) {
+      return;
+    }
+    this.emit({
+      type: "turn_complete",
+      timestamp: new Date().toISOString(),
+      content: "",
+      turnId: this.currentTurnId,
+    });
+    this.currentTurnId = undefined;
   }
 
   // ─── Shared lifecycle implementation ──────────────────────
@@ -191,8 +234,8 @@ export abstract class BaseAgentSession implements AgentSession {
     // Drive the session in the background; events are pushed to the queue
     // and yielded from this generator.
     this.runSession().catch((err) => {
-      this.eventQueue.push({ type: "error", timestamp: ts(), content: String(err) });
-      this.eventQueue.push({ type: "status", timestamp: ts(), content: "failed" });
+      this.emit({ type: "error", timestamp: ts(), content: String(err) });
+      this.emit({ type: "status", timestamp: ts(), content: "failed" });
       this.status = SESSION_STATUS.STOPPED;
       this.eventQueue.close();
     });
@@ -213,7 +256,7 @@ export abstract class BaseAgentSession implements AgentSession {
       if (this.resumeSessionId) {
         await this.setupForResume();
         this.status = SESSION_STATUS.IDLE;
-        this.eventQueue.push({ type: "status", timestamp: ts(), content: "waiting_input" });
+        this.emit({ type: "status", timestamp: ts(), content: "waiting_input" });
         this.startInputLoop();
         return;
       }
@@ -221,6 +264,8 @@ export abstract class BaseAgentSession implements AgentSession {
       // Build final prompt with system context
       const finalPrompt = this.buildInitialPrompt();
 
+      // Open the initial turn, anchored on the raw user prompt (AHP HR2).
+      this.beginTurn(this.prompt);
       const messageCount = await this.runInitialQuery(finalPrompt);
 
       if (this.killed) {
@@ -230,19 +275,20 @@ export abstract class BaseAgentSession implements AgentSession {
       }
 
       if (messageCount === 0) {
-        this.eventQueue.push({ type: "error", timestamp: ts(), content: this.noMessagesError });
+        this.emit({ type: "error", timestamp: ts(), content: this.noMessagesError });
       }
 
-      // Session is idle — ready for follow-up input via sendInput().
+      // Initial turn complete; session is idle — ready for follow-up input.
       // The input loop owns the eventQueue lifecycle from this point.
+      this.endTurn();
       this.status = SESSION_STATUS.IDLE;
-      this.eventQueue.push({ type: "status", timestamp: ts(), content: "waiting_input" });
+      this.emit({ type: "status", timestamp: ts(), content: "waiting_input" });
       this.startInputLoop();
     } catch (err) {
       this.killed = true;
       this.status = SESSION_STATUS.STOPPED;
-      this.eventQueue.push({ type: "error", timestamp: ts(), content: String(err) });
-      this.eventQueue.push({ type: "status", timestamp: ts(), content: "failed" });
+      this.emit({ type: "error", timestamp: ts(), content: String(err) });
+      this.emit({ type: "status", timestamp: ts(), content: "failed" });
       this.inputQueue.close();
       this.releaseResources();
       this.eventQueue.close();
@@ -269,21 +315,24 @@ export abstract class BaseAgentSession implements AgentSession {
         break;
       }
       this.status = SESSION_STATUS.RUNNING;
-      this.eventQueue.push({ type: "status", timestamp: ts(), content: "running" });
+      this.emit({ type: "status", timestamp: ts(), content: "running" });
+      // Open the follow-up turn, anchored on the real input text (AHP HR2).
+      this.beginTurn(text);
 
       try {
         await this.executeFollowUp(text);
       } catch (err: unknown) {
         logger.warn({ err }, `Failed to process follow-up input in ${this.runtimeDisplayName} session`);
-        this.eventQueue.push({ type: "error", timestamp: ts(), content: String(err) });
+        this.emit({ type: "error", timestamp: ts(), content: String(err) });
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- killed changes asynchronously via kill()
       if (this.killed) {
         break;
       }
+      this.endTurn();
       this.status = SESSION_STATUS.IDLE;
-      this.eventQueue.push({ type: "status", timestamp: ts(), content: "waiting_input" });
+      this.emit({ type: "status", timestamp: ts(), content: "waiting_input" });
     }
 
     // Loop exited — queue closed (kill) or drained.
@@ -297,8 +346,8 @@ export abstract class BaseAgentSession implements AgentSession {
       const ts = new Date().toISOString();
       logger.error({ err }, `Input loop crashed in ${this.runtimeDisplayName} session`);
       this.status = SESSION_STATUS.STOPPED;
-      this.eventQueue.push({ type: "error", timestamp: ts, content: String(err) });
-      this.eventQueue.push({ type: "status", timestamp: ts, content: "failed" });
+      this.emit({ type: "error", timestamp: ts, content: String(err) });
+      this.emit({ type: "status", timestamp: ts, content: "failed" });
       this.inputQueue.close();
       this.releaseResources();
       this.eventQueue.close();
@@ -311,8 +360,11 @@ export abstract class BaseAgentSession implements AgentSession {
     this.status = SESSION_STATUS.STOPPED;
     this.abortActive();
     this.inputQueue.close();
+    // A killed turn never completes — drop the turn id so the final status is
+    // turn-less and no turn_complete is emitted (AHP HR2).
+    this.currentTurnId = undefined;
     // Emit a final status event BEFORE closing the queue so the server receives it.
-    this.eventQueue.push({
+    this.emit({
       type: "status",
       timestamp: new Date().toISOString(),
       content: reason,

--- a/packages/runtime-sdk/src/base-session.ts
+++ b/packages/runtime-sdk/src/base-session.ts
@@ -193,7 +193,12 @@ export abstract class BaseAgentSession implements AgentSession {
    * the base class push through this single chokepoint.
    */
   protected emit(event: AgentEvent): void {
-    if (this.currentTurnId !== undefined && event.turnId === undefined) {
+    if (
+      this.currentTurnId !== undefined &&
+      event.turnId === undefined &&
+      event.type !== "status" &&  // liveness: never turn-stamped
+      !event.diagnostic           // lifecycle/diagnostic: out-of-band
+    ) {
       event.turnId = this.currentTurnId;
     }
     this.eventQueue.push(event);

--- a/packages/runtime-sdk/src/runtime.ts
+++ b/packages/runtime-sdk/src/runtime.ts
@@ -20,6 +20,13 @@ export interface AgentEvent {
    * substantive events (agent output, the injected system context).
    */
   diagnostic?: boolean;
+  /**
+   * Identifier of the turn this event belongs to (AHP HR2). Set by base-session
+   * turn framing on `turn_started`/`turn_complete` and stamped on every content
+   * event within a turn; left unset for out-of-band/liveness events (startup,
+   * status, worktree setup, kill). Process-scoped — a resume starts a new turn.
+   */
+  turnId?: string;
 }
 
 /** Parameters for spawning a new agent session. */

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -78,6 +78,11 @@ export interface SessionEvent {
    * non-tool events and on events logged before HR3.
    */
   toolCallId?: string;
+  /**
+   * Turn this event belongs to (AHP HR2). Available for future turn-grouped
+   * rendering; absent on out-of-band/liveness events and pre-HR2 logs.
+   */
+  turnId?: string;
 }
 
 /** A workspace that groups tasks. */
@@ -713,7 +718,8 @@ export function isSessionEvent(v: unknown): v is SessionEvent {
     typeof v.timestamp === "string" &&
     typeof v.content === "string" &&
     (v.raw === undefined || typeof v.raw === "string") &&
-    (v.toolCallId === undefined || typeof v.toolCallId === "string")
+    (v.toolCallId === undefined || typeof v.toolCallId === "string") &&
+    (v.turnId === undefined || typeof v.turnId === "string")
   );
 }
 

--- a/packages/web/src/hooks/proto-converters.ts
+++ b/packages/web/src/hooks/proto-converters.ts
@@ -75,6 +75,7 @@ export function protoToSessionEvent(p: grackle.SessionEvent): SessionEvent {
     content: p.content,
     raw: p.raw || undefined,
     toolCallId: p.toolCallId || undefined,
+    turnId: p.turnId || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Gives Grackle's session event stream **explicit, first-class turn structure** (AHP adoption epic #1285, HR2). Producer-side, behind the existing gRPC wire — mirrors HR3 `tool_call_id`; **no AHP-wire change** (that's HR8). Removes the overload where `waiting_input` meant *both* "turn done / idle" *and* (hypothetically) "blocked mid-turn awaiting input", so the future AHP reducer can emit `turnStarted`/`turnComplete`/`inputRequested` without synthesizing.

- **proto**: `turn_id` field (8) on `AgentEvent` + `SessionEvent`; `EventType` `TURN_STARTED`/`TURN_COMPLETE`/`INPUT_NEEDED` (14/15/16); enum-converters.
- **runtime-sdk (the spine)**: a new `base-session` `emit()` chokepoint stamps the active turn id on every outgoing event; `beginTurn`/`endTurn` open turns anchored on the **real prompt / `sendInput` text** around `runInitialQuery`/`executeFollowUp`. The four conversational runtimes (claude/codex/copilot/acp) get framing for free via the `eventQueue.push` → `emit` migration.
- **genaiscript** (one-shot → one turn) and the **stub legacy path** emit turn framing manually (they don't extend `BaseAgentSession`).
- **threaded** through PowerLine `toProtoEvent`, event-processor, log-writer (JSONL + `LogEntry`), session-recovery drain, and web (`proto-converters` + `SessionEvent` type/guard).

### Key decisions
- `turn_complete` is **advisory** — the existing `waiting_input` status still drives the `IDLE` transition, so there's **no user-visible behavior change** (legacy `waiting_input` is retired at HR8).
- `input_needed` is **plumb-only** — investigation confirmed Grackle has no mid-turn blocking input/approval flow today (all runtime permissions auto-approve; escalations are fire-and-forget). The type/field/mapping exist so the AHP reducer *can* consume it later, but nothing emits it.
- `turn_id` is **process-scoped** (a resume starts a new turn).
- Deferred (consistent with HR3's precedent): `turn_id` as a first-class `SessionAction` column and wiring `incrementTurns()` → HR1b.

## Test plan
- [x] `rush build` whole-repo green, zero warnings
- [x] unit green: `common` (enum round-trips for the 3 new types), `runtime-sdk` (turn-framing suite: prompt-anchored initial turn, distinct follow-up ids, kill-mid-turn = no `turn_complete`, drain preserves `turn_id`, resume = no turn-1), all 5 runtimes, `powerline` (stub + stub-mcp lifecycle sequences updated + turn-id assertions), `core`
- [x] **manual `/launch-grackle`**: real claude-code session → JSONL shows `turn_started` carrying the actual prompt, `text`/`usage`/`turn_complete` sharing the turn id, liveness events (startup `system`, `waiting_input` status) turn-less
- [ ] CI: full build + E2E regression net (existing stub-based specs exercise the spawn/sendInput stream)

**E2E note:** rather than a new Playwright spec, turn-framing end-to-end is covered by the manual verification above plus the existing stub-based E2E regression net (session-lifecycle / send-input / reanimate) which runs in CI and would catch any stream regression.

Part of epic #1285.

Closes #1286