### PR TITLE
Record the squash SHA in .git-blame-ignore-revs (post-#1324)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,4 @@
 #
 # Format: one SHA per line, optional trailing `# comment`.
 
-0881ff5b9b16d675e5cc80a64b01b5bdaf3e3530 # chore: format codebase with prettier (#1324)
+79c5cf10de71f2ffe560919725d7ffe954399204 # Set up Prettier as PR gate and pre-commit hook (#1324)


### PR DESCRIPTION
## Summary

Follow-up to #1324. That PR was squash-merged (the repo only allows squash), so the original local reformat commit SHA (0881ff5b) doesn't exist on main — the squash commit `79c5cf10` is what `git blame` will actually point to for the 872 reformatted files. This PR replaces the recorded SHA accordingly.

## Test plan

- [x] After this lands, `git blame` on a file touched by the reformat should skip `79c5cf10` and show the original author of each line.