### PR TITLE
Fix AHP mapper round-trip gaps for tokens, turn_started, is_error (HR8d follow-up #1355)

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -2007,6 +2007,8 @@ export interface MapperContext {
     eventIndex: number;
     metaAccumulator: {
         costMillicents?: number;
+        inputTokens?: number;
+        outputTokens?: number;
         runtimeSessionId?: string;
     };
     openToolCalls: string[];
@@ -2334,6 +2336,8 @@ export function reverseMapAction(envelope: ActionEnvelope, context: ReverseMappe
 export interface ReverseMapperContext {
     readonly metaAccumulator: {
         costMillicents?: number;
+        inputTokens?: number;
+        outputTokens?: number;
         runtimeSessionId?: string;
     };
     readonly pendingToolCalls: Map<string, PendingToolCall>;

--- a/common/changes/@grackle-ai/cli/nick-pape-1355-mapper-roundtrip-1a-1b_2026-05-29-06-58.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1355-mapper-roundtrip-1a-1b_2026-05-29-06-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix AHP mapper round-trip gaps for tokens, turn_started, is_error (HR8d follow-up #1355): plumb input_tokens/output_tokens through _meta alongside cost_millicents, emit turn_started content as plain text (not JSON-wrapped), refactor EventRenderer is_error detection to read structured content.is_ok with raw fallback. Documents the wire-level event.raw loss decision in ahp-mapper module TSDoc.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/ahp-mapper.test.ts
+++ b/packages/common/src/ahp-mapper.test.ts
@@ -355,6 +355,51 @@ describe("usage", () => {
     // 0 is a valid (non-null) cost — accumulator should be 100 + 0 = 100
     expect(context.metaAccumulator.costMillicents).toBe(100);
   });
+
+  // HR8d follow-up #1355: input/output token plumbing
+  it("carries input_tokens / output_tokens into metaAccumulator alongside cost (HR8d follow-up #1355)", () => {
+    const context = makeContext({
+      metaAccumulator: { costMillicents: 100, inputTokens: 50, outputTokens: 10 },
+    });
+    const event = makeEvent("usage", {
+      content: JSON.stringify({ cost_millicents: 20, input_tokens: 5, output_tokens: 3 }),
+    });
+    mapAgentEvent(event, 6, context);
+    expect(context.metaAccumulator.costMillicents).toBe(120);
+    expect(context.metaAccumulator.inputTokens).toBe(55);
+    expect(context.metaAccumulator.outputTokens).toBe(13);
+  });
+
+  it("ignores non-finite input_tokens / output_tokens (HR8d follow-up #1355)", () => {
+    const context = makeContext();
+    const event = makeEvent("usage", {
+      content: JSON.stringify({ input_tokens: NaN, output_tokens: "abc" }),
+    });
+    mapAgentEvent(event, 6, context);
+    expect(context.metaAccumulator.inputTokens).toBeUndefined();
+    expect(context.metaAccumulator.outputTokens).toBeUndefined();
+  });
+
+  it("accumulates input_tokens / output_tokens with zero increments (HR8d follow-up #1355)", () => {
+    const context = makeContext({ metaAccumulator: { inputTokens: 7, outputTokens: 11 } });
+    const event = makeEvent("usage", {
+      content: JSON.stringify({ input_tokens: 0, output_tokens: 0 }),
+    });
+    mapAgentEvent(event, 6, context);
+    expect(context.metaAccumulator.inputTokens).toBe(7);
+    expect(context.metaAccumulator.outputTokens).toBe(11);
+  });
+
+  it("usage event with only token fields (no cost) still updates accumulator (HR8d follow-up #1355)", () => {
+    const context = makeContext();
+    const event = makeEvent("usage", {
+      content: JSON.stringify({ input_tokens: 42, output_tokens: 11 }),
+    });
+    mapAgentEvent(event, 6, context);
+    expect(context.metaAccumulator.costMillicents).toBeUndefined();
+    expect(context.metaAccumulator.inputTokens).toBe(42);
+    expect(context.metaAccumulator.outputTokens).toBe(11);
+  });
 });
 
 // ─── error ─────────────────────────────────────────────────────────

--- a/packages/common/src/ahp-mapper.ts
+++ b/packages/common/src/ahp-mapper.ts
@@ -13,6 +13,32 @@
  * `powerline.AgentEvent` lets HR8d remove the gRPC path entirely without
  * touching the mapper.
  *
+ * **Wire fidelity notes (HR8d follow-up #1355):**
+ *
+ * AHP `StateAction` is a typed, normalized envelope — it deliberately does
+ * NOT carry the runtime-native event payload (`AgentEvent.raw`). Anything
+ * a consumer used to read out of `event.raw` MUST come through a
+ * first-class structured field on the action instead:
+ *
+ * - Tool ID pairing (was `raw.id` / `raw.tool_use_id`) → use
+ *   `event.toolCallId`, which both the forward mapper and PowerLine's
+ *   runtime adapters set as a first-class HR3 field.
+ * - Tool result success/error (was `raw.is_error`) → use
+ *   `SessionToolCallCompleteAction.result.success`. The reverse mapper
+ *   reconstructs a JSON content of `{is_ok, content, past_tense_message}`
+ *   that downstream code (`EventRenderer.tsx`) can parse.
+ * - System-context marker (was `raw.systemContext === true`) → the
+ *   consumer-side `event-processor.ts` injects its system-context event
+ *   directly and sets `raw: '{"systemContext":true}'` locally, so the
+ *   wire never has to carry it.
+ *
+ * Token / cost counters (`input_tokens`, `output_tokens`, `cost_millicents`)
+ * are carried via the `_meta` channel on `SessionMetaChangedAction`:
+ * accumulated on the producer side, emitted as a single `usage` event
+ * with the delta on the consumer side. Producer-side accumulation lives
+ * in `MapperContext.metaAccumulator`; reverse-side delta computation in
+ * `ahp-reverse-mapper.ts`'s `SessionMetaChanged` case.
+ *
  * @module ahp-mapper
  */
 
@@ -116,6 +142,15 @@ export interface MapperContext {
   metaAccumulator: {
     /** Accumulated cost in millicents (AHP-upstream gap; rides on `_meta`). */
     costMillicents?: number;
+    /**
+     * Accumulated input tokens (HR8d follow-up #1355). Same wire treatment as
+     * `costMillicents` — added on every `usage` event, the reverse mapper
+     * emits the delta back as a `usage` event for the consumer's existing
+     * token-tracking pipeline (`event-processor.ts:case "usage"`).
+     */
+    inputTokens?: number;
+    /** Accumulated output tokens (HR8d follow-up #1355). */
+    outputTokens?: number;
     /** Runtime-provided session ID from the `runtime_session_id` event. */
     runtimeSessionId?: string;
   };
@@ -470,12 +505,31 @@ export function mapAgentEvent(
         const cost = Number(rawCost);
         context.metaAccumulator.costMillicents = Math.max(0, prevCost + Math.trunc(cost));
       }
+      // HR8d follow-up #1355: accumulate input/output tokens alongside cost.
+      // The reverse mapper emits a single `usage` event carrying whichever of
+      // the three deltas changed — preserves the gRPC-era event-processor
+      // pipeline that already reads `{input_tokens, output_tokens, cost_millicents}`
+      // and updates `sessions.{input_tokens, output_tokens, cost_millicents}` cumulatively.
+      const rawInputTokens = hasParsed ? parsed.input_tokens : undefined;
+      // eslint-disable-next-line eqeqeq
+      if (rawInputTokens != null && Number.isFinite(Number(rawInputTokens))) {
+        const prev = context.metaAccumulator.inputTokens ?? 0;
+        const v = Number(rawInputTokens);
+        context.metaAccumulator.inputTokens = Math.max(0, prev + Math.trunc(v));
+      }
+      const rawOutputTokens = hasParsed ? parsed.output_tokens : undefined;
+      // eslint-disable-next-line eqeqeq
+      if (rawOutputTokens != null && Number.isFinite(Number(rawOutputTokens))) {
+        const prev = context.metaAccumulator.outputTokens ?? 0;
+        const v = Number(rawOutputTokens);
+        context.metaAccumulator.outputTokens = Math.max(0, prev + Math.trunc(v));
+      }
 
       note = {
         index,
         type: "usage",
         disposition: "carried",
-        detail: `Usage tracked — costMillicents now ${context.metaAccumulator.costMillicents ?? 0}`,
+        detail: `Usage tracked — costMillicents=${context.metaAccumulator.costMillicents ?? 0} inputTokens=${context.metaAccumulator.inputTokens ?? 0} outputTokens=${context.metaAccumulator.outputTokens ?? 0}`,
       };
       break;
     }

--- a/packages/common/src/ahp-reverse-mapper.test.ts
+++ b/packages/common/src/ahp-reverse-mapper.test.ts
@@ -41,7 +41,10 @@ function textContent(text: string): ToolResultContent {
 
 describe("reverseMapAction", () => {
   describe("turn lifecycle", () => {
-    it("SessionTurnStarted → turn_started with user_message JSON content", () => {
+    it("SessionTurnStarted → turn_started with plain-text user_message content (HR8d follow-up #1355)", () => {
+      // Plain text matches the gRPC-era wire shape that all runtimes emit
+      // via BaseAgentSession.beginTurn() (content: userMessage). Forward
+      // mapper still accepts the legacy JSON-wrapped shape for backward compat.
       const ctx = newReverseMapperContext();
       const res = reverseMapAction(
         envelope({
@@ -54,8 +57,7 @@ describe("reverseMapAction", () => {
       expect(res.events).toHaveLength(1);
       expect(res.events[0]?.type).toBe("turn_started");
       expect(res.events[0]?.turnId).toBe("turn-1");
-      const parsed = JSON.parse(res.events[0]?.content ?? "") as { user_message: string };
-      expect(parsed.user_message).toBe("hello");
+      expect(res.events[0]?.content).toBe("hello");
       expect(ctx.turnId).toBe("turn-1");
     });
 
@@ -448,6 +450,80 @@ describe("reverseMapAction", () => {
       );
       expect(res.events).toEqual([]);
     });
+
+    // HR8d follow-up #1355: input/output token rehydration
+    it("SessionMetaChanged with input_tokens / output_tokens → emits delta-based usage (HR8d follow-up #1355)", () => {
+      const ctx = newReverseMapperContext();
+      const res1 = reverseMapAction(
+        envelope({
+          type: ActionType.SessionMetaChanged,
+          _meta: { input_tokens: 100, output_tokens: 25 },
+        }),
+        ctx,
+      );
+      expect(res1.events).toHaveLength(1);
+      const parsed1 = JSON.parse(res1.events[0]?.content ?? "") as {
+        input_tokens?: number;
+        output_tokens?: number;
+        cost_millicents?: number;
+      };
+      expect(parsed1.input_tokens).toBe(100);
+      expect(parsed1.output_tokens).toBe(25);
+      expect(parsed1.cost_millicents).toBeUndefined();
+      expect(ctx.metaAccumulator.inputTokens).toBe(100);
+      expect(ctx.metaAccumulator.outputTokens).toBe(25);
+
+      const res2 = reverseMapAction(
+        envelope({
+          type: ActionType.SessionMetaChanged,
+          _meta: { input_tokens: 175, output_tokens: 60 },
+        }),
+        ctx,
+      );
+      const parsed2 = JSON.parse(res2.events[0]?.content ?? "") as {
+        input_tokens: number;
+        output_tokens: number;
+      };
+      expect(parsed2.input_tokens).toBe(75); // delta
+      expect(parsed2.output_tokens).toBe(35); // delta
+    });
+
+    it("SessionMetaChanged with all three usage fields → single combined usage event (HR8d follow-up #1355)", () => {
+      const ctx = newReverseMapperContext();
+      const res = reverseMapAction(
+        envelope({
+          type: ActionType.SessionMetaChanged,
+          _meta: { cost_millicents: 500, input_tokens: 200, output_tokens: 50 },
+        }),
+        ctx,
+      );
+      expect(res.events).toHaveLength(1);
+      expect(res.events[0]?.type).toBe("usage");
+      const parsed = JSON.parse(res.events[0]?.content ?? "") as Record<string, number>;
+      expect(parsed.cost_millicents).toBe(500);
+      expect(parsed.input_tokens).toBe(200);
+      expect(parsed.output_tokens).toBe(50);
+    });
+
+    it("SessionMetaChanged with token totals that haven't changed → no usage event (HR8d follow-up #1355)", () => {
+      const ctx = newReverseMapperContext();
+      reverseMapAction(
+        envelope({
+          type: ActionType.SessionMetaChanged,
+          _meta: { input_tokens: 100, output_tokens: 25 },
+        }),
+        ctx,
+      );
+      const res = reverseMapAction(
+        envelope({
+          type: ActionType.SessionMetaChanged,
+          _meta: { input_tokens: 100, output_tokens: 25 },
+        }),
+        ctx,
+      );
+      expect(res.events).toEqual([]);
+      expect(res.disposition).toBe("carried");
+    });
   });
 
   describe("dropped action types", () => {
@@ -491,8 +567,20 @@ describe("reverseMapAction", () => {
       return events;
     }
 
-    it("turn_started round-trips type + turnId + user_message", () => {
-      const out = pushRoundTrip(
+    it("turn_started round-trips type + turnId + user_message text (HR8d follow-up #1355)", () => {
+      // Producer side may emit either plain text (BaseAgentSession-style) OR
+      // the legacy JSON-wrapped shape; consumer always sees plain text after
+      // the wire round-trip.
+      const fromPlain = pushRoundTrip(
+        { type: "turn_started", content: "hi", turnId: "turn-1" },
+        freshMapperContext(),
+        newReverseMapperContext(),
+      );
+      expect(fromPlain[0]?.type).toBe("turn_started");
+      expect(fromPlain[0]?.turnId).toBe("turn-1");
+      expect(fromPlain[0]?.content).toBe("hi");
+
+      const fromWrapped = pushRoundTrip(
         {
           type: "turn_started",
           content: JSON.stringify({ user_message: "hi" }),
@@ -501,11 +589,7 @@ describe("reverseMapAction", () => {
         freshMapperContext(),
         newReverseMapperContext(),
       );
-      expect(out).toHaveLength(1);
-      expect(out[0]?.type).toBe("turn_started");
-      expect(out[0]?.turnId).toBe("turn-1");
-      const parsed = JSON.parse(out[0]?.content ?? "") as { user_message: string };
-      expect(parsed.user_message).toBe("hi");
+      expect(fromWrapped[0]?.content).toBe("hi");
     });
 
     it("text inside a turn round-trips", () => {

--- a/packages/common/src/ahp-reverse-mapper.ts
+++ b/packages/common/src/ahp-reverse-mapper.ts
@@ -61,6 +61,10 @@ export interface ReverseMapperContext {
   /** Accumulated meta carried from `SessionMetaChangedAction` envelopes. */
   readonly metaAccumulator: {
     costMillicents?: number;
+    /** Last-seen total — used to compute deltas for the rehydrated `usage` event. HR8d follow-up #1355. */
+    inputTokens?: number;
+    /** Last-seen total — used to compute deltas for the rehydrated `usage` event. HR8d follow-up #1355. */
+    outputTokens?: number;
     runtimeSessionId?: string;
   };
 }
@@ -140,13 +144,19 @@ export function reverseMapAction(
         };
       }
       context.turnId = a.turnId;
-      const userText = a.userMessage.text;
+      // HR8d-followup #1355: emit the user message as plain text content,
+      // matching the gRPC-era wire shape that all runtimes produce
+      // (BaseAgentSession.beginTurn() emits `content: userMessage`). The
+      // forward mapper at ahp-mapper.ts case "turn_started" accepts both
+      // wrapped (`{user_message: "..."}`) and unwrapped via its
+      // `str(parsed, ["user_message"], content || "")` fallback, so round-trip
+      // stays consistent for any legacy producer that emitted the wrapped shape.
       return {
         events: [
           {
             type: "turn_started",
             turnId: a.turnId,
-            content: JSON.stringify({ user_message: userText }),
+            content: a.userMessage.text,
           },
         ],
         disposition: "mapped",
@@ -389,17 +399,44 @@ export function reverseMapAction(
           context.metaAccumulator.runtimeSessionId = runtimeSessionIdRaw;
           events.push({ type: "runtime_session_id", content: runtimeSessionIdRaw });
         }
+        // HR8d follow-up #1355: cost + tokens are all carried on `_meta` and
+        // rehydrated together as a single `usage` event so the consumer's
+        // event-processor pipeline (which accumulates all three onto the
+        // session row via `sessions.{input,output}_tokens` / `cost_millicents`)
+        // sees one delta-shaped event with the same shape gRPC used to deliver.
         const costRaw = meta.cost_millicents;
+        const inputTokensRaw = meta.input_tokens;
+        const outputTokensRaw = meta.output_tokens;
+        const usagePayload: Record<string, number> = {};
         if (typeof costRaw === "number") {
-          const prevCost = context.metaAccumulator.costMillicents ?? 0;
-          const delta = costRaw - prevCost;
+          const prev = context.metaAccumulator.costMillicents ?? 0;
+          const delta = costRaw - prev;
           context.metaAccumulator.costMillicents = costRaw;
           if (delta !== 0) {
-            events.push({
-              type: "usage",
-              content: JSON.stringify({ cost_millicents: delta }),
-            });
+            usagePayload.cost_millicents = delta;
           }
+        }
+        if (typeof inputTokensRaw === "number") {
+          const prev = context.metaAccumulator.inputTokens ?? 0;
+          const delta = inputTokensRaw - prev;
+          context.metaAccumulator.inputTokens = inputTokensRaw;
+          if (delta !== 0) {
+            usagePayload.input_tokens = delta;
+          }
+        }
+        if (typeof outputTokensRaw === "number") {
+          const prev = context.metaAccumulator.outputTokens ?? 0;
+          const delta = outputTokensRaw - prev;
+          context.metaAccumulator.outputTokens = outputTokensRaw;
+          if (delta !== 0) {
+            usagePayload.output_tokens = delta;
+          }
+        }
+        if (Object.keys(usagePayload).length > 0) {
+          events.push({
+            type: "usage",
+            content: JSON.stringify(usagePayload),
+          });
         }
         // HR8d status rescue: PowerLine forwards lifecycle status events
         // (running / waiting_input / idle / completed) as `_meta.status`

--- a/packages/powerline/src/ahp-handlers.ts
+++ b/packages/powerline/src/ahp-handlers.ts
@@ -611,6 +611,13 @@ export function mountAhpServer(opts: MountAhpServerOptions): AhpServerSocket {
     if (forwarder.mapperContext.metaAccumulator.costMillicents !== undefined) {
       metaSnapshot.cost_millicents = forwarder.mapperContext.metaAccumulator.costMillicents;
     }
+    // HR8d follow-up #1355: carry token totals alongside cost.
+    if (forwarder.mapperContext.metaAccumulator.inputTokens !== undefined) {
+      metaSnapshot.input_tokens = forwarder.mapperContext.metaAccumulator.inputTokens;
+    }
+    if (forwarder.mapperContext.metaAccumulator.outputTokens !== undefined) {
+      metaSnapshot.output_tokens = forwarder.mapperContext.metaAccumulator.outputTokens;
+    }
     if (
       Object.keys(metaSnapshot).length > 0 &&
       !shallowEqualSnapshots(forwarder.lastMetaSnapshot, metaSnapshot)

--- a/packages/web-components/src/components/display/EventRenderer.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.tsx
@@ -331,8 +331,23 @@ export function EventRenderer({ event, toolUseCtx, settled, sandboxProxyUrl }: P
     case "tool_result": {
       // When paired, toolUseCtx provides the tool name, args, and optional detailedResult.
       // When unpaired, fall back to a generic display.
+      //
+      // HR8d follow-up #1355: error detection. The AHP wire doesn't carry
+      // `event.raw` (the runtime-native block) — the reverse mapper instead
+      // produces a structured `{is_ok, content, past_tense_message}` JSON
+      // content shape that encodes the success flag. Read `is_ok === false`
+      // from the content for HR8d-era events; fall back to the legacy
+      // `raw.is_error` path for pre-HR8d JSONL replay.
       let isError = false;
-      if (event.raw) {
+      try {
+        const parsed = JSON.parse(event.content) as Record<string, unknown>;
+        if (parsed.is_ok === false) {
+          isError = true;
+        }
+      } catch {
+        /* content not JSON — fall through to legacy raw check */
+      }
+      if (!isError && event.raw) {
         try {
           const rawData = JSON.parse(event.raw) as Record<string, unknown>;
           isError = rawData.is_error === true;


### PR DESCRIPTION
Closes #1355.

Follow-up to PR #1351 (HR8d AHP wire flip, merged as `a90d8bb0`). Fixes three of the four mapper-layer regressions found via post-HR8d live-smoke against a real Claude Code session.

## What this PR does

| # | Bug | Layer | Fix |
|---|---|---|---|
| 1a | 0 tokens displayed everywhere | Forward mapper dropped `input_tokens`/`output_tokens` from `usage` `_meta` | Plumb both through `MapperContext.metaAccumulator` alongside cost; reverse mapper emits single delta-shaped `usage` event |
| 1b | Raw `{"user_message":"..."}` JSON visible on every turn | Reverse mapper wrapped `turn_started` content | Emit plain text directly, matching gRPC-era wire shape |
| 1d | Tool-result errors not detected on consumer | EventRenderer read `event.raw.is_error` but AHP wire doesn't carry `raw` | Refactor to read `content.is_ok === false` from structured content, fall back to `raw` for legacy replay |

## 1c — Out of scope

Investigation revealed 1c (tool_result content always empty for Claude Code) is NOT a wire bug. The Claude Agent SDK handles tools internally and doesn't surface them as `tool_result` blocks; the adapter at `runtime-claude-code/src/claude-code.ts:617` (`flushPendingToolResults`) hard-codes `content: ""` for synthetic emissions. Sibling runtimes (Copilot, Codex) already work because their SDK events expose execution output differently. Filed separately for `@grackle-ai/runtime-claude-code`.

## Live verification

Spawned a real Claude Code session against the worktree-built stack. JSONL after one turn:

```
turn_started    'Say HELLO and stop.'                                    ← plain text (1b)
text            'Hello!'
usage           '{"cost_millicents":6413,"input_tokens":17082,"output_tokens":5}'  ← all 3 fields (1a)
turn_complete   ''
status          'waiting_input'
```

DB row after the turn:
```
{ id: "8c728b32...", input_tokens: 17082, output_tokens: 5, cost_millicents: 6413 }
```

All three usage fields accumulate correctly through `sessions.input_tokens` / `output_tokens` / `cost_millicents`.

## Wire fidelity documentation

The mapper module-level TSDoc (`ahp-mapper.ts`) now documents the AHP-wire `raw`-loss decision explicitly, listing the structured fields that replaced each former `event.raw` consumer read:

- `event.toolCallId` for tool ID pairing (was `raw.id` / `raw.tool_use_id`)
- `SessionToolCallCompleteAction.result.success` for error detection (was `raw.is_error`)
- Consumer-side `event-processor` injects `raw: '{"systemContext":true}'` locally for the system-context marker

## Tests

| Package | Before | After |
|---|---|---|
| `@grackle-ai/common` | 150 | 157 (+7) |
| `@grackle-ai/powerline` | 115 | 115 |
| `@grackle-ai/web-components` | 200 | 200 |

New tests cover:
- Forward mapper: `input_tokens` / `output_tokens` accumulation with valid + non-finite + zero inputs
- Reverse mapper: token rehydration with deltas, combined three-field usage event, no-op detection
- (Updated) `turn_started`: plain-text content assertion, round-trip from both legacy wrapped and new plain shapes

## Scope discipline

- **Modified**: `ahp-mapper.ts`, `ahp-reverse-mapper.ts`, `ahp-handlers.ts` (forwarder meta snapshot), `EventRenderer.tsx` (is_error refactor), test files, common.public.api.md (regenerated)
- **Out of this PR**: Issue #1356 (lifecycle UX), #1357 (Knowledge retry storm), #1358 (Sessions discovery), and the 1c claude-code adapter investigation.

Built clean, all tests pass, live-verified end-to-end.
