### PR TITLE
PR review thread skills: respond-to-pr-review-thread, resolve-pr-review-thread

### DIFF
--- a/.claude/skills/resolve-pr-review-thread/SKILL.md
+++ b/.claude/skills/resolve-pr-review-thread/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: resolve-pr-review-thread
+description: Resolve unresolved PR review threads using the GraphQL API. Run with /resolve-pr-review-thread or /resolve-pr-review-thread <PR_NUMBER>.
+---
+
+# Resolve PR Review Thread
+
+Resolve unresolved PR review threads (Copilot review comments) using the GraphQL `resolveReviewThread` mutation.
+
+## Usage
+
+```bash
+/resolve-pr-review-thread [PR_NUMBER]
+```
+
+If no PR number is provided, detect from the current branch.
+
+## Step 1: Get PR Details
+
+```bash
+PR_NUMBER=<detected or provided PR number>
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+```
+
+## Step 2: Fetch Unresolved Review Threads
+
+Use the GraphQL API to fetch all unresolved review threads.
+
+**Important**: On Windows (MSYS2/Git Bash), `$` characters in `gh api graphql -f query='...'` are unreliably handled by the shell. Always use Node.js with `gh api -X POST /graphql --input -` to pipe the GraphQL query via stdin:
+
+```javascript
+node -e "
+const {execSync} = require('child_process');
+const body = JSON.stringify({
+  query: 'query(\x24owner: String!, \x24repo: String!, \x24pr: Int!) { repository(owner: \x24owner, name: \x24repo) { pullRequest(number: \x24pr) { reviewThreads(first: 100) { nodes { id isResolved isOutdated path line startLine comments(last: 1) { nodes { id author { login } body createdAt } } } } } } }',
+  variables: {owner: '$OWNER', repo: '$REPO', pr: $PR_NUMBER}
+});
+console.log(execSync('gh api -X POST /graphql --input -', {input: body, encoding: 'utf-8'}));
+"
+```
+
+## Step 3: Filter to Unresolved Threads
+
+Select threads where:
+- `isResolved` is `false`
+- The comment author matches the target (e.g. `copilot-pull-request-reviewer` for Copilot threads, or `nick-pape` for own threads)
+
+## Step 4: Resolve Each Thread
+
+For each unresolved thread, use the GraphQL `resolveReviewThread` mutation:
+
+```javascript
+node -e "
+const {execSync} = require('child_process');
+const body = JSON.stringify({
+  query: 'mutation(\x24threadId: ID!) { resolveReviewThread(input: {threadId: \x24threadId}) { thread { isResolved } } }',
+  variables: {threadId: 'THREAD_NODE_ID'}
+});
+console.log(execSync('gh api -X POST /graphql --input -', {input: body, encoding: 'utf-8'}));
+"
+```
+
+Where `THREAD_NODE_ID` comes from the GraphQL query result (the `id` field of each thread node, e.g. `PRRT_kwDORVQfCc6E2NBI`).
+
+## Important Notes
+
+- **Reply before resolving** — always reply to a thread before resolving it (use the `respond-to-pr-review-thread` skill first)
+- **Thread IDs** — the GraphQL query returns `id` as the node_id (PRRT_...), NOT the REST numeric ID. Use this directly in the mutation.
+- **No force push** — never force-push, even if it seems easier
+- **CLAUDE.md compliance** — follow project conventions when making code changes alongside resolutions

--- a/.claude/skills/respond-to-pr-review-thread/SKILL.md
+++ b/.claude/skills/respond-to-pr-review-thread/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: respond-to-pr-review-thread
+description: Respond to unresolved PR review threads (reply to Copilot review comments). Run with /respond-to-pr-review-thread or /respond-to-pr-review-thread <PR_NUMBER>.
+---
+
+# Respond to PR Review Thread
+
+Reply to unresolved PR review thread comments without resolving them. Useful for providing context before resolving, or for wontfix explanations.
+
+## Usage
+
+```bash
+/respond-to-pr-review-thread [PR_NUMBER]
+```
+
+If no PR number is provided, detect from the current branch.
+
+## Step 1: Get PR Details
+
+```bash
+PR_NUMBER=<detected or provided PR number>
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+```
+
+## Step 2: Fetch Unresolved Review Threads
+
+Use the GraphQL API to fetch all unresolved review threads with Copilot comments.
+
+**Important**: On Windows (MSYS2/Git Bash), `$` characters in `gh api graphql -f query='...'` are unreliably handled by the shell. Always use Node.js with `gh api -X POST /graphql --input -` to pipe the GraphQL query via stdin:
+
+```javascript
+node -e "
+const {execSync} = require('child_process');
+const body = JSON.stringify({
+  query: 'query(\x24owner: String!, \x24repo: String!, \x24pr: Int!) { repository(owner: \x24owner, name: \x24repo) { pullRequest(number: \x24pr) { reviewThreads(first: 100) { nodes { id isResolved isOutdated path line startLine comments(last: 1) { nodes { id author { login } body createdAt } } } } } } }',
+  variables: {owner: '$OWNER', repo: '$REPO', pr: $PR_NUMBER}
+});
+console.log(execSync('gh api -X POST /graphql --input -', {input: body, encoding: 'utf-8'}));
+"
+```
+
+## Step 3: Filter to Actionable Threads
+
+Select threads where:
+- `isResolved` is `false`
+- The comment author is `copilot-pull-request-reviewer` (or the user's own unresolved thread)
+
+## Step 4: Reply to Each Thread
+
+For each unresolved thread, reply using the REST API. The GraphQL `comments.nodes[0].id` is the node_id — you need to get the REST numeric ID. Use the REST comments endpoint to find matching comments:
+
+```bash
+gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" --jq '.[] | select(.user.login == "Copilot") | {id, node_id}'
+```
+
+Match the GraphQL node_id to the REST node_id to get the REST numeric `id`, then reply:
+
+```bash
+gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" -f body="YOUR_REPLY"
+```
+
+## Important Notes
+
+- **Reply before resolving** — always reply to a thread before resolving it
+- **Thread resolution** uses a separate skill (`resolve-pr-review-thread`)
+- **No force push** — never force-push, even if it seems easier
+- **CLAUDE.md compliance** — follow project conventions when making code changes alongside replies


### PR DESCRIPTION
## Summary

- Add `respond-to-pr-review-thread` skill — reply to unresolved PR review threads via REST API
- Add `resolve-pr-review-thread` skill — resolve review threads using the GraphQL `resolveReviewThread` mutation

These extract the thread-reply and thread-resolve primitives from `pr-fixup` into standalone skills for one-off use cases, without the full sync/build/push/CI machinery.

## Test plan

- [ ] Skills appear in Claude's skill registry
- [ ] Skills are self-contained and reference the shared GraphQL queries from pr-fixup