### PR TITLE
Fix #1323: @grackle-ai/ahp cleanup — SOURCE.md SHA, README, single-pass prebuild

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1323-ahp-cleanup_2026-05-29-21-53.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1323-ahp-cleanup_2026-05-29-21-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "@grackle-ai/ahp cleanup: prebuild script now reads the pinned AHP commit SHA from the package's own devDependencies (SOURCE.md SHA was previously always empty), transforms vendored files in a single read/write pass, and the package gained a README.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/ahp/README.md
+++ b/packages/ahp/README.md
@@ -58,7 +58,7 @@ The pinned upstream commit lives in **one place**: `devDependencies["agent-host-
 
 ## Requirements
 
-- Node.js >= 22
+- Node.js >= 22 and < 24
 
 ## License
 

--- a/packages/ahp/README.md
+++ b/packages/ahp/README.md
@@ -1,0 +1,65 @@
+# @grackle-ai/ahp
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@grackle-ai/ahp"><img src="https://img.shields.io/npm/v/@grackle-ai/ahp.svg" alt="npm version" /></a>
+  <a href="https://github.com/nick-pape/grackle/actions/workflows/ci.yml"><img src="https://github.com/nick-pape/grackle/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/nick-pape/grackle/main/apps/docs-site/static/img/grackle-logo.png" alt="Grackle" width="200" />
+</p>
+
+[Agent Host Protocol](https://github.com/microsoft/agent-host-protocol) (AHP) type definitions and reducers, vendored for [Grackle](https://github.com/nick-pape/grackle).
+
+AHP is Microsoft's open-source protocol for the wire format between an agent host and its clients: the JSON-RPC commands, the action envelopes that stream state changes, the notifications, and the pure reducers that fold those actions into derived session/terminal/changeset state. This package re-exports the canonical AHP TypeScript shapes and reducer functions so the rest of Grackle can depend on a single, version-pinned copy.
+
+The source is **vendored**, not hand-maintained: a build-time prebuild script copies the `types/` tree from a pinned commit of the upstream repo, applies a small set of transforms, and writes it to `src/vendor/ahp/`. Do not edit the vendored files directly — change the pin or the transforms instead.
+
+## Install
+
+```bash
+npm install @grackle-ai/ahp
+```
+
+## How the build works
+
+The package builds in two steps, wired through Heft:
+
+1. **Prebuild** (`scripts/prebuild.mjs`) — reads the upstream `types/` tree from `node_modules/agent-host-protocol/` (installed via the `agent-host-protocol` git dependency), applies the transforms below, and writes the result into `src/vendor/ahp/`:
+   - Prepends an `/* eslint-disable -- vendored third-party code, see SOURCE.md */` header to every `.ts` file so upstream style does not trip the repo's lint rules (warnings fail CI).
+   - Converts `const enum` to plain `enum` (a `const enum` is not reliably emitted across files by esbuild, so it would be `undefined` at runtime under the vitest runner).
+   - Strips upstream `.test.ts` files and the upstream `tsconfig.json`.
+   - Generates `src/vendor/ahp/SOURCE.md`, which records the pinned commit SHA and the transforms applied.
+2. **Compile** — Heft compiles the vendored sources plus `src/index.ts` to `dist/`.
+
+The reducer conformance corpus (`test-cases/reducers/*.json`) is kept and exercised by `src/reducer-conformance.test.ts`, which verifies the vendored reducers still match upstream's expected behavior.
+
+## Key exports
+
+All exports come through `src/index.ts`:
+
+- **State types** — `RootState`, `SessionState`, `TerminalState`, `ChangesetState`, and the many supporting shapes (`AgentInfo`, `ToolCallState`, `UserMessage`, `SessionInputRequest`, etc.).
+- **Enum values** (runtime constants) — `SessionStatus`, `SessionLifecycle`, `ToolCallStatus`, `ResponsePartKind`, `ChangesetStatus`, and friends.
+- **Action types** — `ActionEnvelope`, `StateAction`, and the full set of root / session / terminal / changeset action shapes, plus the `ActionType` enum.
+- **Command types** — JSON-RPC command params/results (`InitializeParams`, `CreateSessionParams`, `ResourceReadParams`, …) and command enums (`ReconnectResultType`, `ContentEncoding`, …).
+- **Notification types** — `SessionAddedParams`, `AuthRequiredParams`, the OTLP export params, and the `AuthRequiredReason` enum.
+- **Message types** — JSON-RPC envelopes and the `CommandMap` / notification-map types describing the protocol surface, plus `JsonRpcErrorCodes` / `AhpErrorCodes`.
+- **Reducer functions** — `rootReducer`, `sessionReducer`, `terminalReducer`, `changesetReducer`, and the `softAssertNever` / `isClientDispatchable` helpers.
+
+## Updating the upstream pin
+
+The pinned upstream commit lives in **one place**: `devDependencies["agent-host-protocol"]` in `package.json`, as a `git+https://…#<sha>` spec. To move to a newer upstream commit:
+
+1. Bump the SHA in `package.json` `devDependencies["agent-host-protocol"]`.
+2. Run `rush update && rush build -t @grackle-ai/ahp`.
+3. Confirm `src/vendor/ahp/SOURCE.md` shows the new SHA under **Pinned commit**.
+4. Run `rush test -t @grackle-ai/ahp` to confirm the reducer conformance test still passes against the new corpus. If upstream changed reducer behavior or added/removed exports, update `src/index.ts` re-exports accordingly.
+
+## Requirements
+
+- Node.js >= 22
+
+## License
+
+MIT (vendored AHP sources are MIT, © Microsoft Corporation)

--- a/packages/ahp/scripts/prebuild.mjs
+++ b/packages/ahp/scripts/prebuild.mjs
@@ -63,23 +63,13 @@ async function copyDir(src, dest, isRoot = false) {
   }
 }
 
-async function prependHeader(filePath, header) {
-  const content = await readFile(filePath, "utf-8");
-  await writeFile(filePath, header + "\n" + content);
-}
-
-async function convertConstEnum(filePath) {
-  const content = await readFile(filePath, "utf-8");
-  const transformed = content.replace(/const\s+enum\s+/g, "enum ");
-  if (transformed !== content) {
-    await writeFile(filePath, transformed);
-  }
-}
-
 async function transformFile(filePath) {
+  // Apply both transforms in a single read/write cycle:
+  //  1. Prepend the eslint-disable header.
+  //  2. Convert `const enum` to a plain `enum` (esbuild compatibility).
   const header = "/* eslint-disable -- vendored third-party code, see SOURCE.md */";
-  await prependHeader(filePath, header);
-  await convertConstEnum(filePath);
+  const content = await readFile(filePath, "utf-8");
+  await writeFile(filePath, header + "\n" + content.replace(/const\s+enum\s+/g, "enum "));
 }
 
 // ─── Main ──────────────────────────────────────────────────────────────
@@ -139,15 +129,15 @@ async function main() {
     await transformFile(file);
   }
 
-  // Read the pinned commit from the git dependency's package.json for SOURCE.md
-  const depPackageJson = join(NODE_MODULES_DIR, "agent-host-protocol", "package.json");
-  const depPkg = JSON.parse(await readFile(depPackageJson, "utf-8"));
-  // Derive pinned commit from this package's devDependencies git: spec
-  const depSpec = depPkg.dependencies?.["agent-host-protocol"] || "";
+  // Derive the pinned commit SHA for SOURCE.md from THIS package's own
+  // package.json — the `devDependencies["agent-host-protocol"]` git: spec is
+  // the authoritative pin. (The upstream package.json in node_modules has no
+  // self-reference, so it cannot supply the SHA.)
+  const ownPackageJson = join(SCRIPT_DIR, "..", "package.json");
+  const ownPkg = JSON.parse(await readFile(ownPackageJson, "utf-8"));
+  const depSpec = ownPkg.devDependencies?.["agent-host-protocol"] || "";
   const ahpCommit = depSpec.replace(/^git\+.*#/, "").replace(/\.git$/, "");
-  const ahpRepoUrl =
-    depPkg.repository?.url?.replace(/^git\+/, "").replace(/\.git$/, "") ||
-    "https://github.com/microsoft/agent-host-protocol";
+  const ahpRepoUrl = "https://github.com/microsoft/agent-host-protocol";
   const sourceMd = `# Vendored: Agent Host Protocol types
 
 This directory is the \`types/\` tree from Microsoft's Agent Host


### PR DESCRIPTION
## Summary
- **SOURCE.md SHA fix** — `scripts/prebuild.mjs` now reads the pinned AHP commit SHA from this package's own `devDependencies["agent-host-protocol"]`. It was reading the upstream package's `package.json` (which has no self-reference), so the "Pinned commit" line was always empty. The repo URL is now hardcoded to `https://github.com/microsoft/agent-host-protocol`.
- **Single-pass `transformFile`** — the eslint-disable header prepend and `const enum → enum` rewrite are now applied in one read/write cycle; the unused `prependHeader` / `convertConstEnum` helpers were removed.
- **README** — added `packages/ahp/README.md` (what the package is, how the prebuild/Heft build works, key export groups, and how to update the upstream pin), matching the badge/section conventions of the other package READMEs.

## Test plan
- [x] `node scripts/prebuild.mjs` → `SOURCE.md` shows the full 40-char SHA (`7c6b727bde61bc2c490201fb0e47a86759172782`) and the correct upstream URL
- [x] Second run is idempotent — `SOURCE.md` identical, exactly one eslint-disable header per `.ts` file, no remaining `const enum`
- [x] `rush build -t @grackle-ai/ahp` succeeds with no warnings
- [x] `rush test -t @grackle-ai/ahp` — `reducer-conformance.test.ts` passes
- [x] `rush format:check` clean

Closes #1323