### PR TITLE
AHP HR8c: IHostTransport abstraction + migrate consumers

### DIFF
--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -294,9 +294,9 @@ export class GrpcHostTransport implements IHostTransport {
     createSession(params: CreateSessionParams): CreateSessionResult;
     dispatchInput(sessionUri: string, text: string): Promise<void>;
     dispose(sessionUri: string, reason?: string): Promise<void>;
+    drainBuffered(sessionUri: string): AsyncIterable<ServerActionEnvelope>;
     listSessions(): Promise<HostSessionInfo[]>;
     reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
-    subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
 }
 
 // @public
@@ -312,9 +312,9 @@ export interface IHostTransport {
     createSession(params: CreateSessionParams): CreateSessionResult;
     dispatchInput(sessionUri: string, text: string): Promise<void>;
     dispose(sessionUri: string, reason?: string): Promise<void>;
+    drainBuffered(sessionUri: string): AsyncIterable<ServerActionEnvelope>;
     listSessions(): Promise<HostSessionInfo[]>;
     reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
-    subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
 }
 
 // @public
@@ -401,6 +401,7 @@ export interface PowerLineConnection {
     environmentId: string;
     // (undocumented)
     port: number;
+    transport: IHostTransport;
 }
 
 // @public

--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -47,6 +47,17 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
 };
 
 // @public
+export interface AgentEventFields {
+    content?: string;
+    diagnostic?: boolean;
+    raw?: string;
+    timestamp?: string;
+    toolCallId?: string;
+    turnId?: string;
+    type: string;
+}
+
+// @public
 const AgentEventSchema: GenMessage<AgentEvent>;
 
 // @public
@@ -486,7 +497,6 @@ const ResumeRequestSchema: GenMessage<ResumeRequest>;
 // @public
 export interface ServerActionEnvelope {
     actions: StateAction[];
-    // Warning: (ae-forgotten-export) The symbol "AgentEventFields" needs to be exported by the entry point index.d.ts
     event: AgentEventFields;
 }
 

--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -11,6 +11,7 @@ import type { GenMessage } from '@bufbuild/protobuf/codegenv2';
 import type { GenService } from '@bufbuild/protobuf/codegenv2';
 import type { Message } from '@bufbuild/protobuf';
 import { SpawnOptions } from 'node:child_process';
+import type { StateAction } from '@grackle-ai/ahp';
 
 // @public
 export interface AdapterDependencies {
@@ -49,6 +50,12 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
 const AgentEventSchema: GenMessage<AgentEvent>;
 
 // @public
+export interface AuthenticateParams {
+    provider: string;
+    tokens: AuthenticateTokenItem[];
+}
+
+// @public
 type AuthenticateRequest = Message<"grackle.powerline.AuthenticateRequest"> & {
     provider: string;
     tokens: TokenItem[];
@@ -56,6 +63,15 @@ type AuthenticateRequest = Message<"grackle.powerline.AuthenticateRequest"> & {
 
 // @public
 const AuthenticateRequestSchema: GenMessage<AuthenticateRequest>;
+
+// @public
+export interface AuthenticateTokenItem {
+    envVar?: string;
+    filePath?: string;
+    name: string;
+    type: string;
+    value: string;
+}
 
 // @public
 export interface BaseEnvironmentConfig {
@@ -93,6 +109,32 @@ export function connectThroughTunnel(environmentId: string, localPort: number, p
 
 // @public
 export function createPowerLineClient(baseUrl: string, powerlineToken: string, traceId?: string): PowerLineClient;
+
+// @public
+export interface CreateSessionParams {
+    branch: string;
+    maxTurns: number;
+    mcpServersJson: string;
+    mcpToken: string;
+    mcpUrl: string;
+    model: string;
+    pipe?: string;
+    prompt: string;
+    runtime: string;
+    scriptContent?: string;
+    sessionId: string;
+    systemContext: string;
+    taskId: string;
+    useWorktrees?: boolean;
+    workingDirectory: string;
+    workspaceId?: string;
+}
+
+// @public
+export interface CreateSessionResult {
+    sessionUri: string;
+    stream: AsyncIterable<ServerActionEnvelope>;
+}
 
 // @public
 export const defaultLogger: AdapterLogger;
@@ -235,6 +277,36 @@ const GracklePowerLine: GenService<{
 }>;
 
 // @public
+export class GrpcHostTransport implements IHostTransport {
+    constructor(client: PowerLineClient);
+    authenticate(params: AuthenticateParams): Promise<void>;
+    createSession(params: CreateSessionParams): CreateSessionResult;
+    dispatchInput(sessionUri: string, text: string): Promise<void>;
+    dispose(sessionUri: string, reason?: string): Promise<void>;
+    listSessions(): Promise<HostSessionInfo[]>;
+    reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
+    subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
+}
+
+// @public
+export interface HostSessionInfo {
+    runtime: string;
+    sessionId: string;
+    status: string;
+}
+
+// @public
+export interface IHostTransport {
+    authenticate(params: AuthenticateParams): Promise<void>;
+    createSession(params: CreateSessionParams): CreateSessionResult;
+    dispatchInput(sessionUri: string, text: string): Promise<void>;
+    dispose(sessionUri: string, reason?: string): Promise<void>;
+    listSessions(): Promise<HostSessionInfo[]>;
+    reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
+    subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
+}
+
+// @public
 type InputMessage = Message<"grackle.powerline.InputMessage"> & {
     sessionId: string;
     text: string;
@@ -358,6 +430,13 @@ export interface ProvisionEvent {
 }
 
 // @public
+export interface ReanimateParams {
+    runtime: string;
+    runtimeSessionId: string;
+    sessionId: string;
+}
+
+// @public
 export function reconnectOrProvision(environmentId: string, adapter: EnvironmentAdapter, config: Record<string, unknown>, powerlineToken: string, bootstrapped: boolean, force?: boolean, logger?: AdapterLogger): AsyncGenerator<ProvisionEvent>;
 
 // @public
@@ -403,6 +482,13 @@ type ResumeRequest = Message<"grackle.powerline.ResumeRequest"> & {
 
 // @public
 const ResumeRequestSchema: GenMessage<ResumeRequest>;
+
+// @public
+export interface ServerActionEnvelope {
+    actions: StateAction[];
+    // Warning: (ae-forgotten-export) The symbol "AgentEventFields" needs to be exported by the entry point index.d.ts
+    event: AgentEventFields;
+}
 
 // @public
 type SessionId = Message<"grackle.powerline.SessionId"> & {

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -9,6 +9,7 @@ import type { GenFile } from '@bufbuild/protobuf/codegenv2';
 import type { GenMessage } from '@bufbuild/protobuf/codegenv2';
 import type { GenService } from '@bufbuild/protobuf/codegenv2';
 import type { Message } from '@bufbuild/protobuf';
+import { StateAction } from '@grackle-ai/ahp';
 import { z } from 'zod';
 
 // @public
@@ -58,6 +59,17 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
     diagnostic: boolean;
     turnId: string;
 };
+
+// @public
+export interface AgentEventFields {
+    content?: string;
+    diagnostic?: boolean;
+    raw?: string;
+    timestamp?: string;
+    toolCallId?: string;
+    turnId?: string;
+    type: string;
+}
 
 // @public
 const AgentEventSchema: GenMessage<AgentEvent>;
@@ -149,8 +161,8 @@ export const BUILTIN_COMPONENT_SCHEMAS: {
         variant: z.ZodOptional<z.ZodEnum<{
             success: "success";
             error: "error";
-            warning: "warning";
             info: "info";
+            warning: "warning";
         }>>;
         dismissible: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$strip>;
@@ -259,8 +271,8 @@ export const calloutPropsSchema: z.ZodObject<{
     variant: z.ZodOptional<z.ZodEnum<{
         success: "success";
         error: "error";
-        warning: "warning";
         info: "info";
+        warning: "warning";
     }>>;
     dismissible: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
@@ -272,8 +284,8 @@ export type CalloutVariant = z.infer<typeof calloutVariantSchema>;
 export const calloutVariantSchema: z.ZodEnum<{
     success: "success";
     error: "error";
-    warning: "warning";
     info: "info";
+    warning: "warning";
 }>;
 
 // @public
@@ -545,6 +557,9 @@ export const DEFAULT_WEB_PORT: number;
 
 // @public
 export const DEFAULT_WORKSPACE_ID: string;
+
+// @public
+export type Disposition = "mapped" | "carried" | "dropped";
 
 // @public
 type DockerContainerInfo = Message<"grackle.DockerContainerInfo"> & {
@@ -1981,6 +1996,35 @@ export const LOGS_DIR: string;
 // @public
 export interface LogSink<T> {
     append(channelId: string, entry: Sequenced<T>): void;
+}
+
+// @public
+export function mapAgentEvent(event: AgentEventFields, index: number, context: MapperContext): MapResult;
+
+// @public
+export interface MapperContext {
+    eventIndex: number;
+    metaAccumulator: {
+        costMillicents?: number;
+        runtimeSessionId?: string;
+    };
+    openToolCalls: string[];
+    partCounter: number;
+    turnId?: string;
+}
+
+// @public
+export interface MappingNote {
+    detail: string;
+    disposition: Disposition;
+    index: number;
+    type: string;
+}
+
+// @public
+export interface MapResult {
+    actions: StateAction[];
+    note?: MappingNote;
 }
 
 // @public

--- a/common/changes/@grackle-ai/cli/nick-pape-1335-hr8c-host-transport_2026-05-28-05-59.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1335-hr8c-host-transport_2026-05-28-05-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "AHP HR8c: introduce IHostTransport abstraction in @grackle-ai/adapter-sdk (GrpcHostTransport wraps the existing PowerLine client). Relocate the AgentEvent→AHP mapper to @grackle-ai/common. Migrate the consumer call-sites (spawn/resume/drain/sendInput/authenticate) in core and plugin-core to go through the transport. Refactor only — gRPC remains the wire. Closes #1335.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@connectrpc/connect-node':
         specifier: ^2.0.0
         version: 2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))
+      '@grackle-ai/ahp':
+        specifier: workspace:*
+        version: link:../ahp
       '@grackle-ai/common':
         specifier: workspace:*
         version: link:../common
@@ -300,6 +303,9 @@ importers:
       '@connectrpc/connect':
         specifier: ^2.0.0
         version: 2.1.1(@bufbuild/protobuf@2.11.0)
+      '@grackle-ai/ahp':
+        specifier: workspace:*
+        version: link:../ahp
       fuse.js:
         specifier: ^7.0.0
         version: 7.1.0

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -20,6 +20,7 @@ import {
   exec as defaultExec,
   sleep as defaultSleep,
   defaultLogger,
+  GrpcHostTransport,
   type RemoteExecutor,
 } from "@grackle-ai/adapter-sdk";
 import { existsSync } from "node:fs";
@@ -726,7 +727,7 @@ export class DockerAdapter implements EnvironmentAdapter {
     for (let attempt = 0; attempt < CONNECT_MAX_RETRIES; attempt++) {
       try {
         await client.ping({});
-        return { client, environmentId, port };
+        return { client, environmentId, port, transport: new GrpcHostTransport(client) };
       } catch (err) {
         lastErr = err;
         await this.sleepFn(CONNECT_RETRY_DELAY_MS);

--- a/packages/adapter-local/src/local.ts
+++ b/packages/adapter-local/src/local.ts
@@ -6,7 +6,11 @@ import type {
   ProvisionEvent,
   AdapterDependencies,
 } from "@grackle-ai/adapter-sdk";
-import { createPowerLineClient, sleep as defaultSleep } from "@grackle-ai/adapter-sdk";
+import {
+  createPowerLineClient,
+  GrpcHostTransport,
+  sleep as defaultSleep,
+} from "@grackle-ai/adapter-sdk";
 
 const POWERLINE_RETRY_DELAY_MS: number = 1_000;
 const POWERLINE_MAX_RETRIES: number = 5;
@@ -78,7 +82,7 @@ export class LocalAdapter implements EnvironmentAdapter {
     const client = createPowerLineClient(`http://${host}:${port}`, powerlineToken);
     await client.ping({});
 
-    return { client, environmentId, port };
+    return { client, environmentId, port, transport: new GrpcHostTransport(client) };
   }
 
   public async disconnect(): Promise<void> {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -38,6 +38,7 @@
     "@bufbuild/protobuf": "^2.5.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
+    "@grackle-ai/ahp": "workspace:*",
     "@grackle-ai/common": "workspace:*"
   },
   "devDependencies": {

--- a/packages/adapter-sdk/src/adapter.ts
+++ b/packages/adapter-sdk/src/adapter.ts
@@ -3,6 +3,7 @@ import type { powerline } from "@grackle-ai/common";
 import type { AdapterLogger } from "./logger.js";
 import { defaultLogger } from "./logger.js";
 import { FatalAdapterError } from "./fatal-error.js";
+import type { IHostTransport } from "./host-transport.js";
 
 /** Type-safe ConnectRPC client for the PowerLine gRPC service. */
 export type PowerLineClient = Client<typeof powerline.GracklePowerLine>;
@@ -12,6 +13,13 @@ export interface PowerLineConnection {
   client: PowerLineClient;
   environmentId: string;
   port: number;
+  /**
+   * Transport-agnostic host interface (AHP HR8c). One instance per connection,
+   * constructed when the connection is established. Consumers use this
+   * instead of touching `client` directly so the HR8d wire-flip is a
+   * swap of one `IHostTransport` impl for another.
+   */
+  transport: IHostTransport;
 }
 
 /** Progress event emitted during environment provisioning. */

--- a/packages/adapter-sdk/src/connect.ts
+++ b/packages/adapter-sdk/src/connect.ts
@@ -3,6 +3,7 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { powerline } from "@grackle-ai/common";
 import { createConnection } from "node:net";
 import type { PowerLineClient, PowerLineConnection } from "./adapter.js";
+import { GrpcHostTransport } from "./grpc-host-transport.js";
 import { closeTunnel } from "./tunnel-registry.js";
 import { sleep } from "./utils.js";
 import type { AdapterLogger } from "./logger.js";
@@ -76,7 +77,12 @@ export async function connectThroughTunnel(
   for (let attempt = 0; attempt < CONNECT_MAX_RETRIES; attempt++) {
     try {
       await client.ping({});
-      return { client, environmentId, port: localPort };
+      return {
+        client,
+        environmentId,
+        port: localPort,
+        transport: new GrpcHostTransport(client),
+      };
     } catch (err) {
       lastError = err;
       await sleep(CONNECT_RETRY_DELAY_MS);

--- a/packages/adapter-sdk/src/grpc-host-transport.test.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Contract tests for `GrpcHostTransport` (AHP HR8c).
+ *
+ * Verifies each method translates the typed AHP-shaped input into the right
+ * gRPC RPC call against the wrapped `PowerLineClient` and (for streaming
+ * methods) folds the response through the mapper to produce envelopes.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { powerline } from "@grackle-ai/common";
+import { ActionType } from "@grackle-ai/ahp";
+import { GrpcHostTransport } from "./grpc-host-transport.js";
+import type { PowerLineClient } from "./adapter.js";
+
+/** Build a mock PowerLineClient with vi.fn() stubs for every RPC the transport touches. */
+function makeMockClient(): {
+  client: PowerLineClient;
+  spawn: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  drainBufferedEvents: ReturnType<typeof vi.fn>;
+  sendInput: ReturnType<typeof vi.fn>;
+  authenticate: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  listSessions: ReturnType<typeof vi.fn>;
+} {
+  const spawn = vi.fn();
+  const resume = vi.fn();
+  const drainBufferedEvents = vi.fn();
+  const sendInput = vi.fn().mockResolvedValue(create(powerline.EmptySchema, {}));
+  const authenticate = vi.fn().mockResolvedValue(create(powerline.EmptySchema, {}));
+  const kill = vi.fn().mockResolvedValue(create(powerline.EmptySchema, {}));
+  const listSessions = vi.fn();
+  const client = {
+    spawn,
+    resume,
+    drainBufferedEvents,
+    sendInput,
+    authenticate,
+    kill,
+    listSessions,
+  } as unknown as PowerLineClient;
+  return {
+    client,
+    spawn,
+    resume,
+    drainBufferedEvents,
+    sendInput,
+    authenticate,
+    kill,
+    listSessions,
+  };
+}
+
+/** Build an async iterable that yields a fixed list of AgentEvent messages. */
+async function* eventStream(events: powerline.AgentEvent[]): AsyncIterable<powerline.AgentEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+describe("GrpcHostTransport.createSession", () => {
+  it("calls client.spawn with a populated SpawnRequest and exposes the stream", async () => {
+    const { client, spawn } = makeMockClient();
+    spawn.mockReturnValue(eventStream([]));
+    const transport = new GrpcHostTransport(client);
+
+    const { sessionUri, stream } = transport.createSession({
+      sessionId: "sess-1",
+      runtime: "claude-code",
+      prompt: "do the thing",
+      model: "sonnet",
+      maxTurns: 5,
+      branch: "main",
+      workingDirectory: "/workspace",
+      systemContext: "ctx",
+      workspaceId: "ws-1",
+      taskId: "task-1",
+      mcpServersJson: "[]",
+      mcpUrl: "http://127.0.0.1:7435/mcp",
+      mcpToken: "tok",
+      useWorktrees: true,
+    });
+
+    expect(sessionUri).toBe("sess-1");
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const spawnReq = spawn.mock.calls[0][0];
+    expect(spawnReq.sessionId).toBe("sess-1");
+    expect(spawnReq.runtime).toBe("claude-code");
+    expect(spawnReq.taskId).toBe("task-1");
+    expect(spawnReq.useWorktrees).toBe(true);
+
+    // Stream is iterable (empty here) — drains without error.
+    const collected: unknown[] = [];
+    for await (const envelope of stream) {
+      collected.push(envelope);
+    }
+    expect(collected).toEqual([]);
+  });
+
+  it("folds each AgentEvent into an envelope with mapped AHP actions", async () => {
+    const { client, spawn } = makeMockClient();
+    const turnStarted = create(powerline.AgentEventSchema, {
+      sessionId: "s1",
+      type: "turn_started",
+      timestamp: "2026-01-01T00:00:00Z",
+      content: JSON.stringify({ user_message: "hi" }),
+      turnId: "t1",
+    });
+    spawn.mockReturnValue(eventStream([turnStarted]));
+    const transport = new GrpcHostTransport(client);
+
+    const { stream } = transport.createSession({
+      sessionId: "s1",
+      runtime: "claude-code",
+      prompt: "",
+      model: "",
+      maxTurns: 0,
+      branch: "",
+      workingDirectory: "",
+      systemContext: "",
+      taskId: "",
+      mcpServersJson: "",
+      mcpUrl: "",
+      mcpToken: "",
+    });
+
+    const envelopes: Array<{ event: { type: string }; actions: Array<{ type: string }> }> = [];
+    for await (const envelope of stream) {
+      envelopes.push(envelope);
+    }
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].event.type).toBe("turn_started");
+    expect(envelopes[0].actions.length).toBe(1);
+    expect(envelopes[0].actions[0].type).toBe(ActionType.SessionTurnStarted);
+  });
+});
+
+describe("GrpcHostTransport.reanimate", () => {
+  it("calls client.resume with a populated ResumeRequest and exposes the stream", async () => {
+    const { client, resume } = makeMockClient();
+    resume.mockReturnValue(eventStream([]));
+    const transport = new GrpcHostTransport(client);
+
+    const stream = transport.reanimate({
+      sessionId: "sess-2",
+      runtimeSessionId: "runtime-abc",
+      runtime: "claude-code",
+    });
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    const resumeReq = resume.mock.calls[0][0];
+    expect(resumeReq.sessionId).toBe("sess-2");
+    expect(resumeReq.runtimeSessionId).toBe("runtime-abc");
+    expect(resumeReq.runtime).toBe("claude-code");
+
+    const collected: unknown[] = [];
+    for await (const envelope of stream) {
+      collected.push(envelope);
+    }
+    expect(collected).toEqual([]);
+  });
+});
+
+describe("GrpcHostTransport.subscribe", () => {
+  it("calls client.drainBufferedEvents and folds events into envelopes", async () => {
+    const { client, drainBufferedEvents } = makeMockClient();
+    const textEvent = create(powerline.AgentEventSchema, {
+      sessionId: "sess-3",
+      type: "text",
+      content: "hello",
+      turnId: "t1",
+    });
+    drainBufferedEvents.mockReturnValue(eventStream([textEvent]));
+    const transport = new GrpcHostTransport(client);
+
+    const stream = transport.subscribe("sess-3", "01HX");
+    const envelopes: unknown[] = [];
+    for await (const envelope of stream) {
+      envelopes.push(envelope);
+    }
+
+    expect(drainBufferedEvents).toHaveBeenCalledTimes(1);
+    const drainReq = drainBufferedEvents.mock.calls[0][0];
+    expect(drainReq.sessionId).toBe("sess-3");
+    expect(envelopes.length).toBe(1);
+  });
+});
+
+describe("GrpcHostTransport.dispatchInput", () => {
+  it("calls client.sendInput with the message text", async () => {
+    const { client, sendInput } = makeMockClient();
+    const transport = new GrpcHostTransport(client);
+
+    await transport.dispatchInput("sess-4", "hello from test");
+
+    expect(sendInput).toHaveBeenCalledTimes(1);
+    const inputReq = sendInput.mock.calls[0][0];
+    expect(inputReq.sessionId).toBe("sess-4");
+    expect(inputReq.text).toBe("hello from test");
+  });
+});
+
+describe("GrpcHostTransport.authenticate", () => {
+  it("calls client.authenticate with the provider and tokens", async () => {
+    const { client, authenticate } = makeMockClient();
+    const transport = new GrpcHostTransport(client);
+
+    await transport.authenticate({
+      provider: "claude-code",
+      tokens: [
+        {
+          name: "ANTHROPIC_API_KEY",
+          type: "env_var",
+          envVar: "ANTHROPIC_API_KEY",
+          value: "sk-...",
+        },
+        { name: "claude-cred", type: "file", filePath: "~/.claude/.credentials.json", value: "{}" },
+      ],
+    });
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    const authReq = authenticate.mock.calls[0][0];
+    expect(authReq.provider).toBe("claude-code");
+    expect(authReq.tokens.length).toBe(2);
+    expect(authReq.tokens[0].envVar).toBe("ANTHROPIC_API_KEY");
+    expect(authReq.tokens[1].filePath).toBe("~/.claude/.credentials.json");
+  });
+});
+
+describe("GrpcHostTransport.dispose", () => {
+  it("calls client.kill with the session id and reason", async () => {
+    const { client, kill } = makeMockClient();
+    const transport = new GrpcHostTransport(client);
+
+    await transport.dispose("sess-5", "completed");
+
+    expect(kill).toHaveBeenCalledTimes(1);
+    const killReq = kill.mock.calls[0][0];
+    expect(killReq.id).toBe("sess-5");
+    expect(killReq.reason).toBe("completed");
+  });
+});
+
+describe("GrpcHostTransport.listSessions", () => {
+  it("calls client.listSessions and maps the result", async () => {
+    const { client, listSessions } = makeMockClient();
+    listSessions.mockResolvedValue(
+      create(powerline.SessionListSchema, {
+        sessions: [
+          create(powerline.SessionInfoSchema, {
+            sessionId: "s1",
+            runtime: "claude-code",
+            status: "running",
+          }),
+        ],
+      }),
+    );
+    const transport = new GrpcHostTransport(client);
+
+    const result = await transport.listSessions();
+
+    expect(listSessions).toHaveBeenCalledTimes(1);
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({
+      sessionId: "s1",
+      runtime: "claude-code",
+      status: "running",
+    });
+  });
+});

--- a/packages/adapter-sdk/src/grpc-host-transport.test.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.test.ts
@@ -161,7 +161,7 @@ describe("GrpcHostTransport.reanimate", () => {
   });
 });
 
-describe("GrpcHostTransport.subscribe", () => {
+describe("GrpcHostTransport.drainBuffered", () => {
   it("calls client.drainBufferedEvents and folds events into envelopes", async () => {
     const { client, drainBufferedEvents } = makeMockClient();
     const textEvent = create(powerline.AgentEventSchema, {
@@ -173,7 +173,7 @@ describe("GrpcHostTransport.subscribe", () => {
     drainBufferedEvents.mockReturnValue(eventStream([textEvent]));
     const transport = new GrpcHostTransport(client);
 
-    const stream = transport.subscribe("sess-3", "01HX");
+    const stream = transport.drainBuffered("sess-3");
     const envelopes: unknown[] = [];
     for await (const envelope of stream) {
       envelopes.push(envelope);

--- a/packages/adapter-sdk/src/grpc-host-transport.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.ts
@@ -1,0 +1,212 @@
+/**
+ * gRPC-backed implementation of {@link IHostTransport} (AHP HR8c).
+ *
+ * Wraps a {@link PowerLineClient} (ConnectRPC client) and folds each
+ * incoming `AgentEvent` through the {@link mapAgentEvent} mapper to produce
+ * AHP `StateAction[]`. Per-session {@link MapperContext} state is kept inside
+ * this instance so consumers don't need to thread it through their code.
+ *
+ * @module grpc-host-transport
+ */
+
+import { create } from "@bufbuild/protobuf";
+import { powerline, mapAgentEvent, type MapperContext } from "@grackle-ai/common";
+import type { PowerLineClient } from "./adapter.js";
+import type {
+  AuthenticateParams,
+  CreateSessionParams,
+  CreateSessionResult,
+  HostSessionInfo,
+  IHostTransport,
+  ReanimateParams,
+  ServerActionEnvelope,
+} from "./host-transport.js";
+
+/**
+ * gRPC-backed {@link IHostTransport} for a single environment.
+ *
+ * Lifecycle: one instance per `PowerLineConnection`. The mapper context map
+ * is keyed by session URI so multiple sessions on the same environment each
+ * get their own turn/tool tracking.
+ */
+export class GrpcHostTransport implements IHostTransport {
+  /** Underlying ConnectRPC client for the PowerLine gRPC service. */
+  private readonly client: PowerLineClient;
+
+  /**
+   * Per-session mapper context. Created lazily on first event per session;
+   * cleaned up when the session's stream completes or errors.
+   */
+  private readonly mapperContexts: Map<string, MapperContext> = new Map();
+
+  /**
+   * Create a new gRPC-backed host transport.
+   *
+   * @param client - The ConnectRPC client to wrap. Typically obtained from
+   *   {@link createPowerLineClient} or a `PowerLineConnection`.
+   */
+  public constructor(client: PowerLineClient) {
+    this.client = client;
+  }
+
+  /**
+   * Create a new session via PowerLine's `spawn` RPC.
+   *
+   * Returns the session URI plus a live stream of {@link ServerActionEnvelope}s.
+   * The stream is mapped from the underlying `AgentEvent` stream.
+   */
+  public createSession(params: CreateSessionParams): CreateSessionResult {
+    const spawnReq = create(powerline.SpawnRequestSchema, {
+      sessionId: params.sessionId,
+      runtime: params.runtime,
+      prompt: params.prompt,
+      model: params.model,
+      maxTurns: params.maxTurns,
+      branch: params.branch,
+      workingDirectory: params.workingDirectory,
+      systemContext: params.systemContext,
+      workspaceId: params.workspaceId,
+      taskId: params.taskId,
+      mcpServersJson: params.mcpServersJson,
+      mcpUrl: params.mcpUrl,
+      mcpToken: params.mcpToken,
+      useWorktrees: params.useWorktrees,
+      pipe: params.pipe ?? "",
+      scriptContent: params.scriptContent ?? "",
+    });
+
+    const grpcStream = this.client.spawn(spawnReq);
+    return {
+      sessionUri: params.sessionId,
+      stream: this.foldStream(params.sessionId, grpcStream),
+    };
+  }
+
+  /**
+   * Reanimate a suspended session via PowerLine's `resume` RPC.
+   *
+   * Returns a live stream of envelopes for the reanimated session. Note that
+   * `resume` alone does NOT replay buffered events — use
+   * {@link IHostTransport.subscribe} with `fromServerSeq` for that.
+   */
+  public reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope> {
+    const resumeReq = create(powerline.ResumeRequestSchema, {
+      sessionId: params.sessionId,
+      runtimeSessionId: params.runtimeSessionId,
+      runtime: params.runtime,
+    });
+    const grpcStream = this.client.resume(resumeReq);
+    return this.foldStream(params.sessionId, grpcStream);
+  }
+
+  /**
+   * Subscribe to a session's events from a given sequence.
+   *
+   * When `fromServerSeq` is provided, composes `drainBufferedEvents` (replay
+   * of buffered events) with the live event stream. When omitted, returns
+   * only the live stream.
+   *
+   * Note: the gRPC transport here has no native "subscribe" RPC — `subscribe`
+   * without `fromServerSeq` is currently not callable through this transport
+   * (consumers use `createSession` or `reanimate` for the initial stream).
+   * The drain-only flow is provided for session-recovery, which calls drain
+   * separately and then `reanimate` for the live stream.
+   */
+  public async *subscribe(
+    sessionUri: string,
+    fromServerSeq?: string,
+  ): AsyncIterable<ServerActionEnvelope> {
+    // fromServerSeq is informational in HR8c — gRPC's drainBufferedEvents
+    // replays all parked events regardless. HR8d's wire will respect the seq.
+    void fromServerSeq;
+
+    const drainReq = create(powerline.DrainRequestSchema, {
+      sessionId: sessionUri,
+    });
+    const drainStream = this.client.drainBufferedEvents(drainReq);
+    yield* this.foldStream(sessionUri, drainStream);
+  }
+
+  /** Send input text to a session via PowerLine's `sendInput` RPC. */
+  public async dispatchInput(sessionUri: string, text: string): Promise<void> {
+    await this.client.sendInput(
+      create(powerline.InputMessageSchema, { sessionId: sessionUri, text }),
+    );
+  }
+
+  /** Authenticate credentials via PowerLine's `authenticate` RPC. */
+  public async authenticate(params: AuthenticateParams): Promise<void> {
+    await this.client.authenticate(
+      create(powerline.AuthenticateRequestSchema, {
+        provider: params.provider,
+        tokens: params.tokens.map((t) =>
+          create(powerline.TokenItemSchema, {
+            name: t.name,
+            type: t.type,
+            envVar: t.envVar ?? "",
+            filePath: t.filePath ?? "",
+            value: t.value,
+          }),
+        ),
+      }),
+    );
+  }
+
+  /** Dispose a session via PowerLine's `kill` RPC. */
+  public async dispose(sessionUri: string, reason?: string): Promise<void> {
+    await this.client.kill(
+      create(powerline.KillRequestSchema, { id: sessionUri, reason: reason ?? "" }),
+    );
+    this.mapperContexts.delete(sessionUri);
+  }
+
+  /** List active sessions via PowerLine's `listSessions` RPC. */
+  public async listSessions(): Promise<HostSessionInfo[]> {
+    const list = await this.client.listSessions({});
+    return list.sessions.map((s) => ({
+      sessionId: s.sessionId,
+      runtime: s.runtime,
+      status: s.status,
+    }));
+  }
+
+  /**
+   * Fold a raw `AgentEvent` stream into `ServerActionEnvelope`s by running
+   * each event through the mapper. The per-session `MapperContext` is
+   * created/retrieved lazily and removed when the stream completes.
+   */
+  private async *foldStream(
+    sessionUri: string,
+    grpcStream: AsyncIterable<powerline.AgentEvent>,
+  ): AsyncIterable<ServerActionEnvelope> {
+    const context = this.getOrCreateContext(sessionUri);
+    try {
+      for await (const event of grpcStream) {
+        const idx = context.eventIndex++;
+        const { actions } = mapAgentEvent(event, idx, context);
+        yield { event, actions };
+      }
+    } finally {
+      // Context lifetime tracks the stream; recover paths create a fresh one
+      // on the next subscribe/reanimate. Clearing here prevents memory growth
+      // for sessions that close cleanly.
+      this.mapperContexts.delete(sessionUri);
+    }
+  }
+
+  /** Get an existing or create a fresh `MapperContext` for a session. */
+  private getOrCreateContext(sessionUri: string): MapperContext {
+    let ctx = this.mapperContexts.get(sessionUri);
+    if (!ctx) {
+      ctx = {
+        turnId: undefined,
+        openToolCalls: [],
+        partCounter: 0,
+        eventIndex: 0,
+        metaAccumulator: {},
+      };
+      this.mapperContexts.set(sessionUri, ctx);
+    }
+    return ctx;
+  }
+}

--- a/packages/adapter-sdk/src/grpc-host-transport.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.ts
@@ -177,8 +177,8 @@ export class GrpcHostTransport implements IHostTransport {
       }
     } finally {
       // Context lifetime tracks the stream; recover paths create a fresh one
-      // on the next subscribe/reanimate. Clearing here prevents memory growth
-      // for sessions that close cleanly.
+      // on the next drainBuffered/reanimate. Clearing here prevents memory
+      // growth for sessions that close cleanly.
       this.mapperContexts.delete(sessionUri);
     }
   }

--- a/packages/adapter-sdk/src/grpc-host-transport.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.ts
@@ -100,24 +100,21 @@ export class GrpcHostTransport implements IHostTransport {
   }
 
   /**
-   * Subscribe to a session's events from a given sequence.
+   * Drain previously-parked buffered events for a session (HR8c scope).
    *
-   * When `fromServerSeq` is provided, composes `drainBufferedEvents` (replay
-   * of buffered events) with the live event stream. When omitted, returns
-   * only the live stream.
+   * In HR8c this is the gRPC `drainBufferedEvents` RPC, full stop: the
+   * returned stream yields the buffered envelopes and then terminates. It
+   * does **not** continue into the live event stream — callers compose
+   * `subscribe` + `reanimate` to do recovery (see `session-recovery.ts`).
    *
-   * Note: the gRPC transport here has no native "subscribe" RPC — `subscribe`
-   * without `fromServerSeq` is currently not callable through this transport
-   * (consumers use `createSession` or `reanimate` for the initial stream).
-   * The drain-only flow is provided for session-recovery, which calls drain
-   * separately and then `reanimate` for the live stream.
+   * `fromServerSeq` is accepted for forward compatibility (HR8d will use it
+   * as a true "subscribe from seq N" cursor) but is currently ignored —
+   * `drainBufferedEvents` replays all parked events regardless.
    */
   public async *subscribe(
     sessionUri: string,
     fromServerSeq?: string,
   ): AsyncIterable<ServerActionEnvelope> {
-    // fromServerSeq is informational in HR8c — gRPC's drainBufferedEvents
-    // replays all parked events regardless. HR8d's wire will respect the seq.
     void fromServerSeq;
 
     const drainReq = create(powerline.DrainRequestSchema, {

--- a/packages/adapter-sdk/src/grpc-host-transport.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.ts
@@ -86,8 +86,9 @@ export class GrpcHostTransport implements IHostTransport {
    * Reanimate a suspended session via PowerLine's `resume` RPC.
    *
    * Returns a live stream of envelopes for the reanimated session. Note that
-   * `resume` alone does NOT replay buffered events — use
-   * {@link IHostTransport.subscribe} with `fromServerSeq` for that.
+   * `resume` alone does NOT replay buffered events — call
+   * {@link IHostTransport.drainBuffered} first to replay the parked queue,
+   * then this method to start the live stream.
    */
   public reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope> {
     const resumeReq = create(powerline.ResumeRequestSchema, {

--- a/packages/adapter-sdk/src/grpc-host-transport.ts
+++ b/packages/adapter-sdk/src/grpc-host-transport.ts
@@ -100,23 +100,14 @@ export class GrpcHostTransport implements IHostTransport {
   }
 
   /**
-   * Drain previously-parked buffered events for a session (HR8c scope).
+   * Drain previously-parked buffered events for a session.
    *
-   * In HR8c this is the gRPC `drainBufferedEvents` RPC, full stop: the
-   * returned stream yields the buffered envelopes and then terminates. It
-   * does **not** continue into the live event stream — callers compose
-   * `subscribe` + `reanimate` to do recovery (see `session-recovery.ts`).
-   *
-   * `fromServerSeq` is accepted for forward compatibility (HR8d will use it
-   * as a true "subscribe from seq N" cursor) but is currently ignored —
-   * `drainBufferedEvents` replays all parked events regardless.
+   * Maps to the gRPC `drainBufferedEvents` RPC. The returned stream yields
+   * the buffered envelopes and then terminates — it does NOT continue into
+   * the live event stream. Callers compose `drainBuffered` + `reanimate`
+   * to do recovery.
    */
-  public async *subscribe(
-    sessionUri: string,
-    fromServerSeq?: string,
-  ): AsyncIterable<ServerActionEnvelope> {
-    void fromServerSeq;
-
+  public async *drainBuffered(sessionUri: string): AsyncIterable<ServerActionEnvelope> {
     const drainReq = create(powerline.DrainRequestSchema, {
       sessionId: sessionUri,
     });

--- a/packages/adapter-sdk/src/host-transport.ts
+++ b/packages/adapter-sdk/src/host-transport.ts
@@ -147,25 +147,26 @@ export interface IHostTransport {
    * Reanimate a suspended session, returning its live event stream.
    *
    * Maps directly to `resume`. For recovery flows that also need the
-   * previously-parked buffered events, call `subscribe` first to drain
-   * them, then call `reanimate` to start the live stream.
+   * previously-parked buffered events, call `drainBuffered` first, then
+   * call `reanimate` to start the live stream.
    */
   reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
 
   /**
-   * Drain previously-parked buffered events for a session (HR8c scope).
+   * Drain previously-parked buffered events for a session.
    *
-   * In HR8c the gRPC transport implements this against `drainBufferedEvents`:
-   * the returned stream contains the buffered events and then terminates. It
-   * does **not** continue into the live event stream — callers compose
-   * `subscribe` + `reanimate` to do recovery (see `session-recovery.ts`).
+   * Returns a finite stream of envelopes for events the host has been
+   * holding since the consumer disconnected; the stream terminates once
+   * the parked queue is exhausted. It does NOT continue into the live
+   * event stream — callers compose `drainBuffered` + `reanimate` to do
+   * recovery (see `session-recovery.ts`).
    *
-   * `fromServerSeq` is accepted for forward compatibility (HR8d will honor
-   * it as a real "subscribe from seq N" semantic) but is currently ignored
-   * by the gRPC transport — `drainBufferedEvents` replays all parked events
-   * regardless.
+   * Note: HR8d's AHP wire will add a true seq-cursor `subscribe` method
+   * for "resume from server seq N" semantics. That's intentionally a
+   * separate method on this interface; this one stays narrowly scoped to
+   * the parked-queue drain that gRPC supports today.
    */
-  subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
+  drainBuffered(sessionUri: string): AsyncIterable<ServerActionEnvelope>;
 
   /**
    * Send input text to a session.

--- a/packages/adapter-sdk/src/host-transport.ts
+++ b/packages/adapter-sdk/src/host-transport.ts
@@ -146,18 +146,24 @@ export interface IHostTransport {
   /**
    * Reanimate a suspended session, returning its live event stream.
    *
-   * Maps directly to `resume`. For recovery flows that also need to drain
-   * buffered events, use `subscribe` with `fromServerSeq`.
+   * Maps directly to `resume`. For recovery flows that also need the
+   * previously-parked buffered events, call `subscribe` first to drain
+   * them, then call `reanimate` to start the live stream.
    */
   reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
 
   /**
-   * Subscribe to a session's event stream, optionally including buffered events.
+   * Drain previously-parked buffered events for a session (HR8c scope).
    *
-   * When `fromServerSeq` is provided, the transport composes
-   * `drainBufferedEvents` (buffered, replayed) with `resume` (live events
-   * going forward) into a single ordered stream. When omitted, only the
-   * live `resume` stream is returned.
+   * In HR8c the gRPC transport implements this against `drainBufferedEvents`:
+   * the returned stream contains the buffered events and then terminates. It
+   * does **not** continue into the live event stream — callers compose
+   * `subscribe` + `reanimate` to do recovery (see `session-recovery.ts`).
+   *
+   * `fromServerSeq` is accepted for forward compatibility (HR8d will honor
+   * it as a real "subscribe from seq N" semantic) but is currently ignored
+   * by the gRPC transport — `drainBufferedEvents` replays all parked events
+   * regardless.
    */
   subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
 

--- a/packages/adapter-sdk/src/host-transport.ts
+++ b/packages/adapter-sdk/src/host-transport.ts
@@ -7,13 +7,13 @@
  * changing this interface.
  *
  * Each consumer call-site goes through one of these methods:
- * - `createSession` ← `PowerLineClient.spawn`
- * - `reanimate`     ← `PowerLineClient.resume`
- * - `subscribe`     ← `PowerLineClient.drainBufferedEvents` + `resume` (composed)
- * - `dispatchInput` ← `PowerLineClient.sendInput`
- * - `authenticate`  ← `PowerLineClient.authenticate`
- * - `dispose`       ← `PowerLineClient.kill`
- * - `listSessions`  ← `PowerLineClient.listSessions`
+ * - `createSession`  ← `PowerLineClient.spawn`
+ * - `reanimate`      ← `PowerLineClient.resume`
+ * - `drainBuffered`  ← `PowerLineClient.drainBufferedEvents`
+ * - `dispatchInput`  ← `PowerLineClient.sendInput`
+ * - `authenticate`   ← `PowerLineClient.authenticate`
+ * - `dispose`        ← `PowerLineClient.kill`
+ * - `listSessions`   ← `PowerLineClient.listSessions`
  *
  * @module host-transport
  */

--- a/packages/adapter-sdk/src/host-transport.ts
+++ b/packages/adapter-sdk/src/host-transport.ts
@@ -1,0 +1,191 @@
+/**
+ * Transport-agnostic host interface (AHP HR8c).
+ *
+ * Wraps the PowerLine gRPC client behind an AHP-shaped API so consumers in
+ * `@grackle-ai/core` no longer need to import `powerline.*` proto types. HR8d
+ * will replace the gRPC implementation with a native AHP host without
+ * changing this interface.
+ *
+ * Each consumer call-site goes through one of these methods:
+ * - `createSession` ← `PowerLineClient.spawn`
+ * - `reanimate`     ← `PowerLineClient.resume`
+ * - `subscribe`     ← `PowerLineClient.drainBufferedEvents` + `resume` (composed)
+ * - `dispatchInput` ← `PowerLineClient.sendInput`
+ * - `authenticate`  ← `PowerLineClient.authenticate`
+ * - `dispose`       ← `PowerLineClient.kill`
+ * - `listSessions`  ← `PowerLineClient.listSessions`
+ *
+ * @module host-transport
+ */
+
+import type { AgentEventFields } from "@grackle-ai/common";
+import type { StateAction } from "@grackle-ai/ahp";
+
+/**
+ * A single event from a session stream, in HR8c transitional form.
+ *
+ * Carries both the source `AgentEvent` (so existing event-driven logic in
+ * `event-processor.ts` continues to work) and the AHP `StateAction[]`
+ * produced by the upstream mapper. HR8d removes `event`/`legacyEvent` once
+ * consumers fully consume AHP actions.
+ */
+export interface ServerActionEnvelope {
+  /**
+   * Source AgentEvent — transitional. Existing consumers in
+   * `@grackle-ai/core` drive status/usage/end-reason logic from this. HR8d
+   * removes the field; consumers must migrate to AHP actions by then.
+   */
+  event: AgentEventFields;
+  /** AHP actions derived from the event (possibly empty for carried/dropped). */
+  actions: StateAction[];
+}
+
+/** Parameters for creating a new session via {@link IHostTransport.createSession}. */
+export interface CreateSessionParams {
+  /** Server-assigned session ID (becomes the session URI). */
+  sessionId: string;
+  /** Runtime name (e.g. "claude-code", "copilot"). */
+  runtime: string;
+  /** User-visible prompt to deliver as the initial turn. */
+  prompt: string;
+  /** LLM model identifier. */
+  model: string;
+  /** Maximum agent turns before forced stop. */
+  maxTurns: number;
+  /** Git branch for worktree creation; empty string skips worktree. */
+  branch: string;
+  /** Working directory on the remote (defaults to "/workspace"). */
+  workingDirectory: string;
+  /** System prompt / context injected at session start. */
+  systemContext: string;
+  /** Workspace identifier (optional, for non-workspace sessions). */
+  workspaceId?: string;
+  /** Task identifier this session belongs to. */
+  taskId: string;
+  /** JSON-encoded MCP server configurations. */
+  mcpServersJson: string;
+  /** MCP broker URL the runtime should connect back to. */
+  mcpUrl: string;
+  /** Scoped token for the runtime to authenticate to the MCP broker. */
+  mcpToken: string;
+  /** Whether to use git worktrees. */
+  useWorktrees?: boolean;
+  /** IPC pipe mode ("sync", "async", "detach", or ""). */
+  pipe?: string;
+  /** Script content for script personas (optional). */
+  scriptContent?: string;
+}
+
+/** Parameters for reanimating a suspended session. */
+export interface ReanimateParams {
+  /** Server session ID matching the prior spawn. */
+  sessionId: string;
+  /** Runtime-native session ID stored from the prior spawn's `runtime_session_id` event. */
+  runtimeSessionId: string;
+  /** Runtime name (must match the original spawn). */
+  runtime: string;
+}
+
+/** A single token item delivered via {@link IHostTransport.authenticate}. */
+export interface AuthenticateTokenItem {
+  /** Logical name of the token (e.g. "github-token"). */
+  name: string;
+  /** Delivery kind ("env_var" or "file"). */
+  type: string;
+  /** Environment variable name (when `type === "env_var"`). */
+  envVar?: string;
+  /** Target file path on the remote (when `type === "file"`). */
+  filePath?: string;
+  /** The credential value. */
+  value: string;
+}
+
+/** Parameters for {@link IHostTransport.authenticate}. */
+export interface AuthenticateParams {
+  /** Provider identifier (typically the runtime name) the credentials are scoped to. */
+  provider: string;
+  /** Token items to deliver. */
+  tokens: AuthenticateTokenItem[];
+}
+
+/** A single session entry returned by {@link IHostTransport.listSessions}. */
+export interface HostSessionInfo {
+  /** Server session ID. */
+  sessionId: string;
+  /** Runtime the session is running under. */
+  runtime: string;
+  /** Current status (runtime-defined). */
+  status: string;
+}
+
+/** Result of {@link IHostTransport.createSession}: URI + live event stream. */
+export interface CreateSessionResult {
+  /** Session URI (currently just the sessionId; AHP URI scheme reserved for HR8d). */
+  sessionUri: string;
+  /** Live stream of envelopes for this session. */
+  stream: AsyncIterable<ServerActionEnvelope>;
+}
+
+/**
+ * Transport-agnostic host interface (AHP HR8c).
+ *
+ * All `@grackle-ai/core` consumers obtain an implementation via
+ * `GrpcHostTransport(connection)` (this PR) or directly from the AHP host
+ * (HR8d). The interface shape stays stable across the swap.
+ */
+export interface IHostTransport {
+  /**
+   * Create a new session. Returns the session URI plus the live event stream.
+   *
+   * The stream is returned synchronously alongside the URI (matching gRPC's
+   * spawn behavior) to avoid event-buffer complexity. Consumers must begin
+   * iterating the stream promptly to avoid back-pressure on the wire.
+   */
+  createSession(params: CreateSessionParams): CreateSessionResult;
+
+  /**
+   * Reanimate a suspended session, returning its live event stream.
+   *
+   * Maps directly to `resume`. For recovery flows that also need to drain
+   * buffered events, use `subscribe` with `fromServerSeq`.
+   */
+  reanimate(params: ReanimateParams): AsyncIterable<ServerActionEnvelope>;
+
+  /**
+   * Subscribe to a session's event stream, optionally including buffered events.
+   *
+   * When `fromServerSeq` is provided, the transport composes
+   * `drainBufferedEvents` (buffered, replayed) with `resume` (live events
+   * going forward) into a single ordered stream. When omitted, only the
+   * live `resume` stream is returned.
+   */
+  subscribe(sessionUri: string, fromServerSeq?: string): AsyncIterable<ServerActionEnvelope>;
+
+  /**
+   * Send input text to a session.
+   *
+   * Bypasses any IDLE guard — the runtime accepts input at any time and picks
+   * it up at the next turn boundary. Used by signal delivery and pipe
+   * delivery in `@grackle-ai/core`.
+   */
+  dispatchInput(sessionUri: string, text: string): Promise<void>;
+
+  /**
+   * Authenticate credentials for the given runtime/provider.
+   *
+   * Throws on transport error. Callers in core treat failure as best-effort
+   * (log and continue).
+   */
+  authenticate(params: AuthenticateParams): Promise<void>;
+
+  /**
+   * Dispose (terminate) a session.
+   *
+   * Maps to `kill`. The optional `reason` is currently ignored by the gRPC
+   * transport but reserved for future AHP-native disposition semantics.
+   */
+  dispose(sessionUri: string, reason?: string): Promise<void>;
+
+  /** List active sessions on the host. */
+  listSessions(): Promise<HostSessionInfo[]>;
+}

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -68,3 +68,16 @@ export {
   SSH_CONNECTIVITY_TIMEOUT_MS,
   REMOTE_EXEC_DEFAULT_TIMEOUT_MS,
 } from "./utils.js";
+
+// ─── Host Transport (AHP HR8c) ──────────────────────────────
+export type {
+  IHostTransport,
+  ServerActionEnvelope,
+  CreateSessionParams,
+  CreateSessionResult,
+  ReanimateParams,
+  AuthenticateParams,
+  AuthenticateTokenItem,
+  HostSessionInfo,
+} from "./host-transport.js";
+export { GrpcHostTransport } from "./grpc-host-transport.js";

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -70,6 +70,10 @@ export {
 } from "./utils.js";
 
 // ─── Host Transport (AHP HR8c) ──────────────────────────────
+// Re-export AgentEventFields from common so consumers of `ServerActionEnvelope`
+// (which references it) don't have to import @grackle-ai/common just for the
+// type and api-extractor doesn't flag `ae-forgotten-export`.
+export type { AgentEventFields } from "@grackle-ai/common";
 export type {
   IHostTransport,
   ServerActionEnvelope,

--- a/packages/adapter-sdk/src/shared-operations.test.ts
+++ b/packages/adapter-sdk/src/shared-operations.test.ts
@@ -28,6 +28,7 @@ function createMockConnection(pingFn?: () => Promise<unknown>): PowerLineConnect
     client: {
       ping: pingFn ? vi.fn().mockImplementation(pingFn) : vi.fn().mockResolvedValue({}),
     } as unknown as PowerLineConnection["client"],
+    transport: {} as PowerLineConnection["transport"],
   };
 }
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.0",
     "@connectrpc/connect": "^2.0.0",
+    "@grackle-ai/ahp": "workspace:*",
     "fuse.js": "^7.0.0",
     "zod": "^4.3.0"
   },

--- a/packages/common/src/ahp-mapper.test.ts
+++ b/packages/common/src/ahp-mapper.test.ts
@@ -556,3 +556,265 @@ describe("context mutation", () => {
     expect(context.metaAccumulator.costMillicents).toBe(30);
   });
 });
+
+// ─── Branch-coverage supplement ────────────────────────────────────
+//
+// The tests above cover the headline mappings. This block fills in the
+// remaining branches (parse fallbacks, ternary "else" arms, missing-field
+// paths) so v8 coverage hits the per-package `branches` floor in
+// rigs/heft-rig/coverage-thresholds.json.
+
+describe("branch coverage", () => {
+  it("turn_started with non-JSON content uses raw content as userMessage", () => {
+    const context = makeContext();
+    const event = makeEvent("turn_started", { content: "just a plain string", turnId: "t1" });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { userMessage: { text: string } };
+    expect(action.userMessage.text).toBe("just a plain string");
+  });
+
+  it("turn_started with empty content yields empty userMessage text", () => {
+    const context = makeContext();
+    const event = makeEvent("turn_started", { turnId: "t1" });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { userMessage: { text: string } };
+    expect(action.userMessage.text).toBe("");
+  });
+
+  it("text with no content emits empty markdown part", () => {
+    const context = makeContext({ turnId: "t1", partCounter: 0 });
+    const event = makeEvent("text");
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { part: { content: string } };
+    expect(action.part.content).toBe("");
+  });
+
+  it("tool_use with non-JSON content falls back to unknown_tool / generated invocation", () => {
+    const context = makeContext({ turnId: "t1", partCounter: 0 });
+    const event = makeEvent("tool_use", { content: "not json" });
+    const result = mapAgentEvent(event, 0, context);
+
+    const start = result.actions[0] as { toolName: string; displayName: string };
+    const ready = result.actions[1] as { invocationMessage: string };
+    expect(start.toolName).toBe("unknown_tool");
+    expect(start.displayName).toBe("unknown_tool");
+    expect(ready.invocationMessage).toBe("Running unknown_tool");
+  });
+
+  it("tool_use accepts `name` field when `tool_name` is absent", () => {
+    const context = makeContext({ turnId: "t1", partCounter: 0 });
+    const event = makeEvent("tool_use", { content: JSON.stringify({ name: "shell" }) });
+    const result = mapAgentEvent(event, 0, context);
+
+    const start = result.actions[0] as { toolName: string };
+    expect(start.toolName).toBe("shell");
+  });
+
+  it("tool_use falls back to toolName when display_name is absent", () => {
+    const context = makeContext({ turnId: "t1", partCounter: 0 });
+    const event = makeEvent("tool_use", { content: JSON.stringify({ tool_name: "edit" }) });
+    const result = mapAgentEvent(event, 0, context);
+
+    const start = result.actions[0] as { displayName: string };
+    expect(start.displayName).toBe("edit");
+  });
+
+  it("tool_use uses provided invocation_message when present", () => {
+    const context = makeContext({ turnId: "t1", partCounter: 0 });
+    const event = makeEvent("tool_use", {
+      content: JSON.stringify({ tool_name: "shell", invocation_message: "running shell `ls`" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const ready = result.actions[1] as { invocationMessage: string };
+    expect(ready.invocationMessage).toBe("running shell `ls`");
+  });
+
+  it("tool_result with is_ok:false emits failure result with error", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: JSON.stringify({ is_ok: false, past_tense_message: "failed to read" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as {
+      result: { success: boolean; content?: unknown; error?: { message: string } };
+    };
+    expect(action.result.success).toBe(false);
+    expect(action.result.content).toBeUndefined();
+    expect(action.result.error?.message).toBe("failed to read");
+    // No system notification on failure
+    expect(result.actions.length).toBe(1);
+  });
+
+  it("tool_result accepts `success` field when `is_ok` is absent", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: JSON.stringify({ success: false, content: "nope" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { result: { success: boolean } };
+    expect(action.result.success).toBe(false);
+  });
+
+  it("tool_result defaults to success=true when neither is_ok nor success present", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: JSON.stringify({ content: "ok" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { result: { success: boolean } };
+    expect(action.result.success).toBe(true);
+  });
+
+  it("tool_result with non-JSON content keeps default success=true", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", { toolCallId: "tc-1", content: "raw text result" });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { result: { success: boolean; pastTenseMessage: string } };
+    expect(action.result.success).toBe(true);
+    expect(action.result.pastTenseMessage).toBe("raw text result");
+  });
+
+  it("tool_result with no content emits no system notification", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", { toolCallId: "tc-1" });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(1);
+  });
+
+  it("tool_result with content > 200 chars truncates the system notification", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const longText = "x".repeat(250);
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: JSON.stringify({ is_ok: true, content: longText }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const notification = result.actions[1] as { part: { content: string } };
+    expect(notification.part.content.length).toBe(203); // 200 chars + "..."
+    expect(notification.part.content.endsWith("...")).toBe(true);
+  });
+
+  it("usage with null cost_millicents leaves accumulator untouched", () => {
+    const context = makeContext({ metaAccumulator: { costMillicents: 50 } });
+    const event = makeEvent("usage", { content: JSON.stringify({ cost_millicents: null }) });
+    mapAgentEvent(event, 0, context);
+
+    expect(context.metaAccumulator.costMillicents).toBe(50);
+  });
+
+  it("usage with no parsed content leaves accumulator untouched", () => {
+    const context = makeContext({ metaAccumulator: { costMillicents: 50 } });
+    const event = makeEvent("usage");
+    mapAgentEvent(event, 0, context);
+
+    expect(context.metaAccumulator.costMillicents).toBe(50);
+  });
+
+  it("error with no content falls back to 'Unknown error'", () => {
+    const context = makeContext({ turnId: "t1" });
+    const event = makeEvent("error");
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { error: { message: string } };
+    expect(action.error.message).toBe("Unknown error");
+  });
+
+  it("status with unknown content is dropped", () => {
+    const context = makeContext({ turnId: "t1" });
+    const event = makeEvent("status", { content: "made_up_status" });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(0);
+    expect(result.note?.disposition).toBe("dropped");
+    expect(result.note?.detail).toContain("unrecognized");
+  });
+
+  it("status with no content is dropped (empty default branch)", () => {
+    const context = makeContext({ turnId: "t1" });
+    const event = makeEvent("status");
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(0);
+    expect(result.note?.disposition).toBe("dropped");
+  });
+
+  it("status terminated maps to SessionError when in-turn", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("status", { content: "terminated" });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(1);
+    const action = result.actions[0] as { type: string };
+    expect(action.type).toBe(ActionType.SessionError);
+    expect(context.turnId).toBeUndefined();
+    expect(context.openToolCalls).toEqual([]);
+  });
+
+  it("status terminated drops when no active turn", () => {
+    const context = makeContext();
+    const event = makeEvent("status", { content: "terminated" });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(0);
+    expect(result.note?.disposition).toBe("dropped");
+  });
+
+  it("system diagnostic via parsed `span`/`trace`/`level` keys is carried (not mapped)", () => {
+    const context = makeContext({ turnId: "t1" });
+    const event = makeEvent("system", {
+      content: JSON.stringify({ span: "x", trace: "y" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(0);
+    expect(result.note?.disposition).toBe("carried");
+  });
+
+  it("system with diagnostic-looking keys but also `text` is treated as user-visible", () => {
+    const context = makeContext({ turnId: "t1" });
+    const event = makeEvent("system", {
+      content: JSON.stringify({ span: "x", text: "user-visible content" }),
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    expect(result.actions.length).toBe(1);
+    expect(result.note?.disposition).toBe("mapped");
+  });
+
+  it("tool_result with explicit toolCallId splices from middle of LIFO stack", () => {
+    const context = makeContext({
+      turnId: "t1",
+      openToolCalls: ["tc-old", "tc-target", "tc-newer"],
+    });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-target",
+      content: JSON.stringify({ is_ok: true, content: "done" }),
+    });
+    mapAgentEvent(event, 0, context);
+
+    // Splice removed "tc-target" from the middle, preserving order
+    expect(context.openToolCalls).toEqual(["tc-old", "tc-newer"]);
+  });
+
+  it("text uses event.turnId when context.turnId is unset", () => {
+    const context = makeContext();
+    const event = makeEvent("text", { content: "hi", turnId: "from-event" });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { turnId: string };
+    expect(action.turnId).toBe("from-event");
+  });
+});

--- a/packages/common/src/ahp-mapper.test.ts
+++ b/packages/common/src/ahp-mapper.test.ts
@@ -8,9 +8,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { powerline } from "@grackle-ai/common";
 import { ActionType } from "@grackle-ai/ahp";
-import { mapAgentEvent, type MapperContext } from "./ahp-mapper.js";
+import { mapAgentEvent, type AgentEventFields, type MapperContext } from "./ahp-mapper.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -19,30 +18,26 @@ function makeContext(overrides?: Partial<MapperContext>): MapperContext {
     turnId: undefined,
     openToolCalls: [],
     partCounter: 0,
+    eventIndex: 0,
     metaAccumulator: {},
     ...overrides,
   };
 }
 
-function makeEvent(
-  type: powerline.AgentEvent["type"],
-  overrides?: Record<string, unknown>,
-): powerline.AgentEvent {
+function makeEvent(type: string, overrides?: Record<string, unknown>): AgentEventFields {
   return {
     type,
-    timestamp: new Date().toISOString(),
-    content: overrides?.content,
-    raw: overrides?.raw,
-    toolCallId: overrides?.toolCallId,
-    turnId: overrides?.turnId,
-    diagnostic: overrides?.diagnostic,
+    content: overrides?.content as string | undefined,
+    toolCallId: overrides?.toolCallId as string | undefined,
+    turnId: overrides?.turnId as string | undefined,
+    diagnostic: overrides?.diagnostic as boolean | undefined,
   };
 }
 
 function assertActionType<T extends { type: string }>(
   actions: unknown[],
   expectedType: string,
-  index = 0,
+  index: number = 0,
 ): T {
   const action = actions[index] as T;
   expect(action.type).toBe(expectedType);
@@ -70,7 +65,7 @@ describe("turn_started", () => {
     expect(action.userMessage.text).toBe("Hello world");
     expect(context.turnId).toBe("turn-abc");
     expect(context.openToolCalls).toEqual([]);
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("uses generated turnId when none provided", () => {
@@ -115,7 +110,7 @@ describe("turn_complete", () => {
     );
     expect(context.turnId).toBeUndefined();
     expect(context.openToolCalls).toEqual([]);
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("drops when no active turn", () => {
@@ -124,7 +119,7 @@ describe("turn_complete", () => {
     const result = mapAgentEvent(event, 1, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -137,8 +132,8 @@ describe("input_needed", () => {
     const result = mapAgentEvent(event, 2, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
-    expect(result.note.detail).toContain("Advisory event");
+    expect(result.note?.disposition).toBe("dropped");
+    expect(result.note?.detail).toContain("Advisory event");
   });
 });
 
@@ -159,7 +154,7 @@ describe("text", () => {
     expect(action.part.kind).toBe("markdown");
     expect(action.part.id).toBe("part-5");
     expect(action.part.content).toBe("Hello there");
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("drops when no active turn", () => {
@@ -168,7 +163,7 @@ describe("text", () => {
     const result = mapAgentEvent(event, 3, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -210,7 +205,7 @@ describe("tool_use", () => {
 
     expect(context.openToolCalls).toEqual(["tc-xyz"]);
     expect(result.note ? 1 : 0).toBe(1);
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("generates toolCallId when none provided", () => {
@@ -228,7 +223,7 @@ describe("tool_use", () => {
     const result = mapAgentEvent(event, 4, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -263,7 +258,7 @@ describe("tool_result", () => {
 
     // First-class toolCallId (HR3) is used; matched id is removed from LIFO stack
     expect(context.openToolCalls).toEqual([]);
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("pairs by LIFO stack when no toolCallId", () => {
@@ -286,7 +281,7 @@ describe("tool_result", () => {
     const result = mapAgentEvent(event, 5, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 
   it("adds system notification for successful result", () => {
@@ -302,7 +297,7 @@ describe("tool_result", () => {
 
     expect(result.actions.length).toBe(2);
     expect(result.note).toBeDefined();
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("drops when no active turn", () => {
@@ -311,7 +306,7 @@ describe("tool_result", () => {
     const result = mapAgentEvent(event, 5, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -329,7 +324,7 @@ describe("usage", () => {
 
     expect(context.metaAccumulator.costMillicents).toBe(150);
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("carried");
+    expect(result.note?.disposition).toBe("carried");
   });
 
   it("ignores non-finite cost_millicents", () => {
@@ -368,7 +363,7 @@ describe("error", () => {
     }>(result.actions, ActionType.SessionError);
     expect(action.turnId).toBe("turn-abc");
     expect(action.error.message).toBe("Something went wrong");
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
     // context.turnId must be cleared so subsequent events aren't mapped to the defunct turn
     expect(context.turnId).toBeUndefined();
   });
@@ -393,7 +388,7 @@ describe("error", () => {
       error: { message: string };
     }>(result.actions, ActionType.SessionCreationFailed);
     expect(action.error.message).toBe("Init failed");
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 });
 
@@ -408,7 +403,7 @@ describe("status", () => {
     expect(result.actions.length).toBe(1);
     assertActionType<{ type: string }>(result.actions, ActionType.SessionError);
     expect(context.turnId).toBeUndefined();
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("maps failed to SessionCreationFailed when pre-turn", () => {
@@ -418,7 +413,7 @@ describe("status", () => {
 
     expect(result.actions.length).toBe(1);
     assertActionType<{ type: string }>(result.actions, ActionType.SessionCreationFailed);
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("maps killed to SessionError when in-turn", () => {
@@ -438,7 +433,7 @@ describe("status", () => {
     const result = mapAgentEvent(event, 9, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 
   it("drops completed/waiting_input/running", () => {
@@ -448,7 +443,7 @@ describe("status", () => {
       const result = mapAgentEvent(event, 10, context);
 
       expect(result.actions.length).toBe(0);
-      expect(result.note.disposition).toBe("dropped");
+      expect(result.note?.disposition).toBe("dropped");
     }
   });
 });
@@ -468,7 +463,7 @@ describe("system", () => {
     }>(result.actions, ActionType.SessionResponsePart);
     expect(action.part.kind).toBe("systemNotification");
     expect(action.part.content).toBe("Subagent completed");
-    expect(result.note.disposition).toBe("mapped");
+    expect(result.note?.disposition).toBe("mapped");
   });
 
   it("drops diagnostic system events", () => {
@@ -480,8 +475,8 @@ describe("system", () => {
     const result = mapAgentEvent(event, 12, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("carried");
-    expect(result.note.detail).toContain("diagnostic");
+    expect(result.note?.disposition).toBe("carried");
+    expect(result.note?.detail).toContain("diagnostic");
   });
 
   it("drops non-diagnostic system when no active turn", () => {
@@ -490,7 +485,7 @@ describe("system", () => {
     const result = mapAgentEvent(event, 11, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -504,7 +499,7 @@ describe("runtime_session_id", () => {
 
     expect(context.metaAccumulator.runtimeSessionId).toBe("runtime-abc-123");
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("carried");
+    expect(result.note?.disposition).toBe("carried");
   });
 
   it("drops when no content", () => {
@@ -513,7 +508,7 @@ describe("runtime_session_id", () => {
     const result = mapAgentEvent(event, 13, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("dropped");
   });
 });
 
@@ -526,8 +521,8 @@ describe("unknown event types", () => {
     const result = mapAgentEvent(event, 100, context);
 
     expect(result.actions.length).toBe(0);
-    expect(result.note.disposition).toBe("dropped");
-    expect(result.note.detail).toContain("Unrecognized event type");
+    expect(result.note?.disposition).toBe("dropped");
+    expect(result.note?.detail).toContain("Unrecognized event type");
   });
 });
 

--- a/packages/common/src/ahp-mapper.ts
+++ b/packages/common/src/ahp-mapper.ts
@@ -29,7 +29,7 @@ import {
  * Structural subset of `powerline.AgentEvent` that the mapper plus its
  * downstream consumers actually read.
  *
- * Any object with these fields can be passed to {@link mapAgentEvent} —
+ * Any object with these fields can be passed to `mapAgentEvent` —
  * proto-generated `AgentEvent` messages from the live gRPC stream and plain
  * objects reconstructed from `session_actions` rows during replay both qualify.
  *

--- a/packages/common/src/ahp-mapper.ts
+++ b/packages/common/src/ahp-mapper.ts
@@ -1,17 +1,20 @@
 /**
  * AgentEvent → AHP SessionAction mapper (AHP HR1b / RFC #1292).
  *
- * Stateless function that translates a single PowerLine `AgentEvent` into one
- * or more AHP `SessionAction` payloads. The mapper is stateless — it requires
- * a `MapperContext` from the caller to track turn state and tool-call pairing.
+ * Stateless function that translates a single PowerLine `AgentEvent` (or any
+ * structurally-compatible value — see {@link AgentEventFields}) into one or
+ * more AHP `SessionAction` payloads. The mapper requires a {@link MapperContext}
+ * from the caller to track turn state and tool-call pairing.
  *
- * This mapper is an interim bridge while PowerLine still produces AgentEvents
- * and the AHP host eventually takes over the transport (HR8).
+ * Lives in `@grackle-ai/common` (not core) because both the live gRPC transport
+ * (`GrpcHostTransport` in `@grackle-ai/adapter-sdk`) and the in-core delta-replay
+ * path (`SessionStateManager.reconstruct`) consume it. Decoupling from
+ * `powerline.AgentEvent` lets HR8d remove the gRPC path entirely without
+ * touching the mapper.
  *
  * @module ahp-mapper
  */
 
-import type { powerline } from "@grackle-ai/common";
 import {
   ActionType,
   ToolCallConfirmationReason,
@@ -21,6 +24,37 @@ import {
   type StateAction,
   type ToolResultContent,
 } from "@grackle-ai/ahp";
+
+/**
+ * Structural subset of `powerline.AgentEvent` that the mapper plus its
+ * downstream consumers actually read.
+ *
+ * Any object with these fields can be passed to {@link mapAgentEvent} —
+ * proto-generated `AgentEvent` messages from the live gRPC stream and plain
+ * objects reconstructed from `session_actions` rows during replay both qualify.
+ *
+ * The fields the mapper itself reads are `type`, `content`, `toolCallId`,
+ * `turnId`, and `diagnostic`. `timestamp` and `raw` are not consulted by the
+ * mapper but are included here so downstream consumers (e.g. `event-processor`
+ * in `@grackle-ai/core`) can convert envelopes back into `grackle.SessionEvent`
+ * proto messages without re-importing the powerline types.
+ */
+export interface AgentEventFields {
+  /** Event type discriminator (e.g. `"turn_started"`, `"tool_use"`). */
+  type: string;
+  /** Event payload (string, often JSON). Empty/missing maps to `""`. */
+  content?: string;
+  /** First-class tool call ID for `tool_use` / `tool_result` pairing (HR3). */
+  toolCallId?: string;
+  /** Turn ID this event belongs to (overrides the active context turn). */
+  turnId?: string;
+  /** `true` for diagnostic system events that route to OTLP telemetry (HR7). */
+  diagnostic?: boolean;
+  /** ISO-8601 timestamp string (passed through from the runtime). */
+  timestamp?: string;
+  /** Raw event body — opaque to the mapper, used by JSONL persistence. */
+  raw?: string;
+}
 
 /** Safely parse an event's content JSON, returning a record or undefined on failure. */
 function safeParseContent(content?: string): Record<string, unknown> | undefined {
@@ -105,7 +139,7 @@ function makeTextResult(text: string): ToolResultContent {
 }
 
 /** Check whether a system event is a diagnostic (HR7) that routes to OTLP. */
-function isDiagnosticEvent(event: powerline.AgentEvent): boolean {
+function isDiagnosticEvent(event: AgentEventFields): boolean {
   if (event.diagnostic) return true;
   const parsed = safeParseContent(event.content);
   if (parsed) {
@@ -157,7 +191,7 @@ function str(parsed: Record<string, unknown>, fields: string[], fallback: string
  * | `runtime_session_id` | `_meta.runtimeSessionId` | carried |
  */
 export function mapAgentEvent(
-  event: powerline.AgentEvent,
+  event: AgentEventFields,
   index: number,
   context: MapperContext,
 ): MapResult {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -16,3 +16,11 @@ export type {
 } from "./runtime-catalog.js";
 export { SequencedLog } from "./sequenced-log.js";
 export type { Sequenced, LogSink, SequencedLogOptions } from "./sequenced-log.js";
+export { mapAgentEvent } from "./ahp-mapper.js";
+export type {
+  AgentEventFields,
+  MapperContext,
+  MapResult,
+  MappingNote,
+  Disposition,
+} from "./ahp-mapper.js";

--- a/packages/core/src/ahp-session-state.ts
+++ b/packages/core/src/ahp-session-state.ts
@@ -9,9 +9,8 @@
  * @module ahp-session-state
  */
 
-import { create } from "@bufbuild/protobuf";
 import { logger } from "./logger.js";
-import { powerline } from "@grackle-ai/common";
+import { mapAgentEvent, type AgentEventFields, type MapperContext } from "@grackle-ai/common";
 import {
   sessionReducer,
   SessionLifecycle,
@@ -23,7 +22,6 @@ import {
 // This import is types-only and scoped to this package's internal build — consumers of
 // @grackle-ai/core never see it since .d.ts resolution is confined to dist/.
 import type { SessionAction } from "@grackle-ai/ahp/src/vendor/ahp/action-origin.generated.js";
-import { mapAgentEvent, type MapperContext } from "./ahp-mapper.js";
 import {
   persistSnapshot as dbPersistSnapshot,
   querySnapshot as dbQuerySnapshot,
@@ -185,7 +183,7 @@ export class SessionStateManager {
    * @returns The last action's ULID included in the snapshot, or `undefined`
    *   if no actions were produced or the threshold was not reached.
    */
-  public processEvent(event: powerline.AgentEvent, serverSeq: string): string | undefined {
+  public processEvent(event: AgentEventFields, serverSeq: string): string | undefined {
     // Dedup: skip the first runtime turn_started if we injected the initial prompt.
     // The mapper would otherwise produce a duplicate SessionTurnStarted action.
     if (this.injectedInitialTurn && event.type === "turn_started") {
@@ -553,17 +551,14 @@ export class SessionStateManager {
     return state;
   }
 
-  private static reconstructAgentEvent(row: SessionActionRow): powerline.AgentEvent {
-    return create(powerline.AgentEventSchema, {
-      sessionId: row.sessionId,
+  private static reconstructAgentEvent(row: SessionActionRow): AgentEventFields {
+    return {
       type: row.type,
-      timestamp: row.timestamp,
       content: row.content,
-      raw: row.raw,
       toolCallId: row.toolCallId,
       turnId: row.turnId,
       diagnostic: row.diagnostic,
-    });
+    };
   }
 
   private serializeSnapshot(): string {

--- a/packages/core/src/auto-reconnect.test.ts
+++ b/packages/core/src/auto-reconnect.test.ts
@@ -105,6 +105,7 @@ function makeAdapter(connectResult?: PowerLineConnection): EnvironmentAdapter {
     client: {} as PowerLineConnection["client"],
     environmentId: "env1",
     port: 7433,
+    transport: {} as PowerLineConnection["transport"],
   };
   return {
     type: "test",
@@ -264,6 +265,7 @@ describe("auto-reconnect", () => {
               client: {} as PowerLineConnection["client"],
               environmentId: "env1",
               port: 7433,
+              transport: {} as PowerLineConnection["transport"],
             }),
           100,
         ),
@@ -394,6 +396,7 @@ describe("auto-reconnect", () => {
               client: {} as PowerLineConnection["client"],
               environmentId: "env1",
               port: 7433,
+              transport: {} as PowerLineConnection["transport"],
             }),
           100,
         ),
@@ -502,6 +505,7 @@ describe("auto-reconnect", () => {
       client: {} as PowerLineConnection["client"],
       environmentId: "env1",
       port: 7433,
+      transport: {} as PowerLineConnection["transport"],
     };
     (adapter.connect as ReturnType<typeof vi.fn>).mockResolvedValue(conn);
 

--- a/packages/core/src/credential-bundle.ts
+++ b/packages/core/src/credential-bundle.ts
@@ -10,8 +10,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { create } from "@bufbuild/protobuf";
-import { powerline, type RuntimeName } from "@grackle-ai/common";
+import { type RuntimeName } from "@grackle-ai/common";
 import {
   credentialProviders,
   githubAccountStore,
@@ -19,6 +18,35 @@ import {
   type DatabaseInstance,
 } from "@grackle-ai/database";
 import { exec } from "./utils/exec.js";
+
+/**
+ * A single credential token, structurally compatible with both the legacy
+ * `powerline.TokenItem` proto message and the AHP-shaped
+ * `AuthenticateTokenItem` exported by `@grackle-ai/adapter-sdk`.
+ */
+export interface TokenItem {
+  /** Logical name of the token (e.g. "github-token"). */
+  name: string;
+  /** Delivery kind ("env_var" or "file"). */
+  type: string;
+  /** Environment variable name (when `type === "env_var"`). */
+  envVar?: string;
+  /** Target file path on the remote (when `type === "file"`). */
+  filePath?: string;
+  /** The credential value. */
+  value: string;
+}
+
+/** A bundle of tokens — the return shape of {@link buildProviderTokenBundle}. */
+export interface ProviderTokenBundle {
+  /** The collected token items, in the order they should be delivered. */
+  tokens: TokenItem[];
+}
+
+/** Type-asserting identity helper; replaces the proto-bound `create()` factory. */
+function tokenItem(data: TokenItem): TokenItem {
+  return data;
+}
 
 /**
  * Maps each runtime to the credential providers it needs.
@@ -210,7 +238,7 @@ export async function buildProviderTokenBundle(
   runtime?: string,
   database?: DatabaseInstance,
   githubAccountId?: string,
-): Promise<powerline.TokenBundle> {
+): Promise<ProviderTokenBundle> {
   const config = credentialProviders.getCredentialProviders(database);
   // When runtime is given, look it up in the map. Unknown runtimes get [] (empty, not all providers).
   const runtimeProviders =
@@ -220,7 +248,7 @@ export async function buildProviderTokenBundle(
         : []
       : undefined;
   const allowedProviders = runtimeProviders !== undefined ? new Set(runtimeProviders) : undefined;
-  const items: powerline.TokenItem[] = [];
+  const items: TokenItem[] = [];
 
   // Lazily resolved GitHub token from the `gh` CLI — shared across provider blocks
   // to avoid spawning the subprocess more than once per call. Stores a Promise
@@ -240,7 +268,7 @@ export async function buildProviderTokenBundle(
       const value = readFileSync(credentialsPath, "utf-8");
       if (value.trim()) {
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: "claude-credentials",
             type: "file",
             filePath: "~/.claude/.credentials.json",
@@ -253,7 +281,7 @@ export async function buildProviderTokenBundle(
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (apiKey) {
       items.push(
-        create(powerline.TokenItemSchema, {
+        tokenItem({
           name: "anthropic-api-key",
           type: "env_var",
           envVar: "ANTHROPIC_API_KEY",
@@ -275,7 +303,7 @@ export async function buildProviderTokenBundle(
 
     if (storedToken) {
       items.push(
-        create(powerline.TokenItemSchema, {
+        tokenItem({
           name: "github-token",
           type: "env_var",
           envVar: "GH_TOKEN",
@@ -290,7 +318,7 @@ export async function buildProviderTokenBundle(
         if (value) {
           hasGitHubEnvVar = true;
           items.push(
-            create(powerline.TokenItemSchema, {
+            tokenItem({
               name: varName.toLowerCase().replace(/_/g, "-"),
               type: "env_var",
               envVar: varName,
@@ -306,7 +334,7 @@ export async function buildProviderTokenBundle(
         const cliToken = await getCliToken();
         if (cliToken) {
           items.push(
-            create(powerline.TokenItemSchema, {
+            tokenItem({
               name: "github-token",
               type: "env_var",
               envVar: "GITHUB_TOKEN",
@@ -329,7 +357,7 @@ export async function buildProviderTokenBundle(
       const value = readFileSync(copilotConfigPath, "utf-8");
       if (value.trim()) {
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: "copilot-config",
             type: "file",
             filePath: "~/.copilot/config.json",
@@ -351,7 +379,7 @@ export async function buildProviderTokenBundle(
           hasGitHubToken = true;
         }
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: varName.toLowerCase().replace(/_/g, "-"),
             type: "env_var",
             envVar: varName,
@@ -372,7 +400,7 @@ export async function buildProviderTokenBundle(
         // Only push if not already included by the GitHub provider block above
         if (!items.some((item) => item.envVar === envVarName)) {
           items.push(
-            create(powerline.TokenItemSchema, {
+            tokenItem({
               name: envVarName.toLowerCase().replace(/_/g, "-"),
               type: "env_var",
               envVar: envVarName,
@@ -384,7 +412,7 @@ export async function buildProviderTokenBundle(
         const cliToken = await getCliToken();
         if (cliToken && !items.some((item) => item.envVar === "GITHUB_TOKEN")) {
           items.push(
-            create(powerline.TokenItemSchema, {
+            tokenItem({
               name: "github-token",
               type: "env_var",
               envVar: "GITHUB_TOKEN",
@@ -404,7 +432,7 @@ export async function buildProviderTokenBundle(
       const value = readFileSync(codexAuthPath, "utf-8");
       if (value.trim()) {
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: "codex-auth",
             type: "file",
             filePath: "~/.codex/auth.json",
@@ -416,7 +444,7 @@ export async function buildProviderTokenBundle(
     const openaiKey = process.env.OPENAI_API_KEY;
     if (openaiKey) {
       items.push(
-        create(powerline.TokenItemSchema, {
+        tokenItem({
           name: "openai-api-key",
           type: "env_var",
           envVar: "OPENAI_API_KEY",
@@ -446,7 +474,7 @@ export async function buildProviderTokenBundle(
       const value = readFileSync(gooseConfigPath, "utf-8");
       if (value.trim()) {
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: "goose-config",
             type: "file",
             filePath: gooseConfigFilePath,
@@ -465,7 +493,7 @@ export async function buildProviderTokenBundle(
       const value = process.env[varName];
       if (value) {
         items.push(
-          create(powerline.TokenItemSchema, {
+          tokenItem({
             name: varName.toLowerCase().replace(/_/g, "-"),
             type: "env_var",
             envVar: varName,
@@ -476,5 +504,5 @@ export async function buildProviderTokenBundle(
     }
   }
 
-  return create(powerline.TokenBundleSchema, { tokens: items });
+  return { tokens: items };
 }

--- a/packages/core/src/event-processor.test.ts
+++ b/packages/core/src/event-processor.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { powerline, grackle } from "@grackle-ai/common";
+import type { ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
+
+/** Wrap an AgentEvent as a ServerActionEnvelope with no mapped actions. */
+function envelope(event: powerline.AgentEvent): ServerActionEnvelope {
+  return { event, actions: [] };
+}
 
 // ── Mock all heavy dependencies before importing ──────────────
 vi.mock("./trace-context.js", () => ({
@@ -141,10 +147,10 @@ function applySchema(): void {
   `);
 }
 
-/** Create an async iterable from an array of AgentEvent messages. */
-async function* eventStream(events: powerline.AgentEvent[]): AsyncIterable<powerline.AgentEvent> {
+/** Create an async iterable of envelopes from an array of AgentEvent messages. */
+async function* eventStream(events: powerline.AgentEvent[]): AsyncIterable<ServerActionEnvelope> {
   for (const event of events) {
-    yield event;
+    yield envelope(event);
   }
 }
 
@@ -195,13 +201,13 @@ describe("stream error handling", () => {
     workspaceStore.createWorkspace("proj1", "Test Project", "desc", "", "env1");
   });
 
-  /** Create an async iterable that yields events, then throws an error. */
+  /** Create an async iterable of envelopes that yields events, then throws an error. */
   async function* throwingStream(
     events: powerline.AgentEvent[],
     error: Error,
-  ): AsyncIterable<powerline.AgentEvent> {
+  ): AsyncIterable<ServerActionEnvelope> {
     for (const event of events) {
-      yield event;
+      yield envelope(event);
     }
     throw error;
   }
@@ -556,18 +562,18 @@ describe("late-binding", () => {
    * Call push() to emit events and end() to close the stream.
    */
   function controllableStream(): {
-    stream: AsyncIterable<powerline.AgentEvent>;
+    stream: AsyncIterable<ServerActionEnvelope>;
     push: (event: powerline.AgentEvent) => void;
     end: () => void;
   } {
-    const queue: powerline.AgentEvent[] = [];
+    const queue: ServerActionEnvelope[] = [];
     let waiting: (() => void) | undefined;
     let done = false;
 
-    const stream: AsyncIterable<powerline.AgentEvent> = {
+    const stream: AsyncIterable<ServerActionEnvelope> = {
       [Symbol.asyncIterator]() {
         return {
-          async next(): Promise<IteratorResult<powerline.AgentEvent>> {
+          async next(): Promise<IteratorResult<ServerActionEnvelope>> {
             while (queue.length === 0 && !done) {
               await new Promise<void>((resolve) => {
                 waiting = resolve;
@@ -576,7 +582,7 @@ describe("late-binding", () => {
             if (queue.length > 0) {
               return { value: queue.shift()!, done: false };
             }
-            return { value: undefined as unknown as powerline.AgentEvent, done: true };
+            return { value: undefined as unknown as ServerActionEnvelope, done: true };
           },
         };
       },
@@ -585,7 +591,7 @@ describe("late-binding", () => {
     return {
       stream,
       push(event: powerline.AgentEvent) {
-        queue.push(event);
+        queue.push(envelope(event));
         if (waiting) {
           waiting();
           waiting = undefined;
@@ -819,12 +825,12 @@ describe("budget-exceeded end reason on killed/terminated", () => {
   async function* eventsWithHook(
     events: powerline.AgentEvent[],
     afterFirst: () => void,
-  ): AsyncIterable<powerline.AgentEvent> {
+  ): AsyncIterable<ServerActionEnvelope> {
     for (let i = 0; i < events.length; i++) {
       if (i === 1) {
         afterFirst();
       }
-      yield events[i];
+      yield envelope(events[i]);
     }
   }
 

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -203,9 +203,17 @@ export function processEventStream(
 
       for await (const envelope of envelopes) {
         const event = envelope.event;
-        // Normalize optional fields to proto-default semantics so downstream
-        // string operations can rely on a non-undefined `content`.
+        // Normalize optional AgentEventFields to proto-default semantics so
+        // BOTH downstream string operations and the grackle.SessionEvent
+        // we persist/broadcast see non-undefined values consistently — proto
+        // string fields default to "" and bool to false anyway, so this just
+        // makes the intent explicit at the source.
         const eventContent: string = event.content ?? "";
+        const eventTimestamp: string = event.timestamp ?? "";
+        const eventRaw: string = event.raw ?? "";
+        const eventToolCallId: string = event.toolCallId ?? "";
+        const eventTurnId: string = event.turnId ?? "";
+        const eventDiagnostic: boolean = event.diagnostic ?? false;
         // runtime_session_id is an internal control event: persist it then skip
         // logging/publishing — it has no proto enum value and is not client-visible.
         if (event.type === "runtime_session_id") {
@@ -218,12 +226,12 @@ export function processEventStream(
         const sessionEvent = create(grackle.SessionEventSchema, {
           sessionId,
           type: eventTypeToEnum(event.type),
-          timestamp: event.timestamp,
-          content: event.content,
-          raw: event.raw,
-          toolCallId: event.toolCallId,
-          diagnostic: event.diagnostic,
-          turnId: event.turnId,
+          timestamp: eventTimestamp,
+          content: eventContent,
+          raw: eventRaw,
+          toolCallId: eventToolCallId,
+          diagnostic: eventDiagnostic,
+          turnId: eventTurnId,
         });
         await logWriter.writeEvent(logPath, sessionEvent);
         streamHub.publish(sessionEvent);

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -1,13 +1,14 @@
 import { create } from "@bufbuild/protobuf";
 import {
   grackle,
-  powerline,
   eventTypeToEnum,
   SESSION_STATUS,
   TERMINAL_SESSION_STATUSES,
   END_REASON,
+  type AgentEventFields,
 } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
+import type { ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
 import { sessionStore, taskStore } from "@grackle-ai/database";
 import { recordSessionAction } from "./session-action-recorder.js";
 import * as streamHub from "./stream-hub.js";
@@ -26,27 +27,18 @@ import type { ProcessorContext } from "./processor-registry.js";
 import { SessionStateManager } from "./ahp-session-state.js";
 
 /**
- * Construct a minimal AgentEvent for injected events (system context, initial prompt).
- * Uses the protobuf `create()` helper so the result satisfies the `AgentEvent`
- * type contract without unsafe casts.
+ * Construct a minimal AgentEventFields for injected events (system context,
+ * initial prompt). Returns a plain object structurally compatible with the
+ * mapper's input contract.
  */
-function makeAgentEvent(
-  sessionId: string,
-  type: string,
-  content: string,
-  raw?: string,
-  turnId?: string,
-): powerline.AgentEvent {
-  return create(powerline.AgentEventSchema, {
-    sessionId,
+function makeAgentEvent(type: string, content: string, turnId?: string): AgentEventFields {
+  return {
     type,
-    timestamp: new Date().toISOString(),
     content,
-    raw: raw ?? "",
     toolCallId: "",
     diagnostic: false,
     turnId: turnId ?? "",
-  });
+  };
 }
 
 /** Options for processing an agent event stream. */
@@ -141,7 +133,7 @@ export function publishWidgetEvent(sessionId: string, payload: WidgetEventPayloa
  * events are replayed from the session log.
  */
 export function processEventStream(
-  events: AsyncIterable<powerline.AgentEvent>,
+  envelopes: AsyncIterable<ServerActionEnvelope>,
   options: EventStreamOptions,
 ): void {
   const { sessionId, logPath } = options;
@@ -185,10 +177,7 @@ export function processEventStream(
           lastServerSeq = sysSeq;
           // System events are dropped by the mapper when there's no active turn (no turn_started yet).
           // The mapper only processes system events within an active turn context.
-          stateManager.processEvent(
-            makeAgentEvent(sessionId, "system", options.systemContext),
-            sysSeq,
-          );
+          stateManager.processEvent(makeAgentEvent("system", options.systemContext), sysSeq);
         }
       }
       if (options.prompt && options.taskId) {
@@ -204,11 +193,7 @@ export function processEventStream(
         if (promptSeq) {
           lastServerSeq = promptSeq;
           stateManager.processEvent(
-            makeAgentEvent(
-              sessionId,
-              "turn_started",
-              JSON.stringify({ user_message: options.prompt }),
-            ),
+            makeAgentEvent("turn_started", JSON.stringify({ user_message: options.prompt })),
             promptSeq,
           );
           // Mark so the runtime's first turn_started is deduplicated.
@@ -216,12 +201,16 @@ export function processEventStream(
         }
       }
 
-      for await (const event of events) {
+      for await (const envelope of envelopes) {
+        const event = envelope.event;
+        // Normalize optional fields to proto-default semantics so downstream
+        // string operations can rely on a non-undefined `content`.
+        const eventContent: string = event.content ?? "";
         // runtime_session_id is an internal control event: persist it then skip
         // logging/publishing — it has no proto enum value and is not client-visible.
         if (event.type === "runtime_session_id") {
-          if (event.content) {
-            sessionStore.updateRuntimeSessionId(sessionId, event.content);
+          if (eventContent) {
+            sessionStore.updateRuntimeSessionId(sessionId, eventContent);
           }
           continue;
         }
@@ -256,7 +245,7 @@ export function processEventStream(
         // Intercept usage events and accumulate token counts on the session record
         if (event.type === "usage") {
           try {
-            const data = JSON.parse(event.content) as {
+            const data = JSON.parse(eventContent || "{}") as {
               input_tokens?: number;
               output_tokens?: number;
               cost_millicents?: number;
@@ -333,11 +322,11 @@ export function processEventStream(
 
         if (event.type === "status") {
           // Map runtime status strings to our session status model
-          if (event.content === "waiting_input") {
+          if (eventContent === "waiting_input") {
             sessionStore.updateSessionStatus(sessionId, SESSION_STATUS.IDLE);
-          } else if (event.content === "running") {
+          } else if (eventContent === "running") {
             sessionStore.updateSessionStatus(sessionId, SESSION_STATUS.RUNNING);
-          } else if (event.content === "completed") {
+          } else if (eventContent === "completed") {
             // Derive end reason: budget SIGTERM → BUDGET_EXCEEDED, user SIGTERM → TERMINATED, normal → COMPLETED
             const session = sessionStore.getSession(sessionId);
             const endReason = ctx.budgetSigtermSent
@@ -352,7 +341,7 @@ export function processEventStream(
               undefined,
               endReason,
             );
-          } else if (event.content === "killed") {
+          } else if (eventContent === "killed") {
             const killedEndReason = ctx.budgetSigtermSent
               ? END_REASON.BUDGET_EXCEEDED
               : END_REASON.KILLED;
@@ -363,7 +352,7 @@ export function processEventStream(
               undefined,
               killedEndReason,
             );
-          } else if (event.content === "failed") {
+          } else if (eventContent === "failed") {
             sessionStore.updateSession(
               sessionId,
               SESSION_STATUS.STOPPED,
@@ -372,7 +361,7 @@ export function processEventStream(
               END_REASON.INTERRUPTED,
             );
             cleanupLifecycleStream(sessionId);
-          } else if (event.content === "terminated") {
+          } else if (eventContent === "terminated") {
             const terminatedEndReason = ctx.budgetSigtermSent
               ? END_REASON.BUDGET_EXCEEDED
               : END_REASON.TERMINATED;
@@ -390,21 +379,21 @@ export function processEventStream(
           // unblock when a child goes idle without calling task_complete (#824).
           // publishChildCompletion internally skips waiting_input for async pipes.
           if (
-            ["completed", "killed", "failed", "terminated", "waiting_input"].includes(event.content)
+            ["completed", "killed", "failed", "terminated", "waiting_input"].includes(eventContent)
           ) {
-            await publishChildCompletion(sessionId, event.content);
+            await publishChildCompletion(sessionId, eventContent);
           }
 
           // On abnormal exit (killed/failed), write a minimal server-enriched workpad
           // if no workpad exists yet on the task.
-          if (ctx.taskId && ["killed", "failed"].includes(event.content)) {
+          if (ctx.taskId && ["killed", "failed"].includes(eventContent)) {
             try {
               const task = taskStore.getTask(ctx.taskId);
               if (task && !task.workpad) {
                 const minimalWorkpad = JSON.stringify({
-                  status: event.content,
-                  summary: `Session ended abnormally (${event.content}). No agent-reported workpad.`,
-                  extra: { endReason: event.content, sessionId },
+                  status: eventContent,
+                  summary: `Session ended abnormally (${eventContent}). No agent-reported workpad.`,
+                  extra: { endReason: eventContent, sessionId },
                 });
                 taskStore.setWorkpad(ctx.taskId, minimalWorkpad);
               }
@@ -415,10 +404,7 @@ export function processEventStream(
 
           // AHP HR1b: flush snapshot on terminal status for clean state capture
           // Guard: serverSeq is undefined when recordSessionAction() silently fails.
-          if (
-            ["completed", "killed", "failed", "terminated"].includes(event.content) &&
-            serverSeq
-          ) {
+          if (["completed", "killed", "failed", "terminated"].includes(eventContent) && serverSeq) {
             try {
               const result = stateManager.snapshot(serverSeq);
               if (result.persisted) {
@@ -435,7 +421,7 @@ export function processEventStream(
           if (
             ctx.taskId &&
             ["completed", "killed", "failed", "terminated", "running", "waiting_input"].includes(
-              event.content,
+              eventContent,
             )
           ) {
             emit("task.updated", { taskId: ctx.taskId, workspaceId: ctx.workspaceId });
@@ -481,10 +467,7 @@ export function processEventStream(
         const suspSeq = recordSessionAction(suspendedEvent);
         if (suspSeq) {
           lastServerSeq = suspSeq;
-          stateManager.processEvent(
-            makeAgentEvent(sessionId, "status", SESSION_STATUS.SUSPENDED),
-            suspSeq,
-          );
+          stateManager.processEvent(makeAgentEvent("status", SESSION_STATUS.SUSPENDED), suspSeq);
         }
         if (ctx.taskId) {
           emit("task.updated", { taskId: ctx.taskId, workspaceId: ctx.workspaceId });

--- a/packages/core/src/pipe-delivery.test.ts
+++ b/packages/core/src/pipe-delivery.test.ts
@@ -77,9 +77,10 @@ describe("pipe-delivery integration", () => {
     streamRegistry._resetForTesting();
     pipeDelivery._resetForTesting();
 
-    mockSendInput = vi.fn().mockResolvedValue({});
+    mockSendInput = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { sendInput: mockSendInput },
+      client: {},
+      transport: { dispatchInput: mockSendInput },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 
@@ -120,12 +121,12 @@ describe("pipe-delivery integration", () => {
       // Trigger child completion
       await pipeDelivery.publishChildCompletion("child", "completed");
 
-      // Verify sendInput called on parent with message containing status + child output
+      // Verify dispatchInput called on parent with message containing status + child output
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("parent");
-      expect(call.text).toContain("completed");
-      expect(call.text).toContain("Child's final output");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("parent");
+      expect(text).toContain("completed");
+      expect(text).toContain("Child's final output");
     });
   });
 
@@ -217,11 +218,11 @@ describe("pipe-delivery integration", () => {
       // Parent publishes to stream (mimics writeToFd calling streamRegistry.publish)
       streamRegistry.publish(stream.id, "parent", "Hello from parent");
 
-      // Child should receive via sendInput (listener for child session fires)
+      // Child should receive via dispatchInput (listener for child session fires)
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("child");
-      expect(call.text).toContain("Hello from parent");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("child");
+      expect(text).toContain("Hello from parent");
     });
 
     it("delivers child publish to parent via async listener", () => {
@@ -251,9 +252,9 @@ describe("pipe-delivery integration", () => {
 
       // Parent should receive
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("parent");
-      expect(call.text).toContain("Result from child");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("parent");
+      expect(text).toContain("Result from child");
     });
   });
 
@@ -286,11 +287,11 @@ describe("pipe-delivery integration", () => {
       // Child publishes to selfEcho stream
       streamRegistry.publish(stream.id, "child", "Hello from child");
 
-      // sendInput should be called exactly once — for parent, not child
+      // dispatchInput should be called exactly once — for parent, not child
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("parent");
-      expect(call.text).toContain("Hello from child");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("parent");
+      expect(text).toContain("Hello from child");
     });
   });
 
@@ -771,9 +772,10 @@ describe("pipe-delivery integration", () => {
 
       // Wait deterministically for the async replay delivery to settle
       await vi.waitFor(() => {
-        const calls = mockSendInput.mock.calls.map(
-          (c: unknown[]) => c[0] as { sessionId: string; text: string },
-        );
+        const calls = mockSendInput.mock.calls.map((c: unknown[]) => ({
+          sessionId: c[0] as string,
+          text: c[1] as string,
+        }));
         const parentCall = calls.find((c) => c.sessionId === "parent");
         expect(parentCall).toBeDefined();
         expect(parentCall!.text).toContain("Buffered message from offline window");

--- a/packages/core/src/pipe-delivery.ts
+++ b/packages/core/src/pipe-delivery.ts
@@ -9,8 +9,7 @@
  *   by the WaitForPipe consumer after it reads the message.
  */
 
-import { create } from "@bufbuild/protobuf";
-import { powerline } from "@grackle-ai/common";
+import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import { sessionStore } from "@grackle-ai/database";
 import * as adapterManager from "./adapter-manager.js";
 import * as streamRegistry from "./stream-registry.js";
@@ -63,16 +62,14 @@ export function ensureAsyncDeliveryListener(sessionId: string): void {
     const stream = streamRegistry.getStream(sub.streamId);
     const isStdin = stream?.name.startsWith("stdin:");
     const text = isStdin ? msg.content : `[fd:${sub.fd}] ${msg.content}`;
-    return conn.client
-      .sendInput(create(powerline.InputMessageSchema, { sessionId, text }))
-      .then(() => {})
-      .catch((err: unknown) => {
-        logger.warn(
-          { err, sessionId },
-          "Async pipe delivery: sendInput failed — message left undelivered",
-        );
-        throw err;
-      });
+    const transport = new GrpcHostTransport(conn.client);
+    return transport.dispatchInput(sessionId, text).catch((err: unknown) => {
+      logger.warn(
+        { err, sessionId },
+        "Async pipe delivery: dispatchInput failed — message left undelivered",
+      );
+      throw err;
+    });
   });
 
   asyncListenerCleanups.set(sessionId, unsubscribe);

--- a/packages/core/src/pipe-delivery.ts
+++ b/packages/core/src/pipe-delivery.ts
@@ -9,7 +9,6 @@
  *   by the WaitForPipe consumer after it reads the message.
  */
 
-import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import { sessionStore } from "@grackle-ai/database";
 import * as adapterManager from "./adapter-manager.js";
 import * as streamRegistry from "./stream-registry.js";
@@ -62,8 +61,7 @@ export function ensureAsyncDeliveryListener(sessionId: string): void {
     const stream = streamRegistry.getStream(sub.streamId);
     const isStdin = stream?.name.startsWith("stdin:");
     const text = isStdin ? msg.content : `[fd:${sub.fd}] ${msg.content}`;
-    const transport = new GrpcHostTransport(conn.client);
-    return transport.dispatchInput(sessionId, text).catch((err: unknown) => {
+    return conn.transport.dispatchInput(sessionId, text).catch((err: unknown) => {
       logger.warn(
         { err, sessionId },
         "Async pipe delivery: dispatchInput failed — message left undelivered",

--- a/packages/core/src/reanimate-agent.test.ts
+++ b/packages/core/src/reanimate-agent.test.ts
@@ -130,11 +130,12 @@ describe("reanimateAgent — pipe stream reconstruction", () => {
     streamRegistry._resetForTesting();
     pipeDelivery._resetForTesting();
 
-    mockSendInput = vi.fn().mockResolvedValue({});
+    mockSendInput = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: {
-        sendInput: mockSendInput,
-        resume: vi.fn(() => (async function* () {})()),
+      client: {},
+      transport: {
+        dispatchInput: mockSendInput,
+        reanimate: vi.fn(() => (async function* () {})()),
       },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
@@ -189,9 +190,9 @@ describe("reanimateAgent — pipe stream reconstruction", () => {
     streamRegistry.publish(pipeStream.id, "child", "Hello from child post-reanimate");
 
     expect(mockSendInput).toHaveBeenCalledOnce();
-    const call = mockSendInput.mock.calls[0][0] as { sessionId: string; text: string };
-    expect(call.sessionId).toBe("parent");
-    expect(call.text).toContain("Hello from child post-reanimate");
+    const [sessionUri, text] = mockSendInput.mock.calls[0] as [string, string];
+    expect(sessionUri).toBe("parent");
+    expect(text).toContain("Hello from child post-reanimate");
   });
 
   it("reconstructs pipe streams for active async-piped children when parent is reanimated", () => {
@@ -244,9 +245,10 @@ describe("reanimateAgent — pipe stream reconstruction", () => {
 
     // Replay delivers the buffered message via sendInput
     await vi.waitFor(() => {
-      const calls = mockSendInput.mock.calls.map(
-        (c: unknown[]) => c[0] as { sessionId: string; text: string },
-      );
+      const calls = mockSendInput.mock.calls.map((c: unknown[]) => ({
+        sessionId: c[0] as string,
+        text: c[1] as string,
+      }));
       const parentCall = calls.find((c) => c.sessionId === "parent");
       expect(parentCall).toBeDefined();
       expect(parentCall!.text).toContain("Message sent while offline");
@@ -326,9 +328,9 @@ describe("reanimateAgent — pipe stream reconstruction", () => {
     streamRegistry.publish(pipeStream.id, "child", "Sync child result after reanimate");
 
     expect(mockSendInput).toHaveBeenCalledOnce();
-    const call = mockSendInput.mock.calls[0][0] as { sessionId: string; text: string };
-    expect(call.sessionId).toBe("parent");
-    expect(call.text).toContain("Sync child result after reanimate");
+    const [sessionUri, text] = mockSendInput.mock.calls[0] as [string, string];
+    expect(sessionUri).toBe("parent");
+    expect(text).toContain("Sync child result after reanimate");
   });
 
   it("reconstructs pipe streams for active sync-piped children when parent is reanimated", () => {

--- a/packages/core/src/reanimate-agent.ts
+++ b/packages/core/src/reanimate-agent.ts
@@ -1,6 +1,6 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { SESSION_STATUS, LOGS_DIR } from "@grackle-ai/common";
-import { GrpcHostTransport, type ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
+import { type ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
 import { join } from "node:path";
 import { sessionStore, taskStore, grackleHome } from "@grackle-ai/database";
 import type { SessionRow } from "@grackle-ai/database";
@@ -78,10 +78,9 @@ export function reanimateAgent(sessionId: string): SessionRow {
 
   // Initiate the stream before mutating the DB. If reanimate() throws synchronously
   // the DB is never touched, so no rollback is needed.
-  const transport = new GrpcHostTransport(conn.client);
   let resumeStream: AsyncIterable<ServerActionEnvelope>;
   try {
-    resumeStream = transport.reanimate({
+    resumeStream = conn.transport.reanimate({
       sessionId: session.id,
       runtimeSessionId: session.runtimeSessionId,
       runtime: session.runtime,

--- a/packages/core/src/reanimate-agent.ts
+++ b/packages/core/src/reanimate-agent.ts
@@ -1,6 +1,6 @@
 import { ConnectError, Code } from "@connectrpc/connect";
-import { create } from "@bufbuild/protobuf";
-import { powerline, SESSION_STATUS, LOGS_DIR } from "@grackle-ai/common";
+import { SESSION_STATUS, LOGS_DIR } from "@grackle-ai/common";
+import { GrpcHostTransport, type ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
 import { join } from "node:path";
 import { sessionStore, taskStore, grackleHome } from "@grackle-ai/database";
 import type { SessionRow } from "@grackle-ai/database";
@@ -64,12 +64,6 @@ export function reanimateAgent(sessionId: string): SessionRow {
     );
   }
 
-  const powerlineReq = create(powerline.ResumeRequestSchema, {
-    sessionId: session.id,
-    runtimeSessionId: session.runtimeSessionId,
-    runtime: session.runtime,
-  });
-
   const logPath = session.logPath || join(grackleHome, LOGS_DIR, session.id);
 
   let workspaceId: string | undefined;
@@ -82,11 +76,16 @@ export function reanimateAgent(sessionId: string): SessionRow {
     }
   }
 
-  // Initiate the stream before mutating the DB. If resume() throws synchronously
+  // Initiate the stream before mutating the DB. If reanimate() throws synchronously
   // the DB is never touched, so no rollback is needed.
-  let resumeStream: ReturnType<typeof conn.client.resume>;
+  const transport = new GrpcHostTransport(conn.client);
+  let resumeStream: AsyncIterable<ServerActionEnvelope>;
   try {
-    resumeStream = conn.client.resume(powerlineReq);
+    resumeStream = transport.reanimate({
+      sessionId: session.id,
+      runtimeSessionId: session.runtimeSessionId,
+      runtime: session.runtime,
+    });
   } catch (err) {
     throw new ConnectError(`Failed to initiate resume stream: ${String(err)}`, Code.Internal);
   }

--- a/packages/core/src/session-recovery.test.ts
+++ b/packages/core/src/session-recovery.test.ts
@@ -150,26 +150,32 @@ function makeConnection(
     toolCallId?: string;
   }> = [],
 ): PowerLineConnection {
-  return {
-    client: {
-      drainBufferedEvents: vi.fn(() =>
-        (async function* () {
-          for (const event of drainEvents) {
-            yield {
-              sessionId: "",
+  const transport = {
+    drainBuffered: vi.fn((_uri: string) =>
+      (async function* () {
+        for (const event of drainEvents) {
+          yield {
+            event: {
               type: event.type,
               timestamp: event.timestamp,
               content: event.content,
               raw: "",
               toolCallId: event.toolCallId ?? "",
-            };
-          }
-        })(),
-      ),
-      resume: vi.fn(() => (async function* () {})()),
-    },
+              turnId: "",
+              diagnostic: false,
+            },
+            actions: [],
+          };
+        }
+      })(),
+    ),
+    reanimate: vi.fn(() => (async function* () {})()),
+  };
+  return {
+    client: {} as PowerLineConnection["client"],
     environmentId: "env1",
     port: 7433,
+    transport,
   } as unknown as PowerLineConnection;
 }
 
@@ -303,8 +309,11 @@ describe("session recovery", () => {
 
     // Simulate: another session is spawned on env1 during the async drain window
     const conn = {
-      client: {
-        drainBufferedEvents: vi.fn(() =>
+      client: {} as PowerLineConnection["client"],
+      environmentId: "env1",
+      port: 7433,
+      transport: {
+        drainBuffered: vi.fn(() =>
           (async function* () {
             // Mid-drain, a new session appears on the same environment
             sessionStore.createSession(
@@ -319,8 +328,6 @@ describe("session recovery", () => {
           })(),
         ),
       },
-      environmentId: "env1",
-      port: 7433,
     } as unknown as PowerLineConnection;
 
     await recoverSuspendedSessions("env1", conn);
@@ -359,15 +366,16 @@ describe("session recovery", () => {
     sessionStore.suspendSession("sess1");
 
     const conn = {
-      client: {
-        drainBufferedEvents: vi.fn(() =>
+      client: {} as PowerLineConnection["client"],
+      environmentId: "env1",
+      port: 7433,
+      transport: {
+        drainBuffered: vi.fn(() =>
           (async function* () {
             throw new Error("transport error mid-drain");
           })(),
         ),
       },
-      environmentId: "env1",
-      port: 7433,
     } as unknown as PowerLineConnection;
 
     await recoverSuspendedSessions("env1", conn);

--- a/packages/core/src/session-recovery.test.ts
+++ b/packages/core/src/session-recovery.test.ts
@@ -202,7 +202,7 @@ describe("session recovery", () => {
     await recoverSuspendedSessions("env1", conn);
 
     // Drain should have been called
-    expect(conn.client.drainBufferedEvents).toHaveBeenCalled();
+    expect(conn.transport.drainBuffered).toHaveBeenCalled();
     // Events should have been written to log
     expect(logWriter.writeEvent).toHaveBeenCalled();
     // Log stream should be closed
@@ -236,7 +236,7 @@ describe("session recovery", () => {
 
     await recoverSuspendedSessions("env1", conn);
 
-    expect(conn.client.drainBufferedEvents).toHaveBeenCalled();
+    expect(conn.transport.drainBuffered).toHaveBeenCalled();
     expect(logWriter.writeEvent).not.toHaveBeenCalled();
     expect(reanimateAgent).toHaveBeenCalledWith("sess1");
   });
@@ -262,7 +262,7 @@ describe("session recovery", () => {
     const conn = makeConnection([]);
     await recoverSuspendedSessions("env1", conn);
 
-    expect(conn.client.drainBufferedEvents).not.toHaveBeenCalled();
+    expect(conn.transport.drainBuffered).not.toHaveBeenCalled();
     expect(reanimateAgent).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/session-recovery.ts
+++ b/packages/core/src/session-recovery.ts
@@ -75,14 +75,17 @@ export async function recoverSuspendedSessions(
           if (eventType === grackle.EventType.UNSPECIFIED) {
             continue;
           }
+          // Normalize AgentEventFields to proto-default semantics ("" for
+          // string fields) so the persisted SessionEvent / JSONL row never
+          // has missing keys regardless of what the transport emits.
           const sessionEvent = create(grackle.SessionEventSchema, {
             sessionId: session.id,
             type: eventType,
-            timestamp: event.timestamp,
-            content: event.content,
-            raw: event.raw,
-            toolCallId: event.toolCallId,
-            turnId: event.turnId,
+            timestamp: event.timestamp ?? "",
+            content: event.content ?? "",
+            raw: event.raw ?? "",
+            toolCallId: event.toolCallId ?? "",
+            turnId: event.turnId ?? "",
           });
           await logWriter.writeEvent(logPath, sessionEvent);
           drainedCount++;

--- a/packages/core/src/session-recovery.ts
+++ b/packages/core/src/session-recovery.ts
@@ -1,14 +1,7 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
-import {
-  grackle,
-  powerline,
-  eventTypeToEnum,
-  SESSION_STATUS,
-  LOGS_DIR,
-  END_REASON,
-} from "@grackle-ai/common";
-import type { PowerLineConnection } from "@grackle-ai/adapter-sdk";
+import { grackle, eventTypeToEnum, SESSION_STATUS, LOGS_DIR, END_REASON } from "@grackle-ai/common";
+import { GrpcHostTransport, type PowerLineConnection } from "@grackle-ai/adapter-sdk";
 import { join } from "node:path";
 import { sessionStore, taskStore, grackleHome } from "@grackle-ai/database";
 import * as logWriter from "./log-writer.js";
@@ -68,16 +61,15 @@ export async function recoverSuspendedSessions(
     try {
       // Step 1: Drain buffered events from PowerLine and append to JSONL
       const logPath = session.logPath || join(grackleHome, LOGS_DIR, session.id);
-      const drainReq = create(powerline.DrainRequestSchema, {
-        sessionId: session.id,
-      });
+      const transport = new GrpcHostTransport(connection.client);
 
       let drainedCount = 0;
       try {
-        const drainStream = connection.client.drainBufferedEvents(drainReq);
+        const drainStream = transport.subscribe(session.id);
         logWriter.ensureLogInitialized(logPath);
 
-        for await (const event of drainStream) {
+        for await (const envelope of drainStream) {
+          const event = envelope.event;
           // Skip internal events (e.g. runtime_session_id) that would map
           // to UNSPECIFIED — those are handled by processEventStream, not the drain.
           const eventType = eventTypeToEnum(event.type);

--- a/packages/core/src/session-recovery.ts
+++ b/packages/core/src/session-recovery.ts
@@ -1,7 +1,7 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle, eventTypeToEnum, SESSION_STATUS, LOGS_DIR, END_REASON } from "@grackle-ai/common";
-import { GrpcHostTransport, type PowerLineConnection } from "@grackle-ai/adapter-sdk";
+import { type PowerLineConnection } from "@grackle-ai/adapter-sdk";
 import { join } from "node:path";
 import { sessionStore, taskStore, grackleHome } from "@grackle-ai/database";
 import * as logWriter from "./log-writer.js";
@@ -61,11 +61,10 @@ export async function recoverSuspendedSessions(
     try {
       // Step 1: Drain buffered events from PowerLine and append to JSONL
       const logPath = session.logPath || join(grackleHome, LOGS_DIR, session.id);
-      const transport = new GrpcHostTransport(connection.client);
 
       let drainedCount = 0;
       try {
-        const drainStream = transport.subscribe(session.id);
+        const drainStream = connection.transport.drainBuffered(session.id);
         logWriter.ensureLogInitialized(logPath);
 
         for await (const envelope of drainStream) {

--- a/packages/core/src/signals/signal-delivery.test.ts
+++ b/packages/core/src/signals/signal-delivery.test.ts
@@ -45,11 +45,12 @@ import { deliverSignalToTask, sendInputToSession } from "./signal-delivery.js";
 
 // ── Helpers ──────────────────────────────────────────────────
 
-function makeMockConnection(sendInputMock = vi.fn().mockResolvedValue({})) {
+function makeMockConnection(dispatchInputMock = vi.fn().mockResolvedValue(undefined)) {
   return {
-    client: { sendInput: sendInputMock },
+    client: {},
     environmentId: "env-1",
     port: 7433,
+    transport: { dispatchInput: dispatchInputMock },
   };
 }
 
@@ -108,7 +109,7 @@ describe("deliverSignalToTask", () => {
     const result = await deliverSignalToTask("task-child", "sigchld", "[SIGCHLD] test");
 
     expect(result).toBe(true);
-    expect(mockConn.client.sendInput).toHaveBeenCalledOnce();
+    expect(mockConn.transport.dispatchInput).toHaveBeenCalledOnce();
     expect(adapterManager.getConnection).toHaveBeenCalledWith("env-1");
 
     // Verify the event published to streamHub uses EVENT_TYPE_SIGNAL, not USER_INPUT
@@ -168,7 +169,7 @@ describe("deliverSignalToTask", () => {
     const result = await deliverSignalToTask("task-parent", "sigchld", "[SIGCHLD] test");
 
     expect(result).toBe(true);
-    expect(mockConn.client.sendInput).toHaveBeenCalledOnce();
+    expect(mockConn.transport.dispatchInput).toHaveBeenCalledOnce();
   });
 
   it("reanimates dead session, waits for IDLE, then delivers", async () => {
@@ -220,7 +221,7 @@ describe("deliverSignalToTask", () => {
 
     expect(reanimateAgent).toHaveBeenCalledWith("sess-dead");
     expect(result).toBe(true);
-    expect(mockConn.client.sendInput).toHaveBeenCalledOnce();
+    expect(mockConn.transport.dispatchInput).toHaveBeenCalledOnce();
   });
 
   it("returns false when no sessions exist (logs warning)", async () => {
@@ -303,7 +304,7 @@ describe("sendInputToSession", () => {
     const result = await sendInputToSession("sess-1", "env-1", "[SIGTERM] stop", "sigterm");
 
     expect(result).toBe(true);
-    expect(mockConn.client.sendInput).toHaveBeenCalledOnce();
+    expect(mockConn.transport.dispatchInput).toHaveBeenCalledOnce();
     expect(streamHub.publish).toHaveBeenCalledWith(
       expect.objectContaining({
         type: grackle.EventType.SIGNAL,

--- a/packages/core/src/signals/signal-delivery.ts
+++ b/packages/core/src/signals/signal-delivery.ts
@@ -1,6 +1,5 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, SESSION_STATUS, END_REASON } from "@grackle-ai/common";
-import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import { sessionStore } from "@grackle-ai/database";
 import * as adapterManager from "../adapter-manager.js";
 import { reanimateAgent } from "../reanimate-agent.js";
@@ -141,8 +140,7 @@ export async function sendInputToSession(
     streamHub.publish(signalEvent);
     recordSessionAction(signalEvent);
 
-    const transport = new GrpcHostTransport(conn.client);
-    await transport.dispatchInput(sessionId, text);
+    await conn.transport.dispatchInput(sessionId, text);
     logger.info({ sessionId, signalType }, "Signal delivered to session");
     return true;
   } catch (err) {

--- a/packages/core/src/signals/signal-delivery.ts
+++ b/packages/core/src/signals/signal-delivery.ts
@@ -1,5 +1,6 @@
 import { create } from "@bufbuild/protobuf";
-import { grackle, powerline, SESSION_STATUS, END_REASON } from "@grackle-ai/common";
+import { grackle, SESSION_STATUS, END_REASON } from "@grackle-ai/common";
+import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import { sessionStore } from "@grackle-ai/database";
 import * as adapterManager from "../adapter-manager.js";
 import { reanimateAgent } from "../reanimate-agent.js";
@@ -140,7 +141,8 @@ export async function sendInputToSession(
     streamHub.publish(signalEvent);
     recordSessionAction(signalEvent);
 
-    await conn.client.sendInput(create(powerline.InputMessageSchema, { sessionId, text }));
+    const transport = new GrpcHostTransport(conn.client);
+    await transport.dispatchInput(sessionId, text);
     logger.info({ sessionId, signalType }, "Signal delivered to session");
     return true;
   } catch (err) {

--- a/packages/core/src/stdin-delivery.test.ts
+++ b/packages/core/src/stdin-delivery.test.ts
@@ -77,9 +77,10 @@ describe("stdin-delivery", () => {
     streamRegistry._resetForTesting();
     pipeDelivery._resetForTesting();
 
-    mockSendInput = vi.fn().mockResolvedValue({});
+    mockSendInput = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { sendInput: mockSendInput },
+      client: {},
+      transport: { dispatchInput: mockSendInput },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 
@@ -183,11 +184,11 @@ describe("stdin-delivery", () => {
       publishToStdin("session-1", "hello from user");
 
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("session-1");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("session-1");
       // Should be plain text — NO [fd:N] prefix
-      expect(call.text).toBe("hello from user");
-      expect(call.text).not.toContain("[fd:");
+      expect(text).toBe("hello from user");
+      expect(text).not.toContain("[fd:");
     });
   });
 
@@ -207,8 +208,8 @@ describe("stdin-delivery", () => {
 
       publishToStdin("session-1", "user input");
 
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.text).toBe("user input");
+      const [, text] = mockSendInput.mock.calls[0];
+      expect(text).toBe("user input");
     });
 
     it("pipe messages still arrive with [fd:N] prefix", () => {
@@ -235,10 +236,10 @@ describe("stdin-delivery", () => {
       streamRegistry.publish(pipeStream.id, "parent", "instruction from parent");
 
       expect(mockSendInput).toHaveBeenCalledOnce();
-      const call = mockSendInput.mock.calls[0][0];
-      expect(call.sessionId).toBe("child");
-      expect(call.text).toContain("[fd:");
-      expect(call.text).toContain("instruction from parent");
+      const [sessionUri, text] = mockSendInput.mock.calls[0];
+      expect(sessionUri).toBe("child");
+      expect(text).toContain("[fd:");
+      expect(text).toContain("instruction from parent");
     });
 
     it("both stdin and pipe can coexist on the same session", () => {
@@ -269,7 +270,7 @@ describe("stdin-delivery", () => {
       publishToStdin("child", "stdin message");
 
       expect(mockSendInput).toHaveBeenCalledTimes(1);
-      expect(mockSendInput.mock.calls[0][0].text).toBe("stdin message");
+      expect(mockSendInput.mock.calls[0][1]).toBe("stdin message");
 
       mockSendInput.mockClear();
 
@@ -277,8 +278,8 @@ describe("stdin-delivery", () => {
       streamRegistry.publish(pipeStream.id, "parent", "pipe message");
 
       expect(mockSendInput).toHaveBeenCalledTimes(1);
-      expect(mockSendInput.mock.calls[0][0].text).toContain("[fd:");
-      expect(mockSendInput.mock.calls[0][0].text).toContain("pipe message");
+      expect(mockSendInput.mock.calls[0][1]).toContain("[fd:");
+      expect(mockSendInput.mock.calls[0][1]).toContain("pipe message");
     });
   });
 

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -9,7 +9,6 @@
  * @module
  */
 
-import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import {
   envRegistry,
   sessionStore,
@@ -200,8 +199,7 @@ export async function startTaskSession(
 
   const useWorktrees = workspace?.useWorktrees ?? false;
 
-  const transport = new GrpcHostTransport(conn.client);
-  const { stream } = transport.createSession({
+  const { stream } = conn.transport.createSession({
     sessionId,
     runtime,
     prompt: taskPrompt,

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -9,8 +9,7 @@
  * @module
  */
 
-import { create } from "@bufbuild/protobuf";
-import { powerline } from "@grackle-ai/common";
+import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import {
   envRegistry,
   sessionStore,
@@ -201,7 +200,8 @@ export async function startTaskSession(
 
   const useWorktrees = workspace?.useWorktrees ?? false;
 
-  const powerlineReq = create(powerline.SpawnRequestSchema, {
+  const transport = new GrpcHostTransport(conn.client);
+  const { stream } = transport.createSession({
     sessionId,
     runtime,
     prompt: taskPrompt,
@@ -223,7 +223,7 @@ export async function startTaskSession(
     mcpToken,
   });
 
-  processEventStream(conn.client.spawn(powerlineReq), {
+  processEventStream(stream, {
     sessionId,
     logPath,
     workspaceId: freshTask.workspaceId ?? undefined,

--- a/packages/core/src/token-push.test.ts
+++ b/packages/core/src/token-push.test.ts
@@ -35,14 +35,16 @@ function tok(name: string, type: string, envVar: string): TokenItemLike {
 }
 
 function mockConn(): {
-  client: { authenticate: ReturnType<typeof vi.fn> };
+  client: object;
   environmentId: string;
   port: number;
+  transport: { authenticate: ReturnType<typeof vi.fn> };
 } {
   return {
-    client: { authenticate: vi.fn().mockResolvedValue({}) },
+    client: {},
     environmentId: "env-1",
     port: 7433,
+    transport: { authenticate: vi.fn().mockResolvedValue(undefined) },
   };
 }
 
@@ -70,8 +72,8 @@ describe("authenticateForRuntime", () => {
 
     await authenticateForRuntime("env-1", "claude-code");
 
-    expect(conn.client.authenticate).toHaveBeenCalledTimes(1);
-    const arg = conn.client.authenticate.mock.calls[0][0] as {
+    expect(conn.transport.authenticate).toHaveBeenCalledTimes(1);
+    const arg = conn.transport.authenticate.mock.calls[0][0] as {
       provider: string;
       tokens: TokenItemLike[];
     };
@@ -89,7 +91,7 @@ describe("authenticateForRuntime", () => {
 
     await authenticateForRuntime("env-1", "claude-code", { excludeFileTokens: true });
 
-    const arg = conn.client.authenticate.mock.calls[0][0] as { tokens: TokenItemLike[] };
+    const arg = conn.transport.authenticate.mock.calls[0][0] as { tokens: TokenItemLike[] };
     expect(arg.tokens.map((t) => t.name)).toEqual(["e"]);
   });
 
@@ -97,12 +99,12 @@ describe("authenticateForRuntime", () => {
     const conn = mockConn();
     vi.mocked(adapterManager.getConnection).mockReturnValue(conn as never);
     await authenticateForRuntime("env-1", "claude-code");
-    expect(conn.client.authenticate).not.toHaveBeenCalled();
+    expect(conn.transport.authenticate).not.toHaveBeenCalled();
   });
 
   it("swallows delivery errors (best-effort, never throws)", async () => {
     const conn = mockConn();
-    conn.client.authenticate.mockRejectedValue(new Error("boom"));
+    conn.transport.authenticate.mockRejectedValue(new Error("boom"));
     vi.mocked(adapterManager.getConnection).mockReturnValue(conn as never);
     vi.mocked(tokenStore.getBundle).mockReturnValue({
       tokens: [tok("e", "env_var", "E")],

--- a/packages/core/src/token-push.ts
+++ b/packages/core/src/token-push.ts
@@ -11,8 +11,7 @@
  * Pure persistence lives in `@grackle-ai/database` (tokenStore); credential
  * bundle building lives in {@link ./credential-bundle.ts}.
  */
-import { create } from "@bufbuild/protobuf";
-import { powerline } from "@grackle-ai/common";
+import { GrpcHostTransport, type AuthenticateTokenItem } from "@grackle-ai/adapter-sdk";
 import * as adapterManager from "./adapter-manager.js";
 import { envRegistry, tokenStore } from "@grackle-ai/database";
 import { buildProviderTokenBundle } from "./credential-bundle.js";
@@ -27,8 +26,9 @@ export interface AuthenticateOptions {
 /**
  * Supply credentials for a runtime to its environment on demand, just before a
  * spawn. Combines stored user tokens with the runtime-scoped provider bundle
- * (read fresh from env/disk) and delivers them via the PowerLine `authenticate`
- * RPC. Best-effort: failures are logged and do not block the spawn.
+ * (read fresh from env/disk) and delivers them via the host transport's
+ * `authenticate` method. Best-effort: failures are logged and do not block the
+ * spawn.
  */
 export async function authenticateForRuntime(
   environmentId: string,
@@ -46,18 +46,25 @@ export async function authenticateForRuntime(
   const stored = tokenStore.getBundle();
   const provider = await buildProviderTokenBundle(runtime, undefined, githubAccountId);
   // Provider credentials come last so they win over any same-target stored token.
-  let tokens = [...stored.tokens, ...provider.tokens];
+  let combined = [...stored.tokens, ...provider.tokens];
   if (options?.excludeFileTokens) {
-    tokens = tokens.filter((t) => t.type !== "file");
+    combined = combined.filter((t) => t.type !== "file");
   }
-  if (tokens.length === 0) {
+  if (combined.length === 0) {
     return;
   }
 
+  const tokens: AuthenticateTokenItem[] = combined.map((t) => ({
+    name: t.name,
+    type: t.type,
+    envVar: t.envVar,
+    filePath: t.filePath,
+    value: t.value,
+  }));
+
   try {
-    await conn.client.authenticate(
-      create(powerline.AuthenticateRequestSchema, { provider: runtime, tokens }),
-    );
+    const transport = new GrpcHostTransport(conn.client);
+    await transport.authenticate({ provider: runtime, tokens });
   } catch (err) {
     logger.warn({ environmentId, runtime, err }, "Failed to authenticate credentials before spawn");
   }

--- a/packages/core/src/token-push.ts
+++ b/packages/core/src/token-push.ts
@@ -11,7 +11,7 @@
  * Pure persistence lives in `@grackle-ai/database` (tokenStore); credential
  * bundle building lives in {@link ./credential-bundle.ts}.
  */
-import { GrpcHostTransport, type AuthenticateTokenItem } from "@grackle-ai/adapter-sdk";
+import { type AuthenticateTokenItem } from "@grackle-ai/adapter-sdk";
 import * as adapterManager from "./adapter-manager.js";
 import { envRegistry, tokenStore } from "@grackle-ai/database";
 import { buildProviderTokenBundle } from "./credential-bundle.js";
@@ -63,8 +63,7 @@ export async function authenticateForRuntime(
   }));
 
   try {
-    const transport = new GrpcHostTransport(conn.client);
-    await transport.authenticate({ provider: runtime, tokens });
+    await conn.transport.authenticate({ provider: runtime, tokens });
   } catch (err) {
     logger.warn({ environmentId, runtime, err }, "Failed to authenticate credentials before spawn");
   }

--- a/packages/plugin-core/src/grpc-kill-agent.test.ts
+++ b/packages/plugin-core/src/grpc-kill-agent.test.ts
@@ -159,11 +159,15 @@ const ACTIVE_SESSION = {
   sigtermSentAt: null,
 };
 
-function makeMockConnection(killMock = vi.fn().mockResolvedValue({})) {
+function makeMockConnection(killMock = vi.fn().mockResolvedValue(undefined)) {
   return {
-    client: { kill: killMock, sendInput: vi.fn().mockResolvedValue({}) },
+    client: {},
     environmentId: "env-1",
     port: 7433,
+    transport: {
+      dispose: killMock,
+      dispatchInput: vi.fn().mockResolvedValue(undefined),
+    },
   };
 }
 

--- a/packages/plugin-core/src/grpc-resume.test.ts
+++ b/packages/plugin-core/src/grpc-resume.test.ts
@@ -152,8 +152,9 @@ function makeSession(
 /** Build a mock adapter connection with a resumable client. */
 function makeConnection() {
   return {
-    client: {
-      resume: vi.fn(() => (async function* () {})()),
+    client: {},
+    transport: {
+      reanimate: vi.fn(() => (async function* () {})()),
     },
   };
 }

--- a/packages/plugin-core/src/grpc-send-input.test.ts
+++ b/packages/plugin-core/src/grpc-send-input.test.ts
@@ -202,7 +202,8 @@ describe("gRPC sendInput", () => {
       personaId: "",
     });
     vi.mocked(adapterManager.getConnection).mockReturnValue({
-      client: { sendInput: vi.fn().mockResolvedValue({}) } as never,
+      client: {},
+      transport: { dispatchInput: vi.fn().mockResolvedValue(undefined) },
     } as never);
 
     const result = await handlers.sendInput({

--- a/packages/plugin-core/src/grpc-shared.ts
+++ b/packages/plugin-core/src/grpc-shared.ts
@@ -10,7 +10,7 @@
  */
 
 import { create } from "@bufbuild/protobuf";
-import { grackle, powerline } from "@grackle-ai/common";
+import { grackle } from "@grackle-ai/common";
 import {
   ROOT_TASK_ID,
   SESSION_STATUS,
@@ -75,14 +75,12 @@ export function killSessionAndCleanup(session: SessionRow): void {
   // after subscription cleanup — this ensures immediate process termination.
   const conn = adapterManager.getConnection(session.environmentId);
   if (conn) {
-    conn.client
-      .kill(create(powerline.KillRequestSchema, { id: session.id, reason: END_REASON.KILLED }))
-      .catch((err: unknown) => {
-        logger.debug(
-          { err, sessionId: session.id },
-          "PowerLine kill failed (process may have already exited)",
-        );
-      });
+    conn.transport.dispose(session.id, END_REASON.KILLED).catch((err: unknown) => {
+      logger.debug(
+        { err, sessionId: session.id },
+        "Host transport dispose failed (process may have already exited)",
+      );
+    });
   }
 
   // Transfer ALL pipe fds to grandparent BEFORE cleaning up subscriptions.

--- a/packages/plugin-core/src/lifecycle.test.ts
+++ b/packages/plugin-core/src/lifecycle.test.ts
@@ -94,7 +94,8 @@ describe("lifecycle manager", () => {
 
     mockKill = vi.fn().mockResolvedValue({});
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { kill: mockKill },
+      client: {},
+      transport: { dispose: mockKill },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 
@@ -230,7 +231,8 @@ describe("SIGTERM end reason derivation", () => {
 
     mockKill = vi.fn().mockResolvedValue({});
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { kill: mockKill },
+      client: {},
+      transport: { dispose: mockKill },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 
@@ -325,7 +327,8 @@ describe("ensureLifecycleStream", () => {
 
     mockKill = vi.fn().mockResolvedValue({});
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { kill: mockKill },
+      client: {},
+      transport: { dispose: mockKill },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 
@@ -436,7 +439,8 @@ describe("auto-reanimate on subscribe", () => {
       })(),
     );
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { kill: mockKill, resume: mockResume },
+      client: {},
+      transport: { dispose: mockKill, reanimate: mockResume },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
   });
 

--- a/packages/plugin-core/src/lifecycle.ts
+++ b/packages/plugin-core/src/lifecycle.ts
@@ -13,13 +13,7 @@
  */
 
 import { create } from "@bufbuild/protobuf";
-import {
-  grackle,
-  SESSION_STATUS,
-  TERMINAL_SESSION_STATUSES,
-  END_REASON,
-  powerline,
-} from "@grackle-ai/common";
+import { grackle, SESSION_STATUS, TERMINAL_SESSION_STATUSES, END_REASON } from "@grackle-ai/common";
 import type { SessionStatus, EndReason } from "@grackle-ai/common";
 import { sessionStore, taskStore } from "@grackle-ai/database";
 import {
@@ -71,14 +65,12 @@ export function createLifecycleSubscriber(ctx: PluginContext): Disposable {
       } else {
         reason = END_REASON.KILLED;
       }
-      conn.client
-        .kill(create(powerline.KillRequestSchema, { id: sessionId, reason }))
-        .catch((err: unknown) => {
-          logger.debug(
-            { err, sessionId },
-            "Lifecycle: PowerLine kill failed (process may have already exited)",
-          );
-        });
+      conn.transport.dispose(sessionId, reason).catch((err: unknown) => {
+        logger.debug(
+          { err, sessionId },
+          "Lifecycle: host transport dispose failed (process may have already exited)",
+        );
+      });
     }
 
     // Skip status change and broadcast if already terminal (killAgent already handled it)

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -20,7 +20,7 @@ import {
 } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
-import { reconnectOrProvision, GrpcHostTransport } from "@grackle-ai/adapter-sdk";
+import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import { adapterManager } from "@grackle-ai/core";
 import { streamHub } from "@grackle-ai/core";
 import { tokenPush } from "@grackle-ai/core";
@@ -270,8 +270,7 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
     env.adapterType === "local" ? { excludeFileTokens: true } : undefined,
   );
 
-  const transport = new GrpcHostTransport(conn.client);
-  const { stream } = transport.createSession(createParams);
+  const { stream } = conn.transport.createSession(createParams);
   processEventStream(stream, {
     sessionId,
     logPath,

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -20,7 +20,7 @@ import {
 } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
-import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
+import { reconnectOrProvision, GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import { adapterManager } from "@grackle-ai/core";
 import { streamHub } from "@grackle-ai/core";
 import { tokenPush } from "@grackle-ai/core";
@@ -42,7 +42,7 @@ import { deliverPendingEscalations } from "@grackle-ai/core";
 import { createEventStream } from "@grackle-ai/core";
 import { sessionRowToProto } from "./grpc-proto-converters.js";
 import { validatePipeInputs, toDialableHost, killSessionAndCleanup } from "./grpc-shared.js";
-import { resolveSpawnSelection, buildPowerlineSpawnRequest } from "./spawn-request.js";
+import { resolveSpawnSelection, buildCreateSessionParams } from "./spawn-request.js";
 import { personaMcpServersToJson } from "@grackle-ai/core";
 import { getTraceId } from "@grackle-ai/core";
 import { resolveBootstrapRuntime } from "@grackle-ai/core";
@@ -210,7 +210,7 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
       process.env.GRACKLE_WORKTREE_BASE ||
       "/workspace"
     : "";
-  const powerlineReq = buildPowerlineSpawnRequest({
+  const createParams = buildCreateSessionParams({
     sessionId,
     runtime,
     model,
@@ -270,7 +270,9 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
     env.adapterType === "local" ? { excludeFileTokens: true } : undefined,
   );
 
-  processEventStream(conn.client.spawn(powerlineReq), {
+  const transport = new GrpcHostTransport(conn.client);
+  const { stream } = transport.createSession(createParams);
+  processEventStream(stream, {
     sessionId,
     logPath,
     systemContext,

--- a/packages/plugin-core/src/spawn-request.test.ts
+++ b/packages/plugin-core/src/spawn-request.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import { resolveSpawnSelection, buildPowerlineSpawnRequest } from "./spawn-request.js";
+import { resolveSpawnSelection, buildCreateSessionParams } from "./spawn-request.js";
 
 const persona = { runtime: "claude-code", model: "sonnet" };
 
@@ -55,14 +55,14 @@ describe("resolveSpawnSelection", () => {
   });
 });
 
-describe("buildPowerlineSpawnRequest", () => {
+describe("buildCreateSessionParams", () => {
   it("plumbs task_id from config (no longer hardcoded empty)", () => {
     const config = create(grackle.SessionConfigSchema, {
       taskId: "task-42",
       branch: "feat",
       pipe: "async",
     });
-    const req = buildPowerlineSpawnRequest({ ...serverInputs, config });
+    const req = buildCreateSessionParams({ ...serverInputs, config });
 
     expect(req.taskId).toBe("task-42");
     expect(req.branch).toBe("feat");
@@ -71,21 +71,21 @@ describe("buildPowerlineSpawnRequest", () => {
 
   it("passes use_worktrees=false through explicitly", () => {
     const config = create(grackle.SessionConfigSchema, { useWorktrees: false });
-    expect(buildPowerlineSpawnRequest({ ...serverInputs, config }).useWorktrees).toBe(false);
+    expect(buildCreateSessionParams({ ...serverInputs, config }).useWorktrees).toBe(false);
   });
 
   it("passes use_worktrees=true through explicitly", () => {
     const config = create(grackle.SessionConfigSchema, { useWorktrees: true });
-    expect(buildPowerlineSpawnRequest({ ...serverInputs, config }).useWorktrees).toBe(true);
+    expect(buildCreateSessionParams({ ...serverInputs, config }).useWorktrees).toBe(true);
   });
 
   it("leaves use_worktrees unset when config omits it (host default applies)", () => {
     const config = create(grackle.SessionConfigSchema, {});
-    expect(buildPowerlineSpawnRequest({ ...serverInputs, config }).useWorktrees).toBeUndefined();
+    expect(buildCreateSessionParams({ ...serverInputs, config }).useWorktrees).toBeUndefined();
   });
 
   it("defaults cleanly when config is undefined", () => {
-    const req = buildPowerlineSpawnRequest({ ...serverInputs, config: undefined });
+    const req = buildCreateSessionParams({ ...serverInputs, config: undefined });
 
     expect(req.taskId).toBe("");
     expect(req.branch).toBe("");
@@ -94,7 +94,7 @@ describe("buildPowerlineSpawnRequest", () => {
   });
 
   it("forwards server-resolved values verbatim", () => {
-    const req = buildPowerlineSpawnRequest({ ...serverInputs, config: undefined });
+    const req = buildCreateSessionParams({ ...serverInputs, config: undefined });
 
     expect(req.sessionId).toBe("sess-1");
     expect(req.runtime).toBe("claude-code");
@@ -105,12 +105,11 @@ describe("buildPowerlineSpawnRequest", () => {
 
   it("forwards a resolved workspaceId, leaving it unset when empty", () => {
     expect(
-      buildPowerlineSpawnRequest({ ...serverInputs, workspaceId: "ws-1", config: undefined })
+      buildCreateSessionParams({ ...serverInputs, workspaceId: "ws-1", config: undefined })
         .workspaceId,
     ).toBe("ws-1");
     expect(
-      buildPowerlineSpawnRequest({ ...serverInputs, workspaceId: "", config: undefined })
-        .workspaceId,
+      buildCreateSessionParams({ ...serverInputs, workspaceId: "", config: undefined }).workspaceId,
     ).toBeUndefined();
   });
 });

--- a/packages/plugin-core/src/spawn-request.ts
+++ b/packages/plugin-core/src/spawn-request.ts
@@ -1,13 +1,14 @@
 /**
  * Pure helpers for the createSession (AHP HR4+5) spawn shape: resolving the
  * runtime/model selection and mapping the reshaped `grackle.SpawnRequest`
- * `config` onto the PowerLine `SpawnRequest`. Kept free of I/O (and of the
- * core/database import graph) so the wire mapping is unit-testable.
+ * `config` onto the host-transport `CreateSessionParams`. Kept free of I/O
+ * (and of the core/database import graph) so the wire mapping is
+ * unit-testable.
  *
  * @module
  */
-import { create } from "@bufbuild/protobuf";
-import { grackle, powerline } from "@grackle-ai/common";
+import { grackle } from "@grackle-ai/common";
+import type { CreateSessionParams } from "@grackle-ai/adapter-sdk";
 
 /**
  * Resolve the runtime + model for a spawn, honoring explicit request overrides
@@ -43,14 +44,14 @@ export interface PowerlineSpawnInputs {
 }
 
 /**
- * Build the PowerLine SpawnRequest from a (reshaped) createSession `config` plus
- * server-resolved values. Pure (no I/O) so the config→wire mapping — including
- * `task_id` plumbing and the optional `use_worktrees` passthrough — is
- * unit-testable in isolation from `spawnAgent`'s side effects.
+ * Build the host-transport `CreateSessionParams` from a (reshaped) createSession
+ * `config` plus server-resolved values. Pure (no I/O) so the config→params
+ * mapping — including `task_id` plumbing and the optional `use_worktrees`
+ * passthrough — is unit-testable in isolation from `spawnAgent`'s side effects.
  */
-export function buildPowerlineSpawnRequest(args: PowerlineSpawnInputs): powerline.SpawnRequest {
+export function buildCreateSessionParams(args: PowerlineSpawnInputs): CreateSessionParams {
   const cfg = args.config;
-  return create(powerline.SpawnRequestSchema, {
+  return {
     sessionId: args.sessionId,
     runtime: args.runtime,
     prompt: args.prompt,
@@ -65,7 +66,7 @@ export function buildPowerlineSpawnRequest(args: PowerlineSpawnInputs): powerlin
     mcpUrl: args.mcpUrl,
     mcpToken: args.mcpToken,
     scriptContent: args.scriptContent,
-    useWorktrees: cfg?.useWorktrees, // undefined → host default (true)
+    useWorktrees: cfg?.useWorktrees,
     pipe: cfg?.pipe ?? "",
-  });
+  };
 }

--- a/packages/plugin-core/src/spawn-request.ts
+++ b/packages/plugin-core/src/spawn-request.ts
@@ -26,7 +26,7 @@ export function resolveSpawnSelection(
 }
 
 /** Server-resolved values for a spawn that don't come from the client `config`. */
-export interface PowerlineSpawnInputs {
+export interface CreateSessionInputs {
   sessionId: string;
   runtime: string;
   model: string;
@@ -49,7 +49,7 @@ export interface PowerlineSpawnInputs {
  * mapping — including `task_id` plumbing and the optional `use_worktrees`
  * passthrough — is unit-testable in isolation from `spawnAgent`'s side effects.
  */
-export function buildCreateSessionParams(args: PowerlineSpawnInputs): CreateSessionParams {
+export function buildCreateSessionParams(args: CreateSessionInputs): CreateSessionParams {
   const cfg = args.config;
   return {
     sessionId: args.sessionId,

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -1,6 +1,7 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
-import { grackle, powerline } from "@grackle-ai/common";
+import { grackle } from "@grackle-ai/common";
+import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import type { PipeMode } from "@grackle-ai/common";
 import {
   DEFAULT_MCP_PORT,
@@ -512,7 +513,8 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
     loadOrCreateApiKey(grackleHome),
   );
 
-  const powerlineReq = create(powerline.SpawnRequestSchema, {
+  const transport = new GrpcHostTransport(conn.client);
+  const { stream: spawnStream } = transport.createSession({
     sessionId,
     runtime,
     prompt: taskPrompt,
@@ -562,7 +564,7 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
     }
   }
 
-  processEventStream(conn.client.spawn(powerlineReq), {
+  processEventStream(spawnStream, {
     sessionId,
     logPath,
     workspaceId: task.workspaceId ?? undefined,
@@ -704,17 +706,16 @@ export async function resumeTask(req: grackle.TaskId): Promise<grackle.Session> 
     );
   }
 
-  const powerlineReq = create(powerline.ResumeRequestSchema, {
+  const logPath = latestSession.logPath || join(grackleHome, LOGS_DIR, latestSession.id);
+
+  // Initiate the stream before mutating the DB. If reanimate() throws
+  // synchronously the DB is never touched, so no rollback is needed.
+  const resumeTransport = new GrpcHostTransport(conn.client);
+  const resumeStream = resumeTransport.reanimate({
     sessionId: latestSession.id,
     runtimeSessionId: latestSession.runtimeSessionId,
     runtime: latestSession.runtime,
   });
-
-  const logPath = latestSession.logPath || join(grackleHome, LOGS_DIR, latestSession.id);
-
-  // Initiate the stream before mutating the DB. If resume() throws
-  // synchronously the DB is never touched, so no rollback is needed.
-  const resumeStream = conn.client.resume(powerlineReq);
 
   // Reset session DB row to RUNNING (clears endedAt, error, etc.)
   sessionStore.reanimateSession(latestSession.id);

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -1,7 +1,6 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import { GrpcHostTransport } from "@grackle-ai/adapter-sdk";
 import type { PipeMode } from "@grackle-ai/common";
 import {
   DEFAULT_MCP_PORT,
@@ -513,8 +512,7 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
     loadOrCreateApiKey(grackleHome),
   );
 
-  const transport = new GrpcHostTransport(conn.client);
-  const { stream: spawnStream } = transport.createSession({
+  const { stream: spawnStream } = conn.transport.createSession({
     sessionId,
     runtime,
     prompt: taskPrompt,
@@ -710,8 +708,7 @@ export async function resumeTask(req: grackle.TaskId): Promise<grackle.Session> 
 
   // Initiate the stream before mutating the DB. If reanimate() throws
   // synchronously the DB is never touched, so no rollback is needed.
-  const resumeTransport = new GrpcHostTransport(conn.client);
-  const resumeStream = resumeTransport.reanimate({
+  const resumeStream = conn.transport.reanimate({
     sessionId: latestSession.id,
     runtimeSessionId: latestSession.runtimeSessionId,
     runtime: latestSession.runtime,

--- a/packages/plugin-core/src/task-start-token-push.test.ts
+++ b/packages/plugin-core/src/task-start-token-push.test.ts
@@ -197,18 +197,27 @@ function applySchema(): void {
   `);
 }
 
-/** Build a mock PowerLineConnection with a spawn method and pushTokens. */
+/** Build a mock PowerLineConnection that exposes both the legacy client and the new transport. */
 function makeMockConnection() {
-  const spawnStream = (async function* () {})();
+  const envelopeStream = (async function* () {})();
   return {
     client: {
-      spawn: vi.fn(() => spawnStream),
+      spawn: vi.fn(() => envelopeStream),
       authenticate: vi.fn().mockResolvedValue({}),
       pushTokens: vi.fn().mockResolvedValue({}),
       sendInput: vi.fn().mockResolvedValue({}),
     },
     environmentId: "env-1",
     port: 7433,
+    transport: {
+      createSession: vi.fn(() => ({ sessionUri: "sess-1", stream: envelopeStream })),
+      reanimate: vi.fn(() => envelopeStream),
+      drainBuffered: vi.fn(() => envelopeStream),
+      dispatchInput: vi.fn().mockResolvedValue(undefined),
+      authenticate: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn().mockResolvedValue(undefined),
+      listSessions: vi.fn().mockResolvedValue([]),
+    },
   };
 }
 

--- a/packages/plugin-core/src/task-start-token-push.test.ts
+++ b/packages/plugin-core/src/task-start-token-push.test.ts
@@ -282,9 +282,9 @@ describe("task-start token push", () => {
       // Cutover proof: the deprecated proactive push is never called.
       expect(mockConn.client.pushTokens).not.toHaveBeenCalled();
 
-      // Authenticate happens before spawn.
+      // Authenticate happens before spawn (via transport.createSession).
       const authOrder = authSpy.mock.invocationCallOrder[0];
-      const spawnOrder = mockConn.client.spawn.mock.invocationCallOrder[0];
+      const spawnOrder = mockConn.transport.createSession.mock.invocationCallOrder[0];
       expect(authOrder).toBeLessThan(spawnOrder);
     });
   });

--- a/packages/plugin-core/src/write-close-fd.test.ts
+++ b/packages/plugin-core/src/write-close-fd.test.ts
@@ -41,11 +41,12 @@ describe("writeToFd + closeFd — async delivery integration", () => {
     pipeDelivery._resetForTesting();
     vi.clearAllMocks();
 
-    mockSendInput = vi.fn().mockResolvedValue({});
+    mockSendInput = vi.fn().mockResolvedValue(undefined);
 
-    // Inject a controllable sendInput so the real pipe-delivery async listener can fire.
+    // Inject a controllable dispatchInput so the real pipe-delivery async listener can fire.
     vi.spyOn(adapterManager, "getConnection").mockReturnValue({
-      client: { sendInput: mockSendInput },
+      client: {},
+      transport: { dispatchInput: mockSendInput },
     } as unknown as ReturnType<typeof adapterManager.getConnection>);
 
     // Make sessionStore.getSession return a valid session so the listener doesn't throw.
@@ -83,8 +84,8 @@ describe("writeToFd + closeFd — async delivery integration", () => {
 
       expect(result).toBeDefined();
       expect(mockSendInput).toHaveBeenCalledOnce();
-      // sendInput is called for the parent (the async reader), not the sender
-      expect(mockSendInput.mock.calls[0][0].sessionId).toBe("parent");
+      // dispatchInput is called for the parent (the async reader), not the sender
+      expect(mockSendInput.mock.calls[0][0]).toBe("parent");
     });
 
     it("throws ConnectError(FailedPrecondition) when sendInput rejects", async () => {


### PR DESCRIPTION
## Summary

Closes #1335. Part of #1291 (HR8) which is part of #1285 (AHP epic).

**Refactor only — gRPC remains the wire.** Introduces `IHostTransport` in `@grackle-ai/adapter-sdk` (first impl: `GrpcHostTransport` wrapping the existing PowerLine client). Relocates the `AgentEvent → AHP SessionAction` mapper to `@grackle-ai/common`. Migrates every consumer call-site in `packages/core/` and `packages/plugin-core/` through the transport.

End-state: `packages/core/src/` production code has **zero** `import { powerline }` lines. HR8d's wire flip becomes a swap of one `IHostTransport` implementation for another.

### What moved / what's new

- **`packages/common`**
  - New: `src/ahp-mapper.ts` + `src/ahp-mapper.test.ts` (relocated from `core/`, decoupled from `powerline.AgentEvent` via a new `AgentEventFields` interface — any structurally-compatible object works).
  - Now depends on `@grackle-ai/ahp` (ahp has zero runtime deps; cheap edge).

- **`packages/adapter-sdk`**
  - New: `src/host-transport.ts` — `IHostTransport` interface (`createSession`, `reanimate`, `subscribe`, `dispatchInput`, `authenticate`, `dispose`, `listSessions`) plus AHP-shaped param/result types.
  - New: `src/grpc-host-transport.ts` — `GrpcHostTransport` wraps a `PowerLineClient`, owns a per-session `MapperContext`, folds incoming `AgentEvent` streams into `ServerActionEnvelope { event, actions }`.
  - New: `src/grpc-host-transport.test.ts` — 8 contract tests covering each method.
  - Now depends on `@grackle-ai/ahp`.

- **`packages/core` migrations** (zero `powerline.*` imports in production code):
  - `task-session.ts` — `conn.client.spawn(...)` → `transport.createSession(...)`.
  - `reanimate-agent.ts` — `conn.client.resume(...)` → `transport.reanimate(...)`.
  - `session-recovery.ts` — `conn.client.drainBufferedEvents(...)` → `transport.subscribe(uri, fromServerSeq)`.
  - `token-push.ts` — `conn.client.authenticate(...)` → `transport.authenticate(...)`.
  - `signals/signal-delivery.ts` — `conn.client.sendInput(...)` → `transport.dispatchInput(...)`.
  - `pipe-delivery.ts` — `conn.client.sendInput(...)` → `transport.dispatchInput(...)`.
  - `credential-bundle.ts` — returns a TS-native `ProviderTokenBundle` (no `powerline.TokenBundle`). Internal `tokenItem()` helper replaces the proto-bound `create(powerline.TokenItemSchema, …)` factory.
  - `event-processor.ts` — `processEventStream` now consumes `AsyncIterable<ServerActionEnvelope>`; uses `envelope.event` for the existing event-driven logic.
  - `ahp-session-state.ts` — `SessionStateManager.processEvent` takes `AgentEventFields`; reconstruct path uses plain objects instead of `powerline.AgentEventSchema`. Mapper import now comes from `@grackle-ai/common`.

- **`packages/plugin-core` migrations** (out of strict acceptance scope but required to compile against the new `processEventStream` signature):
  - `session-handlers.ts`, `task-handlers.ts` — spawn + resume call-sites migrated through `GrpcHostTransport`.
  - `spawn-request.ts` — `buildPowerlineSpawnRequest` renamed to `buildCreateSessionParams`, returns `CreateSessionParams`.

### Acceptance

```text
$ rg "import.*\bpowerline\b.*from" packages/core/src
packages/core/src/ahp-reconstruct.test.ts:import type { powerline } from "@grackle-ai/common";
packages/core/src/ahp-session-state.test.ts:import type { powerline } from "@grackle-ai/common";
packages/core/src/credential-bundle.test.ts:import { powerline } from "@grackle-ai/common";
packages/core/src/event-processor.test.ts:import { powerline, grackle } from "@grackle-ai/common";
```

Zero production-code matches. The remaining test-file references are acceptable per the amended acceptance criteria (test fixtures hand-craft `AgentEvent` and will go away in HR8d).

`packages/powerline/` and `packages/common/src/proto/` are unmodified — wire is unchanged.

### Tests

- `rush build` green (warnings-as-errors clean).
- `rushx test` per package: **core 500/500**, **plugin-core 357/357**, **server 111/111**, **adapter-sdk 54/54** (8 new), **common 96/96** (35 mapper tests moved).
- The 4 existing core tests that drove fixtures through mocked `conn.client.<rpc>` calls still pass unchanged — the transport wraps the same client transparently. `event-processor.test.ts` needed only a thin envelope-wrapper helper because `processEventStream`'s parameter type changed.

### Open carve-out

The literal "rewrite `SessionStateManager.processEvent` → `applyAction`" piece from the acceptance discussion is **partially** addressed: the parameter type lost its `powerline.AgentEvent` dependency (now `AgentEventFields`) but the method body still maps internally. Doing the full rewrite (consumer calls `applyAction(action, serverSeq)` for each action in an envelope; the upstream transport owns mapping) would require a much heavier rewrite of `event-processor.ts`'s event-driven logic (status mapping, usage tracking, end-reason derivation, runtime_session_id persistence, etc.) which sits at a wider scope than HR8c. Suggested follow-up ticket: "HR8c.6 — flatten `SessionStateManager.processEvent` to `applyAction`; rewrite event-processor.ts to drive lifecycle off AHP actions instead of `AgentEvent`."

### Issue amendment

Already posted as a comment on #1335 ([link](https://github.com/nick-pape/grackle/issues/1335#issuecomment-4560417154)) capturing the 5 design decisions: 5th call-site (`sendInput`) in scope, mapper relocates to a shared package, one PR (no upfront split), literal acceptance for the "zero powerline in core production" grep, dedicated `reanimate` method instead of overloaded `createSession({fork:…})`.

## Test plan

- [x] `rush build` clean — warnings-as-errors satisfied
- [x] `rushx test` in `@grackle-ai/core` — 500/500
- [x] `rushx test` in `@grackle-ai/plugin-core` — 357/357
- [x] `rushx test` in `@grackle-ai/server` — 111/111 (DB-mock consumer)
- [x] `rushx test` in `@grackle-ai/adapter-sdk` — 54/54 (incl. 8 new)
- [x] `rushx test` in `@grackle-ai/common` — 96/96 (incl. 35 moved mapper tests)
- [x] Acceptance grep — zero `powerline.*` imports in core production code
- [x] Wire unchanged — no diff in `packages/powerline/` or `packages/common/src/proto/`
- [ ] Manual smoke via `/launch-grackle`: spawn → reanimate → signal — deferred, see follow-up
- [ ] Playwright E2E — deferred to CI