### PR TITLE
Enforce per-package coverage thresholds (#1326)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,10 @@ npx buf generate
 
 `rush test` collects unit-test coverage via Vitest's v8 provider. Reports land in each package's `coverage/` directory (`lcov.info`, `coverage-summary.json`, and an `index.html` for browser viewing). CI uploads them as a single `coverage` artifact on the `build` job. The shared config lives at `rigs/heft-rig/vitest-base.mjs` — per-package `vitest.config.ts` files just call `createVitestConfig()` and add overrides if needed.
 
-- **No threshold enforcement yet** ([#1326](https://github.com/nick-pape/grackle/issues/1326)) — the floor is set in a follow-up once we have baseline data.
+- **Per-package thresholds enforced** ([#1326](https://github.com/nick-pape/grackle/issues/1326)). Floors for each metric (branches/lines/functions/statements) live in `rigs/heft-rig/coverage-thresholds.json`. CI fails if any package drops below its floor. Frozen — no auto-ratchet; bump by hand when a package's real coverage climbs and you want to lock the new floor in.
 - **Unit tests only** ([#1327](https://github.com/nick-pape/grackle/issues/1327)) — Storybook interaction tests and Playwright E2E aren't yet instrumented.
 - Excluded by default: `src/gen/**` (proto), `src/vendor/**` (vendored AHP), `src/mocks/**`, `*.stories.tsx`, `*.test.{ts,tsx}`.
+- New packages without a thresholds entry log a one-line warning and run unenforced. Add an entry once the package has a stable baseline.
 
 ### Storybook Component Tests
 

--- a/rigs/heft-rig/coverage-thresholds.json
+++ b/rigs/heft-rig/coverage-thresholds.json
@@ -1,0 +1,200 @@
+{
+  "@grackle-ai/adapter-codespace": {
+    "branches": 55,
+    "functions": 55,
+    "lines": 60,
+    "statements": 60
+  },
+  "@grackle-ai/adapter-docker": {
+    "branches": 65,
+    "functions": 65,
+    "lines": 55,
+    "statements": 55
+  },
+  "@grackle-ai/adapter-local": {
+    "branches": 80,
+    "functions": 30,
+    "lines": 30,
+    "statements": 30
+  },
+  "@grackle-ai/adapter-sdk": {
+    "branches": 80,
+    "functions": 50,
+    "lines": 40,
+    "statements": 40
+  },
+  "@grackle-ai/adapter-ssh": {
+    "branches": 80,
+    "functions": 35,
+    "lines": 40,
+    "statements": 40
+  },
+  "@grackle-ai/ahp": {
+    "branches": 100,
+    "functions": 100,
+    "lines": 100,
+    "statements": 100
+  },
+  "@grackle-ai/auth": {
+    "branches": 85,
+    "functions": 80,
+    "lines": 75,
+    "statements": 75
+  },
+  "@grackle-ai/cli": {
+    "branches": 95,
+    "functions": 80,
+    "lines": 5,
+    "statements": 5
+  },
+  "@grackle-ai/common": {
+    "branches": 90,
+    "functions": 50,
+    "lines": 95,
+    "statements": 95
+  },
+  "@grackle-ai/core": {
+    "branches": 80,
+    "functions": 90,
+    "lines": 70,
+    "statements": 70
+  },
+  "@grackle-ai/database": {
+    "branches": 80,
+    "functions": 80,
+    "lines": 75,
+    "statements": 75
+  },
+  "@grackle-ai/github-import": {
+    "branches": 95,
+    "functions": 100,
+    "lines": 65,
+    "statements": 65
+  },
+  "@grackle-ai/knowledge": {
+    "branches": 80,
+    "functions": 100,
+    "lines": 90,
+    "statements": 90
+  },
+  "@grackle-ai/knowledge-core": {
+    "branches": 80,
+    "functions": 90,
+    "lines": 80,
+    "statements": 80
+  },
+  "@grackle-ai/mcp": {
+    "branches": 80,
+    "functions": 70,
+    "lines": 80,
+    "statements": 80
+  },
+  "@grackle-ai/mcp-stdio": {
+    "branches": 90,
+    "functions": 50,
+    "lines": 40,
+    "statements": 40
+  },
+  "@grackle-ai/plugin-core": {
+    "branches": 75,
+    "functions": 65,
+    "lines": 65,
+    "statements": 65
+  },
+  "@grackle-ai/plugin-knowledge": {
+    "branches": 80,
+    "functions": 75,
+    "lines": 60,
+    "statements": 60
+  },
+  "@grackle-ai/plugin-orchestration": {
+    "branches": 80,
+    "functions": 70,
+    "lines": 90,
+    "statements": 90
+  },
+  "@grackle-ai/plugin-scheduling": {
+    "branches": 90,
+    "functions": 100,
+    "lines": 95,
+    "statements": 95
+  },
+  "@grackle-ai/plugin-sdk": {
+    "branches": 90,
+    "functions": 100,
+    "lines": 90,
+    "statements": 90
+  },
+  "@grackle-ai/powerline": {
+    "branches": 90,
+    "functions": 75,
+    "lines": 55,
+    "statements": 55
+  },
+  "@grackle-ai/prompt": {
+    "branches": 90,
+    "functions": 95,
+    "lines": 95,
+    "statements": 95
+  },
+  "@grackle-ai/runtime-acp": {
+    "branches": 65,
+    "functions": 90,
+    "lines": 75,
+    "statements": 75
+  },
+  "@grackle-ai/runtime-claude-code": {
+    "branches": 75,
+    "functions": 90,
+    "lines": 80,
+    "statements": 80
+  },
+  "@grackle-ai/runtime-codex": {
+    "branches": 60,
+    "functions": 85,
+    "lines": 85,
+    "statements": 85
+  },
+  "@grackle-ai/runtime-copilot": {
+    "branches": 55,
+    "functions": 90,
+    "lines": 70,
+    "statements": 70
+  },
+  "@grackle-ai/runtime-genaiscript": {
+    "branches": 30,
+    "functions": 15,
+    "lines": 5,
+    "statements": 5
+  },
+  "@grackle-ai/runtime-sdk": {
+    "branches": 80,
+    "functions": 80,
+    "lines": 60,
+    "statements": 60
+  },
+  "@grackle-ai/server": {
+    "branches": 85,
+    "functions": 70,
+    "lines": 50,
+    "statements": 50
+  },
+  "@grackle-ai/web": {
+    "branches": 80,
+    "functions": 75,
+    "lines": 15,
+    "statements": 15
+  },
+  "@grackle-ai/web-components": {
+    "branches": 80,
+    "functions": 45,
+    "lines": 10,
+    "statements": 10
+  },
+  "@grackle-ai/web-server": {
+    "branches": 70,
+    "functions": 65,
+    "lines": 40,
+    "statements": 40
+  }
+}

--- a/rigs/heft-rig/vitest-base.mjs
+++ b/rigs/heft-rig/vitest-base.mjs
@@ -2,6 +2,7 @@
 //   - Test discovery globs (`src/**/*.test.ts(x)`)
 //   - The `node` environment + standard timeout/isolation settings
 //   - Coverage collection via the v8 provider
+//   - Per-package coverage thresholds (PR gate, #1326)
 //
 // Per-package configs import `createVitestConfig` and pass overrides:
 //
@@ -9,12 +10,33 @@
 //   export default createVitestConfig({
 //     test: { environment: "jsdom" },  // example override
 //   });
-//
-// Coverage thresholds are intentionally NOT set here — see issue #1326 (Phase 3
-// of the coverage rollout) for the follow-up that enables enforcement once we
-// have real baseline numbers.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { defineConfig, mergeConfig } from "vitest/config";
+
+// Per-package coverage floors (#1326). Values are the rounded-down 5%
+// boundary of each package's baseline coverage from the measurement-only
+// PR (#1328). Frozen — no auto-ratchet. Bump by hand when a package's
+// real coverage climbs and you want to lock the new floor in.
+const THRESHOLDS_PATH = new URL("./coverage-thresholds.json", import.meta.url);
+const COVERAGE_THRESHOLDS = JSON.parse(readFileSync(THRESHOLDS_PATH, "utf8"));
+
+/** Looks up the thresholds entry for the package whose vitest.config.ts is loading us. */
+function thresholdsForCurrentPackage() {
+  const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8"));
+  const entry = COVERAGE_THRESHOLDS[pkg.name];
+  if (!entry) {
+    process.stderr.write(
+      `[vitest-base] No coverage thresholds defined for ${pkg.name}; ` +
+        `running unenforced. Add an entry to ` +
+        `rigs/heft-rig/coverage-thresholds.json after this package has a baseline.\n`,
+    );
+    return undefined;
+  }
+  return entry;
+}
 
 const baseConfig = defineConfig({
   test: {
@@ -46,6 +68,7 @@ const baseConfig = defineConfig({
         "src/**/*.d.ts",
       ],
       clean: true,
+      thresholds: thresholdsForCurrentPackage(),
     },
   },
 });


### PR DESCRIPTION
## Summary

**Phase 3 of the coverage rollout.** Turns the coverage measurement from PR #1328 into a real PR gate. CI will now fail if any package's coverage drops below its frozen floor.

### What this PR does

- **`rigs/heft-rig/coverage-thresholds.json`** (new) — single 33-entry JSON map. Each entry is `floor(actual / 5) * 5` for every metric (branches, lines, functions, statements) using PR #1328's CI baseline.
- **`rigs/heft-rig/vitest-base.mjs`** (modified) — reads the current package's `package.json` at config-load time, looks up the entry, injects the floors as `coverage.thresholds`. Packages without an entry log a one-line stderr warning and run unenforced.

### Floor table (computed from PR #1328's CI artifact)

| Package | branches | lines | functions | statements |
|---|---:|---:|---:|---:|
| adapter-codespace | 55 | 60 | 55 | 60 |
| adapter-docker | 65 | 55 | 65 | 55 |
| adapter-local | 80 | 30 | 30 | 30 |
| adapter-sdk | 80 | 40 | 50 | 40 |
| adapter-ssh | 80 | 40 | 35 | 40 |
| ahp | 100 | 100 | 100 | 100 |
| auth | 85 | 75 | 80 | 75 |
| cli | 95 | 5 | 80 | 5 |
| common | 90 | 95 | 50 | 95 |
| core | 80 | 70 | 90 | 70 |
| database | 80 | 75 | 80 | 75 |
| github-import | 95 | 65 | 100 | 65 |
| knowledge | 80 | 90 | 100 | 90 |
| knowledge-core | 80 | 80 | 90 | 80 |
| mcp | 80 | 80 | 70 | 80 |
| mcp-stdio | 90 | 40 | 50 | 40 |
| plugin-core | 75 | 65 | 65 | 65 |
| plugin-knowledge | 80 | 60 | 75 | 60 |
| plugin-orchestration | 80 | 90 | 70 | 90 |
| plugin-scheduling | 90 | 95 | 100 | 95 |
| plugin-sdk | 90 | 90 | 100 | 90 |
| powerline | 90 | 55 | 75 | 55 |
| prompt | 90 | 95 | 95 | 95 |
| runtime-acp | 65 | 75 | 90 | 75 |
| runtime-claude-code | 75 | 80 | 90 | 80 |
| runtime-codex | 60 | 85 | 85 | 85 |
| runtime-copilot | 55 | 70 | 90 | 70 |
| runtime-genaiscript | 30 | 5 | 15 | 5 |
| runtime-sdk | 80 | 60 | 80 | 60 |
| server | 85 | 50 | 70 | 50 |
| web | 80 | 15 | 75 | 15 |
| web-components | 80 | 10 | 45 | 10 |
| web-server | 70 | 40 | 65 | 40 |

### Policy: frozen, no auto-ratchet

- No `autoUpdate`, no ratchet script. Floors stay where set.
- To raise a floor: edit `coverage-thresholds.json` by hand and commit.
- To unbreak a brittle 100% floor (e.g. `ahp`): edit the JSON, drop by 5%, commit.

This is the most predictable model: tests fail loudly when coverage drops, and never quietly tighten under you.

### Known brittleness (accepted)

- `ahp` at 100/100/100/100 fails on any tiny addition without a test. Tight margin by design.
- `runtime-genaiscript` at branches=30 / lines=5 has only ~3pp margin on branches. Coverage measurements can fluctuate slightly between runs; if it bites, drop to 25 / 0.

### Closes

- #1326

## Test plan

- [x] `rush test -t @grackle-ai/auth` passes locally (actual ≥ floor for auth + transitive deps)
- [x] `rush change --verify` clean (no publishable code changed; rigs/heft-rig isn't lockstep)
- [ ] CI green — every package's actual coverage ≥ its floor (by construction; the floor IS `floor(actual/5)*5`)
- [ ] Post-merge: deliberately delete a test on a follow-up branch, confirm CI fails with a Vitest threshold message, revert