### PR TITLE
Fix Knowledge tab 503 retry storm + frozen tab navigation (#1357)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1357-knowledge-tab-fix_2026-05-29-14-42.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1357-knowledge-tab-fix_2026-05-29-14-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix Knowledge tab 503 retry storm and frozen tab navigation when the knowledge server (Neo4j) is unreachable, and surface an explicit \"Knowledge server can't be reached\" state with a Retry action (#1357).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -672,6 +672,16 @@ export interface UseStreamsResult {
 
 // ─── Knowledge hook result ────────────────────────────────────────────────────
 
+/**
+ * Reason the knowledge graph failed to load.
+ *
+ * - `"unavailable"` — the knowledge server (Neo4j) is not running or is
+ *   unreachable (the RPC returned gRPC `Unavailable`). Surfaced to the user as
+ *   a "knowledge server can't be reached" state.
+ * - `"error"` — any other failure (malformed response, unexpected status).
+ */
+export type KnowledgeLoadError = "unavailable" | "error";
+
 /** Result returned by useKnowledge. */
 export interface UseKnowledgeResult {
   graphData: { nodes: GraphNode[]; links: GraphLink[] };
@@ -679,6 +689,8 @@ export interface UseKnowledgeResult {
   /** Currently selected node ID. */
   selectedId: string | undefined;
   loading: boolean;
+  /** Set when the most recent graph load failed; `undefined` when it succeeded. */
+  loadError: KnowledgeLoadError | undefined;
   searchQuery: string;
   search(query: string): Promise<void>;
   clearSearch(): void;

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -195,6 +195,7 @@ export type {
   GraphLink,
   NodeDetail,
   UseKnowledgeResult,
+  KnowledgeLoadError,
   UseEnvironmentsResult,
   UseSessionsResult,
   UseWorkspacesResult,

--- a/packages/web-components/src/mocks/MockGrackleProvider.tsx
+++ b/packages/web-components/src/mocks/MockGrackleProvider.tsx
@@ -1176,6 +1176,7 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
         graphData: { nodes: knowledgeNodes, links: knowledgeLinks },
         selectedNode: knowledgeSelectedNode,
         loading: false,
+        loadError: undefined,
         selectedId: knowledgeSelectedId,
         searchQuery: knowledgeSearchQuery,
         search: async (query: string) => {

--- a/packages/web/src/hooks/useKnowledge.test.ts
+++ b/packages/web/src/hooks/useKnowledge.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { ConnectError, Code } from "@connectrpc/connect";
 import { useKnowledge } from "./useKnowledge.js";
 
 // ---------------------------------------------------------------------------
@@ -53,9 +54,12 @@ function makeProtoEdge(overrides: Record<string, unknown> = {}): Record<string, 
   };
 }
 
-function setup(): { result: { current: ReturnType<typeof useKnowledge> } } {
-  const { result } = renderHook(() => useKnowledge());
-  return { result };
+function setup(): {
+  result: { current: ReturnType<typeof useKnowledge> };
+  rerender: () => void;
+} {
+  const { result, rerender } = renderHook(() => useKnowledge());
+  return { result, rerender };
 }
 
 beforeEach(() => {
@@ -144,6 +148,61 @@ describe("useKnowledge", () => {
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
+      });
+    });
+
+    // ── loadError classification (#1357) ──────────────────────────
+
+    it("starts with no loadError", () => {
+      const { result } = setup();
+      expect(result.current.loadError).toBeUndefined();
+    });
+
+    it('sets loadError="unavailable" when the knowledge server is unreachable', async () => {
+      mockClient.listRecentKnowledgeNodes.mockRejectedValue(
+        new ConnectError("Neo4j unreachable", Code.Unavailable),
+      );
+      const { result } = setup();
+      act(() => {
+        result.current.loadRecent().catch(() => {});
+      });
+
+      await waitFor(() => {
+        expect(result.current.loadError).toBe("unavailable");
+      });
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('sets loadError="error" for non-Unavailable failures', async () => {
+      mockClient.listRecentKnowledgeNodes.mockRejectedValue(new Error("boom"));
+      const { result } = setup();
+      act(() => {
+        result.current.loadRecent().catch(() => {});
+      });
+
+      await waitFor(() => {
+        expect(result.current.loadError).toBe("error");
+      });
+    });
+
+    it("clears a prior loadError on a subsequent successful load", async () => {
+      mockClient.listRecentKnowledgeNodes.mockRejectedValueOnce(
+        new ConnectError("Neo4j unreachable", Code.Unavailable),
+      );
+      const { result } = setup();
+      act(() => {
+        result.current.loadRecent().catch(() => {});
+      });
+      await waitFor(() => {
+        expect(result.current.loadError).toBe("unavailable");
+      });
+
+      mockClient.listRecentKnowledgeNodes.mockResolvedValue({ nodes: [], edges: [] });
+      act(() => {
+        result.current.loadRecent().catch(() => {});
+      });
+      await waitFor(() => {
+        expect(result.current.loadError).toBeUndefined();
       });
     });
   });
@@ -382,6 +441,23 @@ describe("useKnowledge", () => {
         });
       });
       expect(handled).toBe(false);
+    });
+  });
+
+  // ── referential stability hardening (#1357) ───────────────────
+
+  describe("referential stability", () => {
+    it("keeps a stable object identity across renders with no state change", () => {
+      const { result, rerender } = setup();
+      const first = result.current;
+      rerender();
+      // A new object identity every render is what let a consumer's
+      // `useEffect([knowledge])` re-fire endlessly and storm the server.
+      // Whole-object identity stability also guarantees the callbacks and
+      // nested objects are stable (same reference ⇒ same members).
+      expect(result.current).toBe(first);
+      expect(result.current.graphData).toBe(first.graphData);
+      expect(result.current.domainHook).toBe(first.domainHook);
     });
   });
 

--- a/packages/web/src/hooks/useKnowledge.ts
+++ b/packages/web/src/hooks/useKnowledge.ts
@@ -7,11 +7,13 @@
  * @module
  */
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useMemo } from "react";
+import { ConnectError, Code } from "@connectrpc/connect";
 import type {
   GrackleEvent,
   GraphNode,
   GraphLink,
+  KnowledgeLoadError,
   NodeDetail,
   UseKnowledgeResult,
 } from "@grackle-ai/web-components";
@@ -26,6 +28,7 @@ import { protoToGraphNode, protoToGraphLink } from "./proto-converters.js";
 export type {
   GraphNode,
   GraphLink,
+  KnowledgeLoadError,
   NodeDetail,
   UseKnowledgeResult,
 } from "@grackle-ai/web-components";
@@ -46,6 +49,17 @@ function safeParseJson(json: string): Record<string, unknown> | undefined {
   }
 }
 
+/**
+ * Classify a failed knowledge RPC into a {@link KnowledgeLoadError}.
+ *
+ * The backend throws `ConnectError` with `Code.Unavailable` when Neo4j is not
+ * running or unreachable; that maps to the "knowledge server can't be reached"
+ * UX. Everything else is a generic `"error"`.
+ */
+function classifyLoadError(err: unknown): KnowledgeLoadError {
+  return ConnectError.from(err).code === Code.Unavailable ? "unavailable" : "error";
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -57,6 +71,7 @@ export function useKnowledge(): UseKnowledgeResult {
   const [selectedNode, setSelectedNode] = useState<NodeDetail | undefined>(undefined);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<KnowledgeLoadError | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState("");
 
   /** Tracks the active workspace filter so search and clearSearch can use it. */
@@ -66,6 +81,7 @@ export function useKnowledge(): UseKnowledgeResult {
     const effectiveWsId = workspaceId ?? "";
     workspaceIdRef.current = effectiveWsId;
     setSearchQuery("");
+    setLoadError(undefined);
     setLoading(true);
     try {
       const resp = await grackleClient.listRecentKnowledgeNodes({
@@ -96,8 +112,8 @@ export function useKnowledge(): UseKnowledgeResult {
 
       setNodes(nodeMap);
       setLinks(linkList);
-    } catch {
-      // empty
+    } catch (err) {
+      setLoadError(classifyLoadError(err));
     } finally {
       setLoading(false);
     }
@@ -110,6 +126,7 @@ export function useKnowledge(): UseKnowledgeResult {
     setSearchQuery(query);
     setSelectedId(undefined);
     setSelectedNode(undefined);
+    setLoadError(undefined);
     setLoading(true);
     try {
       const resp = await grackleClient.searchKnowledge({
@@ -131,8 +148,8 @@ export function useKnowledge(): UseKnowledgeResult {
 
       setNodes(nodeMap);
       setLinks(linkList);
-    } catch {
-      // empty
+    } catch (err) {
+      setLoadError(classifyLoadError(err));
     } finally {
       setLoading(false);
     }
@@ -206,25 +223,59 @@ export function useKnowledge(): UseKnowledgeResult {
     return false;
   }, []);
 
-  const domainHook: DomainHook = {
-    onConnect: async () => {}, // Knowledge is page-scoped; no global reload needed
-    onDisconnect: () => {},
-    handleEvent,
-  };
+  // Knowledge is page-scoped; no global reload needed. Memoized so the hook's
+  // public object identity stays stable across renders (see return below).
+  const domainHook = useMemo<DomainHook>(
+    () => ({
+      onConnect: async () => {},
+      onDisconnect: () => {},
+      handleEvent,
+    }),
+    [handleEvent],
+  );
 
-  return {
-    graphData: { nodes: [...nodes.values()], links },
-    selectedNode,
-    selectedId,
-    loading,
-    searchQuery,
-    search,
-    clearSearch,
-    selectNode,
-    clearSelection,
-    expandNode,
-    loadRecent,
-    handleEvent,
-    domainHook,
-  };
+  // Derive graphData only when the underlying node/link state changes, so the
+  // force-directed graph isn't handed a brand-new prop (and re-simulated) on
+  // every unrelated render.
+  const graphData = useMemo(() => ({ nodes: [...nodes.values()], links }), [nodes, links]);
+
+  // Hardening (#1357): return a referentially stable object. All callbacks are
+  // stable (`useCallback([])`) and `graphData`/`domainHook` are memoized, so
+  // this object only changes identity when real state changes. That keeps the
+  // `knowledge` slice from re-triggering consumer effects/`useCallback`s that
+  // depend on it on every render — the render-loop footgun that froze the tab.
+  return useMemo<UseKnowledgeResult>(
+    () => ({
+      graphData,
+      selectedNode,
+      selectedId,
+      loading,
+      loadError,
+      searchQuery,
+      search,
+      clearSearch,
+      selectNode,
+      clearSelection,
+      expandNode,
+      loadRecent,
+      handleEvent,
+      domainHook,
+    }),
+    [
+      graphData,
+      selectedNode,
+      selectedId,
+      loading,
+      loadError,
+      searchQuery,
+      search,
+      clearSearch,
+      selectNode,
+      clearSelection,
+      expandNode,
+      loadRecent,
+      handleEvent,
+      domainHook,
+    ],
+  );
 }

--- a/packages/web/src/pages/KnowledgePage.module.scss
+++ b/packages/web/src/pages/KnowledgePage.module.scss
@@ -29,3 +29,10 @@
     font-size: 14px;
   }
 }
+
+.retryButton {
+  @include btn-outline;
+  margin-top: var(--space-md);
+  padding: var(--space-xs) var(--space-md);
+  font-size: 14px;
+}

--- a/packages/web/src/pages/KnowledgePage.test.tsx
+++ b/packages/web/src/pages/KnowledgePage.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { UseKnowledgeResult } from "@grackle-ai/web-components";
+import { KnowledgePage } from "./KnowledgePage.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// `useGrackle` reads from a mutable holder so each test can control the
+// returned `knowledge` slice and swap it between renders. The heavy
+// web-components (force-graph canvas, router-backed breadcrumbs) are stubbed
+// to nulls — this test only exercises KnowledgePage's own effect + branching.
+// ---------------------------------------------------------------------------
+
+const holder = vi.hoisted(() => ({ knowledge: undefined as unknown as UseKnowledgeResult }));
+
+vi.mock("../context/GrackleContext.js", () => ({
+  useGrackle: () => ({ knowledge: holder.knowledge }),
+}));
+
+vi.mock("@grackle-ai/web-components", () => ({
+  KNOWLEDGE_URL: "/knowledge",
+  Breadcrumbs: () => null,
+  KnowledgeGraph: () => null,
+  KnowledgeDetailPanel: () => null,
+}));
+
+/** Build a knowledge slice with sensible defaults, overridable per test. */
+function makeKnowledge(overrides: Partial<UseKnowledgeResult> = {}): UseKnowledgeResult {
+  return {
+    graphData: { nodes: [], links: [] },
+    selectedNode: undefined,
+    selectedId: undefined,
+    loading: false,
+    loadError: undefined,
+    searchQuery: "",
+    search: vi.fn().mockResolvedValue(undefined),
+    clearSearch: vi.fn(),
+    selectNode: vi.fn().mockResolvedValue(undefined),
+    clearSelection: vi.fn(),
+    expandNode: vi.fn().mockResolvedValue(undefined),
+    loadRecent: vi.fn().mockResolvedValue(undefined),
+    handleEvent: vi.fn().mockReturnValue(false),
+    domainHook: { onConnect: vi.fn(), onDisconnect: vi.fn(), handleEvent: vi.fn() },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  // This package's vitest config doesn't enable globals, so testing-library's
+  // automatic per-test cleanup isn't registered — unmount explicitly.
+  cleanup();
+});
+
+describe("KnowledgePage", () => {
+  // ── mount-once invariant (#1357) ──────────────────────────────
+
+  it("calls loadRecent exactly once on mount", () => {
+    const loadRecent = vi.fn().mockResolvedValue(undefined);
+    holder.knowledge = makeKnowledge({ loadRecent });
+
+    render(<KnowledgePage />);
+
+    expect(loadRecent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-fire loadRecent when the knowledge object identity changes", () => {
+    // Regression for the render-loop: the effect must depend on the stable
+    // `loadRecent` callback, not the `knowledge` wrapper. A fresh wrapper object
+    // every render (the pre-fix reality) must NOT re-trigger the load.
+    const loadRecent = vi.fn().mockResolvedValue(undefined);
+    holder.knowledge = makeKnowledge({ loadRecent });
+
+    const { rerender } = render(<KnowledgePage />);
+    expect(loadRecent).toHaveBeenCalledTimes(1);
+
+    // New wrapper object, same stable callback — as the real hook now behaves.
+    holder.knowledge = makeKnowledge({ loadRecent });
+    rerender(<KnowledgePage />);
+    holder.knowledge = makeKnowledge({ loadRecent });
+    rerender(<KnowledgePage />);
+
+    expect(loadRecent).toHaveBeenCalledTimes(1);
+  });
+
+  // ── error UX (#1357) ──────────────────────────────────────────
+
+  it('shows "knowledge server can\'t be reached" when loadError is "unavailable"', () => {
+    holder.knowledge = makeKnowledge({ loadError: "unavailable" });
+
+    render(<KnowledgePage />);
+
+    expect(screen.getByTestId("knowledge-error")).toBeTruthy();
+    expect(screen.getByText(/can't be reached/i)).toBeTruthy();
+    expect(screen.queryByText(/No knowledge nodes found/i)).toBeNull();
+  });
+
+  it('shows a generic error when loadError is "error"', () => {
+    holder.knowledge = makeKnowledge({ loadError: "error" });
+
+    render(<KnowledgePage />);
+
+    expect(screen.getByTestId("knowledge-error")).toBeTruthy();
+    expect(screen.getByText(/Failed to load the knowledge graph/i)).toBeTruthy();
+  });
+
+  it("retries loadRecent when the Retry button is clicked", () => {
+    const loadRecent = vi.fn().mockResolvedValue(undefined);
+    holder.knowledge = makeKnowledge({ loadError: "unavailable", loadRecent });
+
+    render(<KnowledgePage />);
+    expect(loadRecent).toHaveBeenCalledTimes(1); // mount
+
+    fireEvent.click(screen.getByTestId("knowledge-retry"));
+    expect(loadRecent).toHaveBeenCalledTimes(2); // retry
+  });
+
+  it("hides the error and shows the empty state once loading begins", () => {
+    // While a (re)load is in flight we should not flash the error panel.
+    holder.knowledge = makeKnowledge({ loadError: "unavailable", loading: true });
+
+    render(<KnowledgePage />);
+
+    expect(screen.queryByTestId("knowledge-error")).toBeNull();
+  });
+
+  it("shows the empty state when there are no nodes and no error", () => {
+    holder.knowledge = makeKnowledge();
+
+    render(<KnowledgePage />);
+
+    expect(screen.getByText(/No knowledge nodes found/i)).toBeTruthy();
+    expect(screen.queryByTestId("knowledge-error")).toBeNull();
+  });
+});

--- a/packages/web/src/pages/KnowledgePage.test.tsx
+++ b/packages/web/src/pages/KnowledgePage.test.tsx
@@ -120,13 +120,15 @@ describe("KnowledgePage", () => {
     expect(loadRecent).toHaveBeenCalledTimes(2); // retry
   });
 
-  it("hides the error and shows the empty state once loading begins", () => {
-    // While a (re)load is in flight we should not flash the error panel.
+  it("hides the error panel while a (re)load is in flight", () => {
+    // While loading, neither the error nor the empty state shows (both branches
+    // require !loading) — importantly, a stale error must not flash during retry.
     holder.knowledge = makeKnowledge({ loadError: "unavailable", loading: true });
 
     render(<KnowledgePage />);
 
     expect(screen.queryByTestId("knowledge-error")).toBeNull();
+    expect(screen.queryByText(/No knowledge nodes found/i)).toBeNull();
   });
 
   it("shows the empty state when there are no nodes and no error", () => {

--- a/packages/web/src/pages/KnowledgePage.tsx
+++ b/packages/web/src/pages/KnowledgePage.tsx
@@ -20,11 +20,23 @@ import styles from "./KnowledgePage.module.scss";
 /** Knowledge Graph explorer page. */
 export function KnowledgePage(): JSX.Element {
   const { knowledge } = useGrackle();
+  const { loadRecent, loadError, loading, graphData, selectedId, selectedNode } = knowledge;
 
-  // Load recent nodes on mount
+  // Load recent nodes once on mount.
+  //
+  // Depend on the stable `loadRecent` callback, NOT the whole `knowledge`
+  // object (#1357). `knowledge` changes identity whenever any knowledge state
+  // updates, so `[knowledge]` here re-ran the effect on every render — each run
+  // fired `loadRecent`, whose `setLoading`/`setNodes` calls triggered the next
+  // render, an infinite fetch loop. Against a down Neo4j it became a 503 storm
+  // and froze tab navigation under the constant re-renders.
   useEffect(() => {
-    knowledge.loadRecent().catch(() => {});
-  }, [knowledge]);
+    loadRecent().catch(() => {});
+  }, [loadRecent]);
+
+  const handleRetry = useCallback(() => {
+    loadRecent().catch(() => {});
+  }, [loadRecent]);
 
   const handleNodeClick = useCallback(
     (nodeId: string) => {
@@ -46,29 +58,57 @@ export function KnowledgePage(): JSX.Element {
 
   const breadcrumbs = [{ label: "Knowledge", url: KNOWLEDGE_URL }];
 
+  const showError = loadError !== undefined && !loading;
+  const showEmpty = !showError && graphData.nodes.length === 0 && !loading;
+
   return (
     <div className={styles.layout} data-testid="knowledge-page">
       <Breadcrumbs segments={breadcrumbs} />
 
       <div className={styles.graphArea}>
-        {knowledge.graphData.nodes.length === 0 && !knowledge.loading ? (
+        {showError ? (
+          <div className={styles.empty} data-testid="knowledge-error">
+            {loadError === "unavailable" ? (
+              <>
+                <p>Knowledge server can&apos;t be reached.</p>
+                <p>
+                  The knowledge graph database (Neo4j) isn&apos;t running or is unreachable. Start
+                  it, then retry.
+                </p>
+              </>
+            ) : (
+              <>
+                <p>Failed to load the knowledge graph.</p>
+                <p>Something went wrong while loading knowledge nodes.</p>
+              </>
+            )}
+            <button
+              type="button"
+              className={styles.retryButton}
+              onClick={handleRetry}
+              data-testid="knowledge-retry"
+            >
+              Retry
+            </button>
+          </div>
+        ) : showEmpty ? (
           <div className={styles.empty}>
             <p>No knowledge nodes found.</p>
             <p>Create knowledge via MCP tools or let agents discover it during tasks.</p>
           </div>
         ) : (
           <KnowledgeGraph
-            graphData={knowledge.graphData}
-            selectedNodeId={knowledge.selectedId}
+            graphData={graphData}
+            selectedNodeId={selectedId}
             onNodeClick={handleNodeClick}
             onNodeDoubleClick={handleNodeDoubleClick}
           />
         )}
 
-        {knowledge.selectedNode && knowledge.selectedId && (
+        {selectedNode && selectedId && (
           <KnowledgeDetailPanel
-            detail={knowledge.selectedNode}
-            nodes={knowledge.graphData.nodes}
+            detail={selectedNode}
+            nodes={graphData.nodes}
             onClose={handleCloseDetail}
             onSelectNode={handleNodeClick}
           />

--- a/packages/web/src/pages/KnowledgePage.tsx
+++ b/packages/web/src/pages/KnowledgePage.tsx
@@ -21,6 +21,7 @@ import styles from "./KnowledgePage.module.scss";
 export function KnowledgePage(): JSX.Element {
   const { knowledge } = useGrackle();
   const { loadRecent, loadError, loading, graphData, selectedId, selectedNode } = knowledge;
+  const { selectNode, expandNode, clearSelection } = knowledge;
 
   // Load recent nodes once on mount.
   //
@@ -38,23 +39,26 @@ export function KnowledgePage(): JSX.Element {
     loadRecent().catch(() => {});
   }, [loadRecent]);
 
+  // Depend on the specific stable callback refs, not the whole `knowledge`
+  // object — `knowledge` changes identity on any knowledge state change, which
+  // would needlessly recreate these handlers and re-render the graph/detail.
   const handleNodeClick = useCallback(
     (nodeId: string) => {
-      knowledge.selectNode(nodeId).catch(() => {});
+      selectNode(nodeId).catch(() => {});
     },
-    [knowledge],
+    [selectNode],
   );
 
   const handleNodeDoubleClick = useCallback(
     (nodeId: string) => {
-      knowledge.expandNode(nodeId).catch(() => {});
+      expandNode(nodeId).catch(() => {});
     },
-    [knowledge],
+    [expandNode],
   );
 
   const handleCloseDetail = useCallback(() => {
-    knowledge.clearSelection();
-  }, [knowledge]);
+    clearSelection();
+  }, [clearSelection]);
 
   const breadcrumbs = [{ label: "Knowledge", url: KNOWLEDGE_URL }];
 


### PR DESCRIPTION
## Summary

Both reported symptoms trace to **one** root cause, not the two-distinct-bugs framing in the issue: there was no retry logic anywhere. `KnowledgePage`'s mount effect depended on the whole `knowledge` object, which changes identity on **every** render. So `useEffect([knowledge])` re-ran each render → `loadRecent` → `setState` → render → repeat: an infinite fetch loop throttled only by the network round-trip.

- Against a down/unreachable Neo4j the loop became a 503 **request storm** (bug 3a).
- The constant context-value churn re-rendered the whole tree every cycle, so sidebar tab clicks never stuck — the **frozen navigation** (bug 3b).
- It also looped on the success path, silently hammering `ListRecentKnowledgeNodes` whenever the tab was open.

### Changes

- **`KnowledgePage`**: depend on the stable `loadRecent` callback (`useCallback([])`) instead of the `knowledge` object — the load now runs exactly once on mount. Kills both the storm and the freeze.
- **`useKnowledge`** (hardening): return a referentially **stable, memoized** object (and memoize `graphData`/`domainHook`), so a stray `[knowledge]` dependency elsewhere can't resurrect this render-loop class and unrelated state changes don't re-render every `useGrackle()` consumer.
- **Failure UX**: track a `loadError` (`"unavailable"` when the RPC returns gRPC `Unavailable` = Neo4j down, vs generic `"error"`). The page now shows **"Knowledge server can't be reached."** with a Neo4j hint and a **Retry** button instead of the misleading "No knowledge nodes found" empty state.

## Test plan

- [x] `rushx test` — `@grackle-ai/web` (24 files / 251 tests) and `@grackle-ai/web-components` (21 files / 200 tests) green
- [x] New hook tests: `loadError` classification (`unavailable`/`error`/clear-on-success) + referential-stability hardening
- [x] New `KnowledgePage` tests: loads exactly once on mount, does **not** re-fire when the `knowledge` object identity changes, error/empty branching, Retry behavior
- [x] `rush build` clean (no warnings), `rush format:check` passes
- [x] Manual (Neo4j down): exactly **one** `ListRecentKnowledgeNodes` request on mount (no storm, verified after 5s); clicking another sidebar tab navigates away (not frozen); **Retry** fires exactly one more request; error UI renders as designed

## Screenshots

**Knowledge tab when the knowledge server (Neo4j) is unreachable:**

![Knowledge tab unavailable state](https://gist.githubusercontent.com/nick-pape/11b281239f3bfb6aad0b36cc58fddf5a/raw/661d3dda12be7ce88125e1db6b8d0065a607bc8e/knowledge-unavailable.svg)

Closes #1357