### PR TITLE
Fix tool-result failures serializing as success=true on AHP wire

### DIFF
--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -38,6 +38,7 @@ export interface AgentEventFields {
     raw?: string;
     timestamp?: string;
     toolCallId?: string;
+    toolError?: boolean;
     turnId?: string;
     type: string;
 }

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -59,6 +59,7 @@ type AgentEvent = Message<"grackle.powerline.AgentEvent"> & {
     toolCallId: string;
     diagnostic: boolean;
     turnId: string;
+    toolError: boolean;
 };
 
 // @public
@@ -68,6 +69,7 @@ export interface AgentEventFields {
     raw?: string;
     timestamp?: string;
     toolCallId?: string;
+    toolError?: boolean;
     turnId?: string;
     type: string;
 }
@@ -2654,6 +2656,7 @@ type SessionEvent = Message<"grackle.SessionEvent"> & {
     diagnostic: boolean;
     turnId: string;
     serverSeq: string;
+    toolError: boolean;
 };
 
 // @public

--- a/common/api/runtime-sdk.public.api.md
+++ b/common/api/runtime-sdk.public.api.md
@@ -16,6 +16,7 @@ export interface AgentEvent {
     // (undocumented)
     timestamp: string;
     toolCallId?: string;
+    toolError?: boolean;
     turnId?: string;
     // Warning: (ae-forgotten-export) The symbol "AgentEventType" needs to be exported by the entry point index.d.ts
     //

--- a/common/changes/@grackle-ai/cli/nick-pape-1362-ahp-tool-result-success_2026-05-29-13-22.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1362-ahp-tool-result-success_2026-05-29-13-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix tool-result failures serializing as success=true over the AHP wire: lift each runtime's native outcome signal to a first-class AgentEvent.tool_error field that the forward mapper reads (the wire drops `raw`, where the error flags lived), round-tripped through the reverse mapper, SessionEvent, and web consumers (#1362).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/ahp-mapper.test.ts
+++ b/packages/common/src/ahp-mapper.test.ts
@@ -31,6 +31,7 @@ function makeEvent(type: string, overrides?: Record<string, unknown>): AgentEven
     toolCallId: overrides?.toolCallId as string | undefined,
     turnId: overrides?.turnId as string | undefined,
     diagnostic: overrides?.diagnostic as boolean | undefined,
+    toolError: overrides?.toolError as boolean | undefined,
   };
 }
 
@@ -783,7 +784,9 @@ describe("branch coverage", () => {
     expect(action.result.success).toBe(true);
   });
 
-  it("tool_result with non-JSON content keeps default success=true", () => {
+  it("tool_result with non-JSON content keeps default success=true (no toolError field)", () => {
+    // Fallback path: when the first-class `toolError` field is absent AND the
+    // content isn't structured JSON, default to success.
     const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
     const event = makeEvent("tool_result", { toolCallId: "tc-1", content: "raw text result" });
     const result = mapAgentEvent(event, 0, context);
@@ -791,6 +794,58 @@ describe("branch coverage", () => {
     const action = result.actions[0] as { result: { success: boolean; pastTenseMessage: string } };
     expect(action.result.success).toBe(true);
     expect(action.result.pastTenseMessage).toBe("raw text result");
+  });
+
+  // ─── #1362: first-class toolError field is authoritative ──────────────
+  // Real runtimes (Claude Code, Copilot, Codex, ACP) carry the failure flag in
+  // `raw`, never in `content` — which the AHP wire drops. The producer lifts it
+  // to `toolError`; the mapper MUST read that, not the (always-absent) content
+  // `is_ok`. This is the regression #1359 left unaddressed on the producer side.
+
+  it("tool_result with toolError:true maps to success=false even with plain-text content", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: "bash: command not found",
+      toolError: true,
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as {
+      result: { success: boolean; error?: { message: string }; content?: unknown };
+    };
+    expect(action.result.success).toBe(false);
+    expect(action.result.error?.message).toBe("bash: command not found");
+    // No success-only system notification when the tool failed
+    expect(result.actions.length).toBe(1);
+  });
+
+  it("tool_result with toolError:false maps to success=true", () => {
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: "file written",
+      toolError: false,
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { result: { success: boolean } };
+    expect(action.result.success).toBe(true);
+  });
+
+  it("toolError field overrides a conflicting content is_ok flag", () => {
+    // The first-class field wins over content — guards against a runtime whose
+    // output text happens to contain a misleading `is_ok` key.
+    const context = makeContext({ turnId: "t1", openToolCalls: ["tc-1"] });
+    const event = makeEvent("tool_result", {
+      toolCallId: "tc-1",
+      content: JSON.stringify({ is_ok: true, content: "looks ok but failed" }),
+      toolError: true,
+    });
+    const result = mapAgentEvent(event, 0, context);
+
+    const action = result.actions[0] as { result: { success: boolean } };
+    expect(action.result.success).toBe(false);
   });
 
   it("tool_result with no content emits no system notification", () => {

--- a/packages/common/src/ahp-mapper.ts
+++ b/packages/common/src/ahp-mapper.ts
@@ -77,6 +77,13 @@ export interface AgentEventFields {
   turnId?: string;
   /** `true` for diagnostic system events that route to OTLP telemetry (HR7). */
   diagnostic?: boolean;
+  /**
+   * `true` when a `tool_result` reported a tool failure (#1362). Set by the
+   * runtime adapter from its native outcome signal; this is the authoritative
+   * source for `SessionToolCallComplete.result.success` (the AHP wire drops
+   * `raw`, where the runtimes' error flags used to live).
+   */
+  toolError?: boolean;
   /** ISO-8601 timestamp string (passed through from the runtime). */
   timestamp?: string;
   /** Raw event body — opaque to the mapper, used by JSONL persistence. */
@@ -449,13 +456,22 @@ export function mapAgentEvent(
         }
       }
 
-      const isOk = hasParsed
-        ? "is_ok" in parsed
-          ? parsed.is_ok === true
-          : "success" in parsed
-            ? parsed.success === true
-            : true
-        : true;
+      // The first-class `toolError` field (#1362) is authoritative — every
+      // runtime adapter sets it from its native outcome signal, which the AHP
+      // wire would otherwise lose (it doesn't carry `raw`). Fall back to the
+      // content `is_ok`/`success` keys only when `toolError` is absent (e.g.
+      // legacy/replayed events reconstructed from `content` by the reverse
+      // mapper), defaulting to success when nothing indicates failure.
+      const isOk =
+        event.toolError !== undefined
+          ? !event.toolError
+          : hasParsed
+            ? "is_ok" in parsed
+              ? parsed.is_ok === true
+              : "success" in parsed
+                ? parsed.success === true
+                : true
+            : true;
       const pastTenseMessage = hasParsed
         ? str(parsed, ["past_tense_message"], content || "")
         : content || "";

--- a/packages/common/src/ahp-reverse-mapper.test.ts
+++ b/packages/common/src/ahp-reverse-mapper.test.ts
@@ -325,6 +325,8 @@ describe("reverseMapAction", () => {
       expect(parsed.is_ok).toBe(true);
       expect(parsed.content).toBe("file contents");
       expect(parsed.past_tense_message).toBe("Read foo.txt");
+      // #1362: success also clears the first-class field.
+      expect(evt.toolError).toBe(false);
     });
 
     it("SessionToolCallComplete (failure) → tool_result with is_ok=false", () => {
@@ -344,6 +346,8 @@ describe("reverseMapAction", () => {
       );
       const parsed = JSON.parse(res.events[0]?.content ?? "") as { is_ok: boolean };
       expect(parsed.is_ok).toBe(false);
+      // #1362: failure sets the first-class field so consumers needn't parse content.
+      expect(res.events[0]?.toolError).toBe(true);
     });
   });
 

--- a/packages/common/src/ahp-reverse-mapper.ts
+++ b/packages/common/src/ahp-reverse-mapper.ts
@@ -330,6 +330,10 @@ export function reverseMapAction(
       const trEvt: AgentEventFields = {
         type: "tool_result",
         toolCallId: a.toolCallId,
+        // Carry the outcome on both the first-class `toolError` field (#1362)
+        // and the structured `content.is_ok` so consumers that prefer the
+        // field and those that still parse content both see the failure.
+        toolError: !isOk,
         content: JSON.stringify({
           is_ok: isOk,
           content: resultText,

--- a/packages/common/src/proto/grackle/grackle_types.proto
+++ b/packages/common/src/proto/grackle/grackle_types.proto
@@ -368,6 +368,7 @@ message SessionEvent {
   bool diagnostic = 7; // true = runtime lifecycle/diagnostic; tee to telemetry sinks (may be excluded from SessionState in a later HR step); AHP HR7
   string turn_id = 8; // turn this event belongs to; "" for out-of-band/liveness events (startup, status, worktree setup, kill); set by host turn framing (AHP HR2)
   string server_seq = 9; // ULID assigned by recordSessionAction(); the canonical dedup + sort key for the UI. Empty for legacy logs predating HR8d (the UI falls back to timestamp|type then).
+  bool tool_error = 10; // true = tool_result reported failure; false/unset = success or N/A. Lifted from each runtime's native outcome signal so the AHP wire (which drops `raw`) carries it as result.success (#1362)
 }
 
 message SessionEventList {

--- a/packages/common/src/proto/grackle/powerline/powerline.proto
+++ b/packages/common/src/proto/grackle/powerline/powerline.proto
@@ -66,6 +66,7 @@ message AgentEvent {
   string tool_call_id = 6; // stable runtime tool-call id (pairs tool_use↔tool_result); "" when N/A (AHP HR3)
   bool diagnostic = 7; // true = runtime lifecycle/diagnostic; tee to telemetry sinks (may be excluded from SessionState in a later HR step); AHP HR7
   string turn_id = 8; // turn this event belongs to; "" for out-of-band/liveness events (startup, status, worktree setup, kill); set by host turn framing (AHP HR2)
+  bool tool_error = 9; // true = tool_result reported failure; false/unset = success or N/A. Lifted from each runtime's native outcome signal so the AHP wire (which drops `raw`) carries it as result.success (#1362)
 }
 
 message SessionInfo {

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -189,6 +189,7 @@ export function processEventStream(
         const eventToolCallId: string = event.toolCallId ?? "";
         const eventTurnId: string = event.turnId ?? "";
         const eventDiagnostic: boolean = event.diagnostic ?? false;
+        const eventToolError: boolean = event.toolError ?? false;
         // runtime_session_id is an internal control event: persist it then skip
         // logging/publishing — it has no proto enum value and is not client-visible.
         if (event.type === "runtime_session_id") {
@@ -207,6 +208,7 @@ export function processEventStream(
           toolCallId: eventToolCallId,
           diagnostic: eventDiagnostic,
           turnId: eventTurnId,
+          toolError: eventToolError,
         });
         // ULID first — JSONL + WS push carry it so the UI can dedup/sort on
         // a stable key independent of the (possibly synthesized) timestamp.

--- a/packages/core/src/log-writer.ts
+++ b/packages/core/src/log-writer.ts
@@ -54,6 +54,7 @@ export async function writeEvent(logPath: string, event: grackle.SessionEvent): 
     diagnostic: event.diagnostic || undefined,
     turn_id: event.turnId || undefined,
     server_seq: event.serverSeq || undefined,
+    tool_error: event.toolError || undefined,
   });
 
   const ok = ws.write(line + "\n");
@@ -91,6 +92,8 @@ export interface LogEntry {
   turn_id?: string;
   /** ULID assigned by `recordSessionAction()` — canonical dedup + sort key. Absent on legacy logs predating HR8d. */
   server_seq?: string;
+  /** True when a tool_result reported failure (#1362). Absent on success and non-tool events. */
+  tool_error?: boolean;
 }
 
 /** Number of bytes to read from the tail of a log file when searching for the last text entry. */

--- a/packages/powerline/src/ahp-handlers.ts
+++ b/packages/powerline/src/ahp-handlers.ts
@@ -500,6 +500,7 @@ export function mountAhpServer(opts: MountAhpServerOptions): AhpServerSocket {
       toolCallId: event.toolCallId,
       turnId: event.turnId,
       diagnostic: event.diagnostic,
+      toolError: event.toolError,
       timestamp: event.timestamp,
       raw: event.raw !== undefined ? JSON.stringify(event.raw) : undefined,
     };

--- a/packages/powerline/src/runtimes/stub-scenario.ts
+++ b/packages/powerline/src/runtimes/stub-scenario.ts
@@ -226,6 +226,13 @@ export function buildEventFromEmitStep(
   if (raw !== undefined) {
     event.raw = raw;
   }
+  // Mirror the synthetic raw.is_error onto the first-class toolError field
+  // (#1362) so scenario fixtures faithfully exercise failure propagation, not
+  // just the legacy raw reader.
+  if (step.emit === "tool_result") {
+    const rawObj = typeof raw === "object" && raw !== null ? (raw as { is_error?: unknown }) : {};
+    event.toolError = rawObj.is_error === true;
+  }
   // Surface the synthesized id on the first-class field (AHP HR3) so fixtures
   // exercise tool_call_id pairing, not just the legacy raw reader.
   if (step.emit === "tool_use") {

--- a/packages/powerline/src/runtimes/stub.ts
+++ b/packages/powerline/src/runtimes/stub.ts
@@ -257,6 +257,7 @@ export class StubSession implements AgentSession {
             }),
             raw: { type: "tool_result", tool_use_id: toolUseId, is_error: true },
             toolCallId: toolUseId,
+            toolError: true,
           };
         } else {
           const mcpEvents = await this.performMcpToolCall(ts, step.mcp_call, step.args ?? {});
@@ -338,6 +339,7 @@ export class StubSession implements AgentSession {
         content: JSON.stringify(result),
         raw: { type: "tool_result", tool_use_id: toolUseId, is_error: false },
         toolCallId: toolUseId,
+        toolError: false,
       });
     } catch (err) {
       logger.warn(
@@ -363,6 +365,7 @@ export class StubSession implements AgentSession {
         }),
         raw: { type: "tool_result", tool_use_id: toolUseId, is_error: true },
         toolCallId: toolUseId,
+        toolError: true,
       });
     } finally {
       if (mcpClient) {
@@ -464,6 +467,7 @@ export class StubSession implements AgentSession {
         }),
         raw: { type: "tool_result", tool_use_id: toolUseId, is_error: !present },
         toolCallId: toolUseId,
+        toolError: !present,
       });
       // Distinctive marker (only on the success path) so a test can assert the
       // notification actually drove the re-list, not just that the tool name appears.
@@ -488,6 +492,7 @@ export class StubSession implements AgentSession {
         }),
         raw: { type: "tool_result", tool_use_id: toolUseId, is_error: true },
         toolCallId: toolUseId,
+        toolError: true,
       });
     } finally {
       if (mcpClient) {

--- a/packages/runtime-acp/src/acp.ts
+++ b/packages/runtime-acp/src/acp.ts
@@ -154,7 +154,16 @@ export function mapSessionUpdate(update: Record<string, unknown>): AgentEvent[] 
           update.rawOutput !== null && update.rawOutput !== undefined
             ? JSON.stringify(update.rawOutput)
             : ((update.content || "") as string);
-        return [{ type: "tool_result", timestamp: ts, content: output, raw, toolCallId }];
+        return [
+          {
+            type: "tool_result",
+            timestamp: ts,
+            content: output,
+            raw,
+            toolCallId,
+            toolError: false,
+          },
+        ];
       }
       if (status === "failed") {
         const rawOutput = update.rawOutput as Record<string, unknown> | undefined;
@@ -166,6 +175,8 @@ export function mapSessionUpdate(update: Record<string, unknown>): AgentEvent[] 
             content: typeof errorContent === "string" ? errorContent : JSON.stringify(errorContent),
             raw,
             toolCallId,
+            // ACP signals failure via the update status, not content (#1362).
+            toolError: true,
           },
         ];
       }

--- a/packages/runtime-claude-code/src/claude-code.ts
+++ b/packages/runtime-claude-code/src/claude-code.ts
@@ -118,6 +118,8 @@ export function mapMessage(msg: Record<string, unknown>): AgentEvent[] {
             content: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
             raw: b,
             toolCallId: typeof b.tool_use_id === "string" ? b.tool_use_id : undefined,
+            // Anthropic tool_result blocks carry the failure flag here (#1362).
+            toolError: b.is_error === true,
           });
         }
       }
@@ -617,6 +619,9 @@ class ClaudeCodeSession extends BaseAgentSession {
         content: "",
         raw: { tool_use_id: id, is_error: false, synthetic: true },
         toolCallId: id,
+        // Synthetic results stand in for tools the SDK ran internally and
+        // didn't surface — treat as successful completions (#1362).
+        toolError: false,
       });
     }
     this.pendingToolUseIds.clear();

--- a/packages/runtime-codex/src/codex.ts
+++ b/packages/runtime-codex/src/codex.ts
@@ -353,6 +353,8 @@ class CodexSession extends BaseAgentSession {
               content: exitCode !== undefined ? `[exit ${exitCode}] ${output}` : output,
               raw: event,
               toolCallId,
+              // Non-zero exit code is a command failure (#1362).
+              toolError: exitCode !== undefined && exitCode !== 0,
             });
           } else if (type === "file_change") {
             messageCount++;
@@ -369,6 +371,8 @@ class CodexSession extends BaseAgentSession {
               }),
               raw: event,
               toolCallId,
+              // Codex marks a rejected/failed patch via `status` (#1362).
+              toolError: item.status === "failed",
             });
           } else if (type === "agent_message") {
             messageCount++;
@@ -398,6 +402,8 @@ class CodexSession extends BaseAgentSession {
               content: errorStr || resultStr || "",
               raw: event,
               toolCallId,
+              // An `error` object on the MCP result means the call failed (#1362).
+              toolError: errorObj !== undefined,
             });
           } else if (type === "reasoning") {
             messageCount++;

--- a/packages/runtime-copilot/src/copilot.ts
+++ b/packages/runtime-copilot/src/copilot.ts
@@ -327,6 +327,8 @@ export class CopilotSession extends BaseAgentSession {
         content: output,
         raw: event,
         toolCallId: typeof data?.toolCallId === "string" ? data.toolCallId : undefined,
+        // Copilot reports the outcome on the event data, not in content (#1362).
+        toolError: data?.success === false || Boolean(error),
       });
     });
 

--- a/packages/runtime-sdk/src/runtime.ts
+++ b/packages/runtime-sdk/src/runtime.ts
@@ -27,6 +27,15 @@ export interface AgentEvent {
    * status, worktree setup, kill). Process-scoped — a resume starts a new turn.
    */
   turnId?: string;
+  /**
+   * True when a `tool_result` event reports a tool failure (AHP-followup #1362).
+   * Set by the runtime adapter from its SDK's native outcome signal (Claude
+   * Code `is_error`, Copilot `data.success`/`error`, Codex exit code/status,
+   * ACP `status === "failed"`). Left unset on success and on non-tool events.
+   * The AHP wire drops `raw`, so this first-class field is what carries the
+   * pass/fail outcome into `SessionToolCallComplete.result.success`.
+   */
+  toolError?: boolean;
 }
 
 /** Parameters for spawning a new agent session. */

--- a/packages/web-components/src/components/display/EventRenderer.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.tsx
@@ -332,20 +332,22 @@ export function EventRenderer({ event, toolUseCtx, settled, sandboxProxyUrl }: P
       // When paired, toolUseCtx provides the tool name, args, and optional detailedResult.
       // When unpaired, fall back to a generic display.
       //
-      // HR8d follow-up #1355: error detection. The AHP wire doesn't carry
-      // `event.raw` (the runtime-native block) — the reverse mapper instead
-      // produces a structured `{is_ok, content, past_tense_message}` JSON
-      // content shape that encodes the success flag. Read `is_ok === false`
-      // from the content for HR8d-era events; fall back to the legacy
-      // `raw.is_error` path for pre-HR8d JSONL replay.
-      let isError = false;
-      try {
-        const parsed = JSON.parse(event.content) as Record<string, unknown>;
-        if (parsed.is_ok === false) {
-          isError = true;
+      // Error detection (#1362): prefer the first-class `toolError` field,
+      // set by every runtime adapter from its native outcome signal and
+      // carried across the AHP wire as `result.success`. Fall back to the
+      // structured `content.is_ok === false` shape the reverse mapper writes
+      // (HR8d #1355), then to the legacy `raw.is_error` path for pre-HR8d
+      // JSONL replay.
+      let isError = event.toolError === true;
+      if (!isError) {
+        try {
+          const parsed = JSON.parse(event.content) as Record<string, unknown>;
+          if (parsed.is_ok === false) {
+            isError = true;
+          }
+        } catch {
+          /* content not JSON — fall through to legacy raw check */
         }
-      } catch {
-        /* content not JSON — fall through to legacy raw check */
       }
       if (!isError && event.raw) {
         try {

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -90,6 +90,13 @@ export interface SessionEvent {
    * predating HR8d; consumers should fall back to `${timestamp}|${eventType}`.
    */
   serverSeq?: string;
+  /**
+   * `true` when a `tool_result` reported a tool failure (#1362). First-class
+   * outcome flag, preferred over parsing `is_ok` out of `content` or
+   * `is_error` out of the legacy `raw` payload. Absent/false on success and
+   * on non-tool events.
+   */
+  toolError?: boolean;
 }
 
 /** A workspace that groups tasks. */

--- a/packages/web/src/hooks/proto-converters.ts
+++ b/packages/web/src/hooks/proto-converters.ts
@@ -77,6 +77,7 @@ export function protoToSessionEvent(p: grackle.SessionEvent): SessionEvent {
     toolCallId: p.toolCallId || undefined,
     turnId: p.turnId || undefined,
     serverSeq: p.serverSeq || undefined,
+    toolError: p.toolError || undefined,
   };
 }
 

--- a/packages/web/src/hooks/useEventStream.ts
+++ b/packages/web/src/hooks/useEventStream.ts
@@ -37,6 +37,7 @@ export interface UseEventStreamOptions {
     toolCallId: string;
     turnId: string;
     serverSeq: string;
+    toolError: boolean;
   }) => void;
   /** Called for each domain event (task.created, environment.changed, etc.). */
   onDomainEvent: (event: {
@@ -138,6 +139,7 @@ export function useEventStream(options: UseEventStreamOptions): UseEventStreamRe
               toolCallId: v.toolCallId,
               turnId: v.turnId,
               serverSeq: v.serverSeq,
+              toolError: v.toolError,
             });
           } else if (evt.case === "domainEvent") {
             const v = evt.value;

--- a/packages/web/src/hooks/useGrackleSocket.ts
+++ b/packages/web/src/hooks/useGrackleSocket.ts
@@ -139,6 +139,7 @@ export function useGrackleSocket(): UseGrackleSocketResult {
         toolCallId: evt.toolCallId || undefined,
         turnId: evt.turnId || undefined,
         serverSeq: evt.serverSeq || undefined,
+        toolError: evt.toolError || undefined,
       });
     },
     onDomainEvent: (evt) => {


### PR DESCRIPTION
## Summary
The HR8d forward mapper derived tool success from the event **content** (`is_ok`/`success`, default `true`), but every runtime carries the outcome in `raw` — Claude `is_error`, Copilot `data.success`/`error`, Codex `exit_code`/`status`/`error`, ACP `status === "failed"` — which the AHP wire drops. So **every failed tool call serialized as `SessionToolCallComplete{ success: true }`** and rendered as a success. #1359 fixed only the consumer half (`EventRenderer` reading `content.is_ok`); the producer edge was never connected.

Fix follows the HR3/HR7 precedent — lift the signal to a first-class field:
- **proto**: `AgentEvent.tool_error=9`, `SessionEvent.tool_error=10`; `runtime-sdk` `AgentEvent.toolError`; `AgentEventFields.toolError`
- **runtimes**: each adapter sets `toolError` from its native outcome signal (Claude `is_error`, Copilot `data.success`/`error`, Codex per-type exit/status/error, ACP failed-status)
- **forward mapper** (`ahp-mapper.ts`): `isOk = !(event.toolError ?? false)`, with content `is_ok`/`success` kept as a defensive fallback for replayed events — this is the actual fix
- **reverse mapper / event-processor / web hooks**: thread `toolError` through; `EventRenderer` now prefers the first-class field over parsing `content.is_ok`

The conformance spike (#1235) caught this: it read `raw.is_error`, which production diverged from during the wire flip.

## Test plan
- [x] `rush build` clean (api-extractor reports regenerated)
- [x] Unit tests green: `common` 160 (new authoritative mapper + round-trip cases, incl. field-overrides-content), runtimes 148, `core` 470, `powerline` 115
- [x] Replaced the bug-encoding `ahp-mapper.test.ts` assertion; added per-field tests
- [ ] **Live**: spawn Claude Code, run a failing command, confirm UI shows the error accent and the wire `SessionToolCallComplete` carries `success:false`

Note: `packages/web` changes are non-visual hook plumbing (forwarding the field) — no screenshots.

Closes #1362