### PR TITLE
Fix #1367: randomize sandbox port in launch-grackle.sh

### DIFF
--- a/.claude/scripts/launch-grackle.sh
+++ b/.claude/scripts/launch-grackle.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# === Find 4 free ports ===
+# === Find 5 free ports ===
 GRACKLE_PORTS="$(node -e "
 const net = require('net');
 function findPort() {
@@ -24,7 +24,7 @@ function findPort() {
 }
 async function main() {
   const ports = new Set();
-  while (ports.size < 4) { ports.add(await findPort()); }
+  while (ports.size < 5) { ports.add(await findPort()); }
   console.log([...ports].join(' '));
 }
 main();
@@ -33,13 +33,13 @@ if [ -z "$GRACKLE_PORTS" ]; then
   echo "Error: node port-finder produced no output" >&2
   exit 1
 fi
-read -r GRPC_PORT WEB_PORT MCP_PORT POWERLINE_PORT <<< "$GRACKLE_PORTS"
-for p in "$GRPC_PORT" "$WEB_PORT" "$MCP_PORT" "$POWERLINE_PORT"; do
+read -r GRPC_PORT WEB_PORT MCP_PORT POWERLINE_PORT SANDBOX_PORT <<< "$GRACKLE_PORTS"
+for p in "$GRPC_PORT" "$WEB_PORT" "$MCP_PORT" "$POWERLINE_PORT" "$SANDBOX_PORT"; do
   case "$p" in
     ''|*[!0-9]*) echo "Error: invalid port value '$p' in GRACKLE_PORTS='$GRACKLE_PORTS'" >&2; exit 1 ;;
   esac
 done
-echo "Ports: gRPC=$GRPC_PORT web=$WEB_PORT mcp=$MCP_PORT powerline=$POWERLINE_PORT"
+echo "Ports: gRPC=$GRPC_PORT web=$WEB_PORT mcp=$MCP_PORT powerline=$POWERLINE_PORT sandbox=$SANDBOX_PORT"
 
 # === Create isolated home directory ===
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
@@ -53,6 +53,7 @@ GRACKLE_PORT=$GRPC_PORT \
 GRACKLE_WEB_PORT=$WEB_PORT \
 GRACKLE_MCP_PORT=$MCP_PORT \
 GRACKLE_POWERLINE_PORT=$POWERLINE_PORT \
+GRACKLE_SANDBOX_PORT=$SANDBOX_PORT \
 GRACKLE_HOST=127.0.0.1 \
 GRACKLE_HOME="$GRACKLE_HOME" \
 node "$REPO_ROOT/packages/server/dist/index.js" > "$GRACKLE_HOME/server.log" 2>&1 &
@@ -137,6 +138,7 @@ echo "Pairing URL:  $PAIRING_URL"
   printf 'export WEB_PORT=%q\n' "$WEB_PORT"
   printf 'export MCP_PORT=%q\n' "$MCP_PORT"
   printf 'export POWERLINE_PORT=%q\n' "$POWERLINE_PORT"
+  printf 'export SANDBOX_PORT=%q\n' "$SANDBOX_PORT"
   printf 'export GRACKLE_HOME=%q\n' "$GRACKLE_HOME"
   printf 'export REPO_ROOT=%q\n' "$REPO_ROOT"
   printf 'export SERVER_PID=%q\n' "$SERVER_PID"
@@ -153,6 +155,7 @@ echo "  Web UI:       http://127.0.0.1:$WEB_PORT"
 echo "  Pairing URL:  $PAIRING_URL"
 echo "  gRPC:         http://127.0.0.1:$GRPC_PORT"
 echo "  MCP:          http://127.0.0.1:$MCP_PORT/mcp"
+echo "  Sandbox:      http://127.0.0.1:$SANDBOX_PORT/sandbox.html"
 echo "  PowerLine:    http://127.0.0.1:$POWERLINE_PORT"
 echo "  API Key:      $GRACKLE_API_KEY"
 echo "  Home:         $GRACKLE_HOME"

--- a/.claude/skills/launch-grackle/SKILL.md
+++ b/.claude/skills/launch-grackle/SKILL.md
@@ -79,7 +79,7 @@ rm -rf "$GRACKLE_HOME"
 ## Important Notes
 
 - **Never kill processes you didn't start.** Only kill the PID from your own launch.
-- **Never use the user's default ports** (7434, 3000, 7435, 7433). Always use this skill to get isolated ports.
+- **Never use the user's default ports** (7434, 3000, 7435, 7433, 7436). Always use this skill to get isolated ports. (7436 is the MCP Apps sandbox port — the script now randomizes it too, so concurrent test servers don't collide on it.)
 - **Always use `GRACKLE_URL` (not `GRACKLE_PORT`)** when running CLI commands against your test server.
 - **Always pair before browsing.** Navigate to the pairing URL before any Playwright testing.
 - The database at `$GRACKLE_HOME/.grackle/grackle.db` is fully isolated from `~/.grackle/grackle.db`.


### PR DESCRIPTION
## Summary
- `.claude/scripts/launch-grackle.sh` allocated 4 ephemeral ports (gRPC/web/mcp/powerline) but never overrode `GRACKLE_SANDBOX_PORT`, so every launched server fell back to `DEFAULT_SANDBOX_PORT` (7436). The sandbox server treats `EADDRINUSE` as fatal (`process.exit(1)` in `packages/server/src/index.ts`), so any **second** concurrent instance self-terminated on startup — defeating the multi-session isolation the script is supposed to guarantee.
- Fix: find a **5th** free port and pass it as `GRACKLE_SANDBOX_PORT` in the launch env block. Also export it to `env.sh` and surface it in the "Server Ready" report. This mirrors what the E2E harness already does (`tests/e2e-tests/tests/server-manager.ts` → `findDistinctPorts(5)`).
- Doc: note 7436 in the SKILL.md "default ports to avoid" list.

## Test plan
- [x] Port-finder + `read` now yields **5 distinct ports** with `SANDBOX_PORT` populated (verified directly).
- [x] **Bug reproduced:** two server instances sharing one sandbox port → the second logs `Port <N> is already in use. Is another Grackle server running?` → `Shutting down...` and the process dies.
- [x] **Fix proven:** two instances with **distinct** sandbox ports → both stay alive; the second binds its own sandbox (`MCP Apps sandbox on http://127.0.0.1:<N>/sandbox.html`).
- [x] `rush change --verify` — no change file required (diff touches only `.claude/`, no publishable packages).
- [ ] CI green.

Note: no `rush build` run locally — the change is a dev-tooling shell script with no compiled source; behavior was verified end-to-end against the existing build.

Closes #1367