### PR TITLE
fix(#1371): make web/MCP servers reverse-proxy aware (GRACKLE_PUBLIC_URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,26 @@
 # MCP server port.
 # GRACKLE_MCP_PORT=7435
 
-# Explicit browser-facing MCP origin. Used as the trusted asset/CSP origin for
-# broker-captured MCP Apps widgets (the widget's <script src> + CSP allowlist),
-# so it never depends on the request Host header. Set this for reverse-proxy /
-# TLS deployments where the loopback MCP origin isn't browser-reachable. When
-# unset, the broker derives it from the bind host + GRACKLE_MCP_PORT.
+# ── Public Origin (reverse proxy / TLS) ───────────────────────────
+# Canonical browser-facing origin when Grackle runs behind a TLS-terminating
+# reverse proxy (e.g. Caddy). When set, it is the source of truth for the
+# browser-facing scheme + host: the OAuth authorization-server metadata uses its
+# scheme + host, the session cookie gets the Secure flag iff https, HSTS is sent
+# iff https, and the pairing/QR URL + channel webhook ingress base URL use it.
+# Must be a bare http(s) origin (no path/query/fragment). When unset, behavior is
+# unchanged (loopback http defaults), so the casual local user is unaffected.
+# Behind a proxy, also set GRACKLE_MCP_ORIGIN (below) so the MCP server's OAuth
+# resource/audience matches the public https origin it's reached on.
+# GRACKLE_PUBLIC_URL=https://grackle.home
+
+# Explicit browser-facing MCP origin. Used as (1) the trusted asset/CSP origin
+# for broker-captured MCP Apps widgets (the widget's <script src> + CSP
+# allowlist) and (2) the MCP server's OAuth resource identifier / token audience
+# advertised in RFC 9728 protected-resource metadata — so neither depends on the
+# spoofable request Host header. Set this for reverse-proxy / TLS deployments
+# where the loopback MCP origin isn't browser-reachable. When unset, the broker
+# derives it from the bind host + GRACKLE_MCP_PORT and validates the OAuth
+# audience against the loopback origin.
 # GRACKLE_MCP_ORIGIN=https://mcp.example.com
 
 # MCP Apps widget sandbox port (separate origin for the double-iframe sandbox).

--- a/common/api/auth.public.api.md
+++ b/common/api/auth.public.api.md
@@ -148,6 +148,9 @@ export interface OAuthTokenClaims {
 export function parseCookies(header: string): Record<string, string>;
 
 // @public
+export function parsePublicOrigin(value: string, label: string): URL;
+
+// @public
 export function pruneRevocations(ttlMs?: number): void;
 
 // @public

--- a/common/api/auth.public.api.md
+++ b/common/api/auth.public.api.md
@@ -40,7 +40,12 @@ export type AuthContext = {
 };
 
 // @public
-export function authenticateMcpRequest(req: http.IncomingMessage, apiKey: string): AuthContext | undefined;
+export function authenticateMcpRequest(req: http.IncomingMessage, apiKey: string, options?: AuthenticateMcpRequestOptions): AuthContext | undefined;
+
+// @public
+export interface AuthenticateMcpRequestOptions {
+    expectedResource?: string;
+}
 
 // @public
 export interface AuthLogger {
@@ -179,13 +184,18 @@ export interface ScopedTokenClaims {
 }
 
 // @public
+export interface SecurityHeaderOptions {
+    hsts?: boolean;
+}
+
+// @public
 export const SESSION_COOKIE_NAME: string;
 
 // @public
 export function setAuthLogger(l: AuthLogger): void;
 
 // @public
-export function setSecurityHeaders(res: ServerResponse, requestHost?: string): void;
+export function setSecurityHeaders(res: ServerResponse, requestHost?: string, options?: SecurityHeaderOptions): void;
 
 // @public
 export function startOAuthCleanup(): void;

--- a/common/api/auth.public.api.md
+++ b/common/api/auth.public.api.md
@@ -189,6 +189,7 @@ export interface ScopedTokenClaims {
 // @public
 export interface SecurityHeaderOptions {
     hsts?: boolean;
+    sandboxOrigin?: string;
 }
 
 // @public

--- a/common/api/web-server.public.api.md
+++ b/common/api/web-server.public.api.md
@@ -72,6 +72,7 @@ export interface WebServerOptions {
     connectRoutes?: (router: ConnectRouter) => void;
     handleWebhook?: (token: string, body: WebhookBody) => Promise<WebhookResult>;
     pluginNames?: string[];
+    publicUrl?: string;
     readinessCheck?: () => ReadinessResult | Promise<ReadinessResult>;
     sandboxOrigin?: string;
     sandboxPort?: number;

--- a/common/changes/@grackle-ai/cli/nick-pape-1371-reverse-proxy-aware_2026-05-29-20-50.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1371-reverse-proxy-aware_2026-05-29-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Make the web/MCP servers reverse-proxy aware (#1371). New GRACKLE_PUBLIC_URL (--public-url) is the canonical browser-facing origin behind a TLS-terminating proxy: it drives the OAuth authorization-server metadata scheme/host, the session cookie Secure flag, HSTS emission, the pairing/QR URL, and the channel webhook ingress base URL. GRACKLE_MCP_ORIGIN now also fixes the MCP server's OAuth resource identifier / token audience (RFC 9728) so it isn't a downgraded http:// URL behind TLS. When both are unset, behavior is unchanged (loopback http defaults). Remediation for draft advisory GHSA-wcpf-6gwv-47c8 (Pattern E).",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/auth/src/auth-middleware.test.ts
+++ b/packages/auth/src/auth-middleware.test.ts
@@ -191,6 +191,40 @@ describe("authenticateMcpRequest", () => {
     expect(result).toEqual({ type: "oauth", clientId: OAUTH_CLIENT_ID });
   });
 
+  /**
+   * Audience isolation: a token whose `aud` carries a path must NOT match a
+   * bare-origin `expectedResource` (path is preserved, not stripped to origin).
+   */
+  test("OAuth token with a path in the audience is rejected against an origin expectedResource", () => {
+    const token = createOAuthAccessToken(
+      OAUTH_CLIENT_ID,
+      "https://mcp.example.com/some/path",
+      API_KEY,
+    );
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY, {
+      expectedResource: "https://mcp.example.com",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  /** Same path is preserved on both sides, so an exact path audience still matches. */
+  test("OAuth token with a matching path audience is accepted", () => {
+    const resource = "https://mcp.example.com/some/path";
+    const token = createOAuthAccessToken(OAUTH_CLIENT_ID, resource, API_KEY);
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY, { expectedResource: resource });
+    expect(result).toEqual({ type: "oauth", clientId: OAUTH_CLIENT_ID });
+  });
+
+  /** Audience with a path is also rejected on the loopback default path. */
+  test("OAuth token with a path is rejected on the loopback-derived audience", () => {
+    const token = createOAuthAccessToken(OAUTH_CLIENT_ID, `${OAUTH_RESOURCE}/some/path`, API_KEY);
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY);
+    expect(result).toBeUndefined();
+  });
+
   /** All three auth types work independently. */
   test("api key, scoped, and oauth tokens work independently", () => {
     const apiKeyReq = mockRequest(`Bearer ${API_KEY}`);

--- a/packages/auth/src/auth-middleware.test.ts
+++ b/packages/auth/src/auth-middleware.test.ts
@@ -159,6 +159,38 @@ describe("authenticateMcpRequest", () => {
     expect(result).toEqual({ type: "oauth", clientId: OAUTH_CLIENT_ID });
   });
 
+  /**
+   * With an explicit expectedResource (GRACKLE_MCP_ORIGIN behind a TLS proxy), an
+   * OAuth token whose audience matches the configured https origin is accepted —
+   * even though the socket's local port would not match the loopback default.
+   */
+  test("OAuth token matching expectedResource is accepted", () => {
+    const publicResource = "https://mcp.example.com";
+    const token = createOAuthAccessToken(OAUTH_CLIENT_ID, publicResource, API_KEY);
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY, { expectedResource: publicResource });
+    expect(result).toEqual({ type: "oauth", clientId: OAUTH_CLIENT_ID });
+  });
+
+  /** With expectedResource set, the loopback-derived audience is rejected. */
+  test("OAuth token with loopback audience is rejected when expectedResource is set", () => {
+    const token = createOAuthAccessToken(OAUTH_CLIENT_ID, OAUTH_RESOURCE, API_KEY);
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY, {
+      expectedResource: "https://mcp.example.com",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  /** expectedResource tolerates a trailing slash on the token audience. */
+  test("OAuth token with trailing-slash audience matches expectedResource", () => {
+    const publicResource = "https://mcp.example.com";
+    const token = createOAuthAccessToken(OAUTH_CLIENT_ID, publicResource + "/", API_KEY);
+    const req = mockRequest(`Bearer ${token}`, OAUTH_PORT);
+    const result = authenticateMcpRequest(req, API_KEY, { expectedResource: publicResource });
+    expect(result).toEqual({ type: "oauth", clientId: OAUTH_CLIENT_ID });
+  });
+
   /** All three auth types work independently. */
   test("api key, scoped, and oauth tokens work independently", () => {
     const apiKeyReq = mockRequest(`Bearer ${API_KEY}`);

--- a/packages/auth/src/auth-middleware.ts
+++ b/packages/auth/src/auth-middleware.ts
@@ -8,8 +8,26 @@ import { isRevokedTask, verifyScopedToken } from "./scoped-token.js";
 const API_KEY_LENGTH: number = 64;
 
 /**
- * Normalize loopback hostnames so that `localhost` and `127.0.0.1` compare equal.
- * Parses the URL and replaces `localhost` with `127.0.0.1`, returning the origin.
+ * Strip trailing `/` characters from a string with a linear scan.
+ *
+ * Avoids a `/\/+$/` regex, which CodeQL flags as a polynomial-ReDoS risk on
+ * uncontrolled (library) input.
+ */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* "/" */) {
+    end--;
+  }
+  return value.slice(0, end);
+}
+
+/**
+ * Normalize loopback hostnames so that `localhost` and `127.0.0.1` compare equal,
+ * and strip any trailing slash so `http://h/` matches `http://h`.
+ *
+ * Parses the URL and replaces `localhost` with `127.0.0.1`, returning the origin
+ * (which is already trailing-slash-free). Falls back to a trailing-slash-trimmed
+ * copy of the raw input when the value does not parse as a URL.
  */
 function normalizeLoopback(url: string): string {
   try {
@@ -19,7 +37,7 @@ function normalizeLoopback(url: string): string {
     }
     return parsed.origin;
   } catch {
-    return url;
+    return stripTrailingSlashes(url);
   }
 }
 
@@ -91,11 +109,11 @@ export function authenticateMcpRequest(
       if (oauthClaims.aud) {
         const localPort = req.socket.localPort;
         const expectedAudience = options?.expectedResource
-          ? normalizeLoopback(options.expectedResource.replace(/\/+$/, ""))
+          ? normalizeLoopback(options.expectedResource)
           : localPort
             ? `http://127.0.0.1:${localPort}`
             : undefined;
-        const normalizedAud = normalizeLoopback(oauthClaims.aud.replace(/\/+$/, ""));
+        const normalizedAud = normalizeLoopback(oauthClaims.aud);
         if (!expectedAudience || normalizedAud !== expectedAudience) {
           return undefined;
         }

--- a/packages/auth/src/auth-middleware.ts
+++ b/packages/auth/src/auth-middleware.ts
@@ -23,6 +23,19 @@ function normalizeLoopback(url: string): string {
   }
 }
 
+/** Options for {@link authenticateMcpRequest}. */
+export interface AuthenticateMcpRequestOptions {
+  /**
+   * Canonical resource (audience) this server is reachable as, e.g.
+   * `https://mcp.example.com`. When set, an OAuth token's `aud` is validated
+   * against this configured origin instead of the loopback-derived default.
+   * Set it from a static, operator-provided origin (`GRACKLE_MCP_ORIGIN`) — never
+   * from the request `Host` header, which a client could spoof. When unset, the
+   * audience is validated against the server-controlled `http://127.0.0.1:<localPort>`.
+   */
+  expectedResource?: string;
+}
+
 /**
  * Authenticate an incoming MCP HTTP request.
  *
@@ -33,11 +46,13 @@ function normalizeLoopback(url: string): string {
  *
  * @param req - The incoming HTTP request.
  * @param apiKey - The server's API key (used for both direct comparison and as the HMAC signing secret).
+ * @param options - Optional audience-validation overrides (see {@link AuthenticateMcpRequestOptions}).
  * @returns An {@link AuthContext} if authentication succeeds, or `undefined` for a 401.
  */
 export function authenticateMcpRequest(
   req: http.IncomingMessage,
   apiKey: string,
+  options?: AuthenticateMcpRequestOptions,
 ): AuthContext | undefined {
   const authHeader = req.headers.authorization || "";
   const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
@@ -67,13 +82,19 @@ export function authenticateMcpRequest(
     if (oauthClaims) {
       // Validate audience if present — when non-empty, must match this server's resource URL.
       // Empty aud is accepted because the client may omit the resource indicator (RFC 8707).
-      // Use the socket's local port (server-controlled) rather than the Host header (client-controlled)
-      // to prevent token replay via Host spoofing.
+      // When an explicit resource is configured (GRACKLE_MCP_ORIGIN, e.g. behind a
+      // TLS reverse proxy) validate against that static, operator-provided origin.
+      // Otherwise fall back to the socket's local port (server-controlled) rather than
+      // the Host header (client-controlled) to prevent token replay via Host spoofing.
       // Normalize trailing slashes and treat "localhost" as equivalent to "127.0.0.1" since
       // MCP clients may connect via either hostname.
       if (oauthClaims.aud) {
         const localPort = req.socket.localPort;
-        const expectedAudience = localPort ? `http://127.0.0.1:${localPort}` : undefined;
+        const expectedAudience = options?.expectedResource
+          ? normalizeLoopback(options.expectedResource.replace(/\/+$/, ""))
+          : localPort
+            ? `http://127.0.0.1:${localPort}`
+            : undefined;
         const normalizedAud = normalizeLoopback(oauthClaims.aud.replace(/\/+$/, ""));
         if (!expectedAudience || normalizedAud !== expectedAudience) {
           return undefined;

--- a/packages/auth/src/auth-middleware.ts
+++ b/packages/auth/src/auth-middleware.ts
@@ -22,12 +22,14 @@ function stripTrailingSlashes(value: string): string {
 }
 
 /**
- * Normalize loopback hostnames so that `localhost` and `127.0.0.1` compare equal,
- * and strip any trailing slash so `http://h/` matches `http://h`.
+ * Normalize an audience URL for comparison: treat `localhost` and `127.0.0.1`
+ * as equal, and ignore a single trailing slash so `http://h/` matches `http://h`.
  *
- * Parses the URL and replaces `localhost` with `127.0.0.1`, returning the origin
- * (which is already trailing-slash-free). Falls back to a trailing-slash-trimmed
- * copy of the raw input when the value does not parse as a URL.
+ * Crucially, any non-root path, query, or fragment is **preserved** — dropping
+ * it (e.g. via `URL.origin`) would let a token minted for
+ * `https://mcp.example.com/some/path` be accepted when the expected resource is
+ * just `https://mcp.example.com`, weakening audience isolation. Falls back to a
+ * trailing-slash-trimmed copy of the raw input when the value does not parse.
  */
 function normalizeLoopback(url: string): string {
   try {
@@ -35,7 +37,10 @@ function normalizeLoopback(url: string): string {
     if (parsed.hostname === "localhost") {
       parsed.hostname = "127.0.0.1";
     }
-    return parsed.origin;
+    // Collapse a bare "/" path to empty so origin-only audiences match with or
+    // without a trailing slash; otherwise keep the path (minus a trailing slash).
+    const path = parsed.pathname === "/" ? "" : stripTrailingSlashes(parsed.pathname);
+    return `${parsed.origin}${path}${parsed.search}${parsed.hash}`;
   } catch {
     return stripTrailingSlashes(url);
   }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -69,7 +69,11 @@ export { createChannelToken, verifyChannelToken } from "./channel-token.js";
 export type { AuthContext } from "./auth-context.js";
 
 // ─── Auth Middleware ────────────────────────────────────────
-export { authenticateMcpRequest } from "./auth-middleware.js";
+export { authenticateMcpRequest, type AuthenticateMcpRequestOptions } from "./auth-middleware.js";
 
 // ─── Security Headers ──────────────────────────────────────
-export { WEB_CONTENT_SECURITY_POLICY, setSecurityHeaders } from "./security-headers.js";
+export {
+  WEB_CONTENT_SECURITY_POLICY,
+  setSecurityHeaders,
+  type SecurityHeaderOptions,
+} from "./security-headers.js";

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -77,3 +77,6 @@ export {
   setSecurityHeaders,
   type SecurityHeaderOptions,
 } from "./security-headers.js";
+
+// ─── Public Origin ─────────────────────────────────────────
+export { parsePublicOrigin } from "./public-origin.js";

--- a/packages/auth/src/public-origin.test.ts
+++ b/packages/auth/src/public-origin.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parsePublicOrigin } from "./public-origin.js";
+
+describe("parsePublicOrigin", () => {
+  it("accepts an https origin and returns the normalized origin", () => {
+    expect(parsePublicOrigin("https://grackle.home", "TEST").origin).toBe("https://grackle.home");
+  });
+
+  it("accepts an http origin with an explicit port", () => {
+    expect(parsePublicOrigin("http://grackle.home:8080", "TEST").origin).toBe(
+      "http://grackle.home:8080",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parsePublicOrigin("  https://grackle.home  ", "TEST").origin).toBe(
+      "https://grackle.home",
+    );
+  });
+
+  it("strips a trailing slash via origin normalization", () => {
+    expect(parsePublicOrigin("https://grackle.home/", "TEST").origin).toBe("https://grackle.home");
+  });
+
+  it("rejects a non-URL value", () => {
+    expect(() => parsePublicOrigin("not-a-url", "TEST")).toThrow("Invalid TEST");
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    expect(() => parsePublicOrigin("ftp://grackle.home", "TEST")).toThrow(
+      "Scheme must be http or https",
+    );
+  });
+
+  it("rejects a URL with a path", () => {
+    expect(() => parsePublicOrigin("https://grackle.home/grackle", "TEST")).toThrow(
+      "bare origin with no path",
+    );
+  });
+
+  it("rejects a URL with a query string", () => {
+    expect(() => parsePublicOrigin("https://grackle.home?x=1", "TEST")).toThrow(
+      "bare origin with no path",
+    );
+  });
+
+  it("rejects embedded userinfo (credentials)", () => {
+    expect(() => parsePublicOrigin("https://user:pass@grackle.home", "TEST")).toThrow(
+      "must not contain a username or password",
+    );
+  });
+
+  it("does not echo the raw value when rejecting userinfo (no credential leak)", () => {
+    let message = "";
+    try {
+      parsePublicOrigin("https://user:s3cret@grackle.home", "TEST");
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).not.toContain("s3cret");
+    expect(message).not.toContain("user:");
+  });
+});

--- a/packages/auth/src/public-origin.ts
+++ b/packages/auth/src/public-origin.ts
@@ -1,0 +1,37 @@
+/**
+ * Validate and normalize a browser-facing public origin (e.g. `https://grackle.home`),
+ * the value of `GRACKLE_PUBLIC_URL` / `WebServerOptions.publicUrl`.
+ *
+ * Accepts only a bare http(s) origin: leading/trailing whitespace is trimmed, and
+ * a path, query, fragment, or embedded userinfo (`user:pass@host`) is rejected.
+ * Userinfo in particular is refused rather than silently dropped by `URL.origin`,
+ * and its error message never echoes the raw value so credentials cannot leak into
+ * logs. Throws an `Error` with a clear, label-prefixed message on any invalid
+ * input so callers fail fast at startup.
+ *
+ * @param value - The raw origin string (may contain surrounding whitespace).
+ * @param label - Human-readable source name for error messages (e.g. `GRACKLE_PUBLIC_URL`).
+ * @returns The parsed `URL`; use `.origin` for the normalized string form.
+ */
+export function parsePublicOrigin(value: string, label: string): URL {
+  const trimmed = value.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `Invalid ${label}: must be an absolute http(s) origin, e.g. https://grackle.home.`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid ${label}: Scheme must be http or https.`);
+  }
+  if (parsed.username || parsed.password) {
+    // Do NOT echo the raw value — it contains credentials.
+    throw new Error(`Invalid ${label}: must not contain a username or password (userinfo).`);
+  }
+  if ((parsed.pathname !== "" && parsed.pathname !== "/") || parsed.search || parsed.hash) {
+    throw new Error(`Invalid ${label}: must be a bare origin with no path, query, or fragment.`);
+  }
+  return parsed;
+}

--- a/packages/auth/src/security-headers.test.ts
+++ b/packages/auth/src/security-headers.test.ts
@@ -147,6 +147,48 @@ describe("security headers", () => {
       }
     });
 
+    it("emits Strict-Transport-Security when hsts is true", async () => {
+      const server = http.createServer((req, res) => {
+        setSecurityHeaders(res, "grackle.home", { hsts: true });
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html></html>");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const resp = await request(server, "/");
+        expect(resp.headers["strict-transport-security"]).toBe("max-age=31536000");
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    });
+
+    it("omits Strict-Transport-Security when hsts is false or absent", async () => {
+      const server = http.createServer((req, res) => {
+        setSecurityHeaders(res, "grackle.home", { hsts: false });
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html></html>");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const resp = await request(server, "/");
+        expect(resp.headers["strict-transport-security"]).toBeUndefined();
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    });
+
     it("widens frame-src to the request hostname so the chat can embed the widget sandbox", async () => {
       // The MCP Apps widget sandbox runs on the same hostname, different port
       // (GRACKLE_SANDBOX_PORT); frame-src must allow it across ports.

--- a/packages/auth/src/security-headers.test.ts
+++ b/packages/auth/src/security-headers.test.ts
@@ -189,6 +189,61 @@ describe("security headers", () => {
       }
     });
 
+    it("adds the configured sandbox origin to frame-src (different-host proxy case)", async () => {
+      const server = http.createServer((req, res) => {
+        setSecurityHeaders(res, "web.grackle.test", {
+          sandboxOrigin: "https://sandbox.grackle.test:8445",
+        });
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html></html>");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const resp = await request(server, "/");
+        const csp = resp.headers["content-security-policy"] as string;
+        const frameSrc = csp
+          .split(";")
+          .map((d) => d.trim())
+          .find((d) => d.startsWith("frame-src"));
+        expect(frameSrc).toContain("https://sandbox.grackle.test:8445");
+        // The request-host wildcard is still present too.
+        expect(frameSrc).toContain("https://web.grackle.test:*");
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    });
+
+    it("ignores an invalid sandbox origin without breaking the CSP", async () => {
+      const server = http.createServer((req, res) => {
+        setSecurityHeaders(res, "web.grackle.test", { sandboxOrigin: "not a url" });
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html></html>");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const resp = await request(server, "/");
+        const csp = resp.headers["content-security-policy"] as string;
+        expect(csp).toContain(
+          "frame-src 'self' http://web.grackle.test:* https://web.grackle.test:*",
+        );
+        expect(csp).not.toContain("not a url");
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    });
+
     it("widens frame-src to the request hostname so the chat can embed the widget sandbox", async () => {
       // The MCP Apps widget sandbox runs on the same hostname, different port
       // (GRACKLE_SANDBOX_PORT); frame-src must allow it across ports.

--- a/packages/auth/src/security-headers.ts
+++ b/packages/auth/src/security-headers.ts
@@ -49,6 +49,14 @@ export interface SecurityHeaderOptions {
    * origin), never for a plain-http origin.
    */
   hsts?: boolean;
+  /**
+   * Explicit browser-facing MCP Apps sandbox origin (`GRACKLE_SANDBOX_ORIGIN`),
+   * added to the CSP `frame-src` directive. Behind a reverse proxy the sandbox
+   * iframe may live on a *different host* than the web app, which the
+   * request-host wildcard does not cover; without this the browser would block
+   * the widget iframe. Invalid values are ignored.
+   */
+  sandboxOrigin?: string;
 }
 
 /**
@@ -87,17 +95,28 @@ export function setSecurityHeaders(
   // hostname on any port (same workaround as form-action). The framed sandbox
   // is itself origin-isolated with its own locked-down CSP, so this only widens
   // which origins the app may *embed*, not what runs inside them.
-  let frameSrc = "frame-src 'self'";
+  const frameSrcSources: string[] = ["'self'"];
   if (requestHost) {
     try {
       const parsed = new URL(`http://${requestHost}`);
       const hostname = parsed.hostname;
       formAction = `form-action 'self' http://${hostname}:* https://${hostname}:*`;
-      frameSrc = `frame-src 'self' http://${hostname}:* https://${hostname}:*`;
+      frameSrcSources.push(`http://${hostname}:*`, `https://${hostname}:*`);
     } catch {
       // Malformed Host header — fall back to 'self' only
     }
   }
+  // Allow the explicitly-configured sandbox origin (which may be a different host
+  // behind a reverse proxy, uncovered by the request-host wildcard above). Parse
+  // via URL to normalize and prevent CSP injection through a malformed value.
+  if (options?.sandboxOrigin) {
+    try {
+      frameSrcSources.push(new URL(options.sandboxOrigin).origin);
+    } catch {
+      // Invalid sandbox origin — ignore.
+    }
+  }
+  const frameSrc = `frame-src ${frameSrcSources.join(" ")}`;
   const csp = [...BASE_CSP_DIRECTIVES, frameSrc, formAction].join("; ");
   res.setHeader("Content-Security-Policy", csp);
 }

--- a/packages/auth/src/security-headers.ts
+++ b/packages/auth/src/security-headers.ts
@@ -34,6 +34,24 @@ export const WEB_CONTENT_SECURITY_POLICY: string = [
 ].join("; ");
 
 /**
+ * `Strict-Transport-Security` value emitted when the connection is served over
+ * HTTPS. One year, without `includeSubDomains` — the latter could force HTTPS
+ * onto sibling subdomains of a shared apex (e.g. `grackle.home`) and is hard to
+ * roll back, so it is intentionally omitted.
+ */
+const HSTS_MAX_AGE_SECONDS: number = 31_536_000;
+
+/** Optional flags controlling scheme-dependent security headers. */
+export interface SecurityHeaderOptions {
+  /**
+   * When true, emit a `Strict-Transport-Security` header. Set this only when the
+   * browser-facing scheme is HTTPS (e.g. `GRACKLE_PUBLIC_URL` is an https
+   * origin), never for a plain-http origin.
+   */
+  hsts?: boolean;
+}
+
+/**
  * Set defense-in-depth security headers on every web response.
  *
  * Called at the top of `createWebHandler`'s returned function so that all
@@ -45,10 +63,18 @@ export const WEB_CONTENT_SECURITY_POLICY: string = [
  *   provided, the CSP `form-action` directive explicitly includes the
  *   request origin to work around a Chromium bug where `'self'` does not
  *   match form submissions on non-standard ports.
+ * @param options - Optional scheme-dependent headers (e.g. {@link SecurityHeaderOptions.hsts}).
  */
-export function setSecurityHeaders(res: ServerResponse, requestHost?: string): void {
+export function setSecurityHeaders(
+  res: ServerResponse,
+  requestHost?: string,
+  options?: SecurityHeaderOptions,
+): void {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "DENY");
+  if (options?.hsts) {
+    res.setHeader("Strict-Transport-Security", `max-age=${HSTS_MAX_AGE_SECONDS}`);
+  }
   // Chromium does not reliably match 'self' or explicit origin+port for
   // form-action on non-standard ports. Use the request hostname with a
   // wildcard port so the form POST is allowed regardless of port.

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -62,9 +62,10 @@ function sign(value: string, secret: string): string {
  * is an HMAC-SHA256 of the session ID using the API key as secret.
  *
  * When `options.secure` is true the cookie includes the `Secure` flag,
- * which tells browsers to only send it over HTTPS. This should be
- * enabled when the server is network-accessible (`--allow-network`)
- * behind a TLS-terminating reverse proxy.
+ * which tells browsers to only send it over HTTPS. The caller should set
+ * this from the browser-facing scheme (i.e. `GRACKLE_PUBLIC_URL` is an
+ * https origin), not from the bind address — a `Secure` cookie is refused
+ * by browsers over plain http and would break login.
  */
 export function createSession(apiKey: string, options?: { secure?: boolean }): string {
   const sessionId = randomBytes(SESSION_ID_BYTES).toString("hex");

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,16 +76,17 @@ grackle serve --port 8000 --web-port 4000
 grackle serve --allow-network    # bind to 0.0.0.0 for LAN access
 ```
 
-| Option                      | Description                                                                                                                        | Default                                |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `--port <port>`             | Server gRPC port                                                                                                                   | `7434`                                 |
-| `--web-port <port>`         | Web UI port                                                                                                                        | `3000`                                 |
-| `--mcp-port <port>`         | MCP server port                                                                                                                    | `7435`                                 |
-| `--mcp-origin <origin>`     | Browser-facing MCP origin (e.g. `https://mcp.example.com`) for reverse-proxy/TLS deployments; trusted asset/CSP origin for widgets | (derived from host + `--mcp-port`)     |
-| `--sandbox-port <port>`     | MCP Apps widget sandbox port                                                                                                       | `7436`                                 |
-| `--sandbox-origin <origin>` | Browser-facing MCP Apps sandbox origin (e.g. `https://sandbox.example.com`) for reverse-proxy/TLS deployments                      | (derived from host + `--sandbox-port`) |
-| `--powerline-port <port>`   | Local PowerLine port                                                                                                               | `7433`                                 |
-| `--allow-network`           | Bind to all interfaces (0.0.0.0)                                                                                                   | Off (127.0.0.1)                        |
+| Option                      | Description                                                                                                                                                                  | Default                                |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `--port <port>`             | Server gRPC port                                                                                                                                                             | `7434`                                 |
+| `--web-port <port>`         | Web UI port                                                                                                                                                                  | `3000`                                 |
+| `--mcp-port <port>`         | MCP server port                                                                                                                                                              | `7435`                                 |
+| `--public-url <url>`        | Canonical browser-facing origin (e.g. `https://grackle.home`) when behind a TLS reverse proxy; source of truth for OAuth scheme/host, `Secure` cookie, HSTS, and pairing URL | (loopback http defaults)               |
+| `--mcp-origin <origin>`     | Browser-facing MCP origin (e.g. `https://mcp.example.com`) for reverse-proxy/TLS deployments; trusted asset/CSP origin for widgets and OAuth resource/audience               | (derived from host + `--mcp-port`)     |
+| `--sandbox-port <port>`     | MCP Apps widget sandbox port                                                                                                                                                 | `7436`                                 |
+| `--sandbox-origin <origin>` | Browser-facing MCP Apps sandbox origin (e.g. `https://sandbox.example.com`) for reverse-proxy/TLS deployments                                                                | (derived from host + `--sandbox-port`) |
+| `--powerline-port <port>`   | Local PowerLine port                                                                                                                                                         | `7433`                                 |
+| `--allow-network`           | Bind to all interfaces (0.0.0.0)                                                                                                                                             | Off (127.0.0.1)                        |
 
 ---
 

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -15,6 +15,7 @@ describe("registerServeCommand", () => {
     delete process.env.GRACKLE_PORT;
     delete process.env.GRACKLE_WEB_PORT;
     delete process.env.GRACKLE_HOST;
+    delete process.env.GRACKLE_PUBLIC_URL;
     vi.restoreAllMocks();
     vi.resetModules();
   });
@@ -57,5 +58,27 @@ describe("registerServeCommand", () => {
     expect(process.env.GRACKLE_PORT).toBe("8000");
     expect(process.env.GRACKLE_WEB_PORT).toBe("8001");
     expect(process.env.GRACKLE_MCP_PORT).toBe("8002");
+  });
+
+  it("--public-url sets GRACKLE_PUBLIC_URL", async () => {
+    const { registerServeCommand } = await import("./serve.js");
+    const program = new Command();
+    program.exitOverride();
+    registerServeCommand(program);
+
+    await program.parseAsync(["serve", "--public-url", "https://grackle.home"], { from: "user" });
+
+    expect(process.env.GRACKLE_PUBLIC_URL).toBe("https://grackle.home");
+  });
+
+  it("leaves GRACKLE_PUBLIC_URL unset when --public-url is omitted", async () => {
+    const { registerServeCommand } = await import("./serve.js");
+    const program = new Command();
+    program.exitOverride();
+    registerServeCommand(program);
+
+    await program.parseAsync(["serve"], { from: "user" });
+
+    expect(process.env.GRACKLE_PUBLIC_URL).toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -9,6 +9,10 @@ export function registerServeCommand(program: Command): void {
     .option("--web-port <port>", "Web UI port", "3000")
     .option("--mcp-port <port>", "MCP server port", "7435")
     .option(
+      "--public-url <url>",
+      "Canonical browser-facing origin (e.g. https://grackle.home) when behind a TLS reverse proxy; source of truth for the OAuth scheme/host, Secure cookie, HSTS, and pairing URL",
+    )
+    .option(
       "--mcp-origin <origin>",
       "Browser-facing MCP origin (e.g. https://mcp.example.com) for reverse-proxy/TLS deployments; trusted asset/CSP origin for widgets",
     )
@@ -24,6 +28,7 @@ export function registerServeCommand(program: Command): void {
         port: string;
         webPort: string;
         mcpPort: string;
+        publicUrl?: string;
         mcpOrigin?: string;
         sandboxPort: string;
         sandboxOrigin?: string;
@@ -33,6 +38,9 @@ export function registerServeCommand(program: Command): void {
         process.env.GRACKLE_PORT = opts.port;
         process.env.GRACKLE_WEB_PORT = opts.webPort;
         process.env.GRACKLE_MCP_PORT = opts.mcpPort;
+        if (opts.publicUrl !== undefined) {
+          process.env.GRACKLE_PUBLIC_URL = opts.publicUrl;
+        }
         if (opts.mcpOrigin !== undefined) {
           process.env.GRACKLE_MCP_ORIGIN = opts.mcpOrigin;
         }

--- a/packages/mcp/src/mcp-server.test.ts
+++ b/packages/mcp/src/mcp-server.test.ts
@@ -356,6 +356,40 @@ describe("OAuth Protected Resource Metadata", () => {
     const metadata = JSON.parse(res.body);
     expect(metadata.authorization_servers).toEqual(["http://grackle:3000"]);
   });
+
+  /** Start an MCP server behind a TLS reverse proxy (public origins configured). */
+  function startProxiedServer(): Promise<http.Server> {
+    const srv = createMcpServer({
+      bindHost: "127.0.0.1",
+      mcpPort: 0,
+      grpcPort: 19999,
+      apiKey: TEST_API_KEY,
+      authorizationServerUrl: "https://grackle.home",
+      mcpOrigin: "https://mcp.grackle.home",
+    });
+    return new Promise<http.Server>((resolve) => {
+      srv.listen(0, "127.0.0.1", () => resolve(srv));
+    });
+  }
+
+  it("advertises the configured public resource (GRACKLE_MCP_ORIGIN), ignoring request Host", async () => {
+    server = await startProxiedServer();
+
+    const res = await getMetadata(server!, "attacker.example.com");
+
+    expect(res.status).toBe(200);
+    const metadata = JSON.parse(res.body);
+    expect(metadata.resource).toBe("https://mcp.grackle.home");
+  });
+
+  it("advertises the explicit public auth server verbatim, ignoring request Host", async () => {
+    server = await startProxiedServer();
+
+    const res = await getMetadata(server!, "attacker.example.com");
+
+    const metadata = JSON.parse(res.body);
+    expect(metadata.authorization_servers).toEqual(["https://grackle.home"]);
+  });
 });
 
 describe("MCP session cleanup on SSE disconnect", () => {

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -638,6 +638,11 @@ async function createMcpServerInstance(
 /** Interval for pruning stale revocation entries (1 hour). */
 const REVOCATION_PRUNE_INTERVAL_MS: number = 60 * 60 * 1000;
 
+/** Whether a hostname is a loopback address (`localhost`, `127.0.0.1`, or `::1`). */
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
 /**
  * Session ids whose scoped auth context is bound to `workspaceId`. Pure helper so
  * the promoted-tool `tools/list_changed` fan-out (#1297) is unit-testable without
@@ -690,6 +695,16 @@ export function createMcpServer(options: McpServerOptions): http.Server {
     : undefined;
   /** Scheme to use for derived auth URLs (preserves https when configured). */
   const authServerScheme = parsedAuthServerUrl?.protocol ?? "http:";
+  /**
+   * When the configured auth server host is a real (non-loopback) hostname — i.e.
+   * `GRACKLE_PUBLIC_URL` is set behind a TLS reverse proxy — advertise it verbatim
+   * so discovery points at the correct public origin. For a loopback default we
+   * keep request-host derivation (preserves the localhost-vs-127.0.0.1 CSP fix).
+   */
+  const explicitAuthOrigin =
+    parsedAuthServerUrl && !isLoopbackHostname(parsedAuthServerUrl.hostname)
+      ? `${parsedAuthServerUrl.protocol}//${parsedAuthServerUrl.host}`
+      : undefined;
   const grpcClients = createGrpcClients(bindHost, grpcPort, apiKey);
 
   /** Map of active session transports, keyed by session ID. */
@@ -729,19 +744,26 @@ export function createMcpServer(options: McpServerOptions): http.Server {
   const httpServer = http.createServer(async (req, res) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
-    // Derive resource URL from request Host header (dialable by the client)
-    const requestResourceUrl = `http://${req.headers.host || url.host}`;
+    // Canonical resource (OAuth audience) identifying this MCP server. Use the
+    // configured public MCP origin (GRACKLE_MCP_ORIGIN) when set — e.g. behind a
+    // TLS reverse proxy, so the advertised resource isn't a downgraded http://
+    // URL — otherwise derive it from the request Host header (dialable by the
+    // client on loopback / LAN). NOT the request Host when configured: a hostile
+    // client could spoof it to mint a token for an attacker-controlled audience.
+    const resourceUrl = mcpOrigin ?? `http://${req.headers.host || url.host}`;
 
-    // OAuth Protected Resource Metadata (RFC 9728) — no auth required
-    // Derive auth server URL from request hostname so the browser stays on the
-    // same host — avoids CSP form-action 'self' mismatch (localhost vs 127.0.0.1).
+    // OAuth Protected Resource Metadata (RFC 9728) — no auth required.
+    // For a loopback auth server, derive its URL from the request hostname so the
+    // browser stays on the same host (avoids CSP form-action 'self' mismatch,
+    // localhost vs 127.0.0.1); for an explicit public auth origin, use it verbatim.
     if (authServerPort && url.pathname === "/.well-known/oauth-protected-resource/mcp") {
       const hostPart = url.hostname.includes(":") ? `[${url.hostname}]` : url.hostname;
-      const derivedAuthUrl = `${authServerScheme}//${hostPart}:${authServerPort}`;
+      const derivedAuthUrl =
+        explicitAuthOrigin ?? `${authServerScheme}//${hostPart}:${authServerPort}`;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          resource: requestResourceUrl,
+          resource: resourceUrl,
           authorization_servers: [derivedAuthUrl],
         }),
       );
@@ -762,13 +784,18 @@ export function createMcpServer(options: McpServerOptions): http.Server {
       return;
     }
 
-    // Auth check on every request
-    const authContext = authenticateMcpRequest(req, apiKey);
+    // Auth check on every request. When a public MCP origin is configured, OAuth
+    // tokens are audience-validated against it (not the loopback default).
+    const authContext = authenticateMcpRequest(
+      req,
+      apiKey,
+      mcpOrigin ? { expectedResource: mcpOrigin } : undefined,
+    );
     if (!authContext) {
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (authorizationServerUrl) {
         headers["WWW-Authenticate"] =
-          `Bearer resource_metadata="${requestResourceUrl}/.well-known/oauth-protected-resource/mcp"`;
+          `Bearer resource_metadata="${resourceUrl}/.well-known/oauth-protected-resource/mcp"`;
       }
       res.writeHead(401, headers);
       res.end(JSON.stringify({ error: "Unauthorized" }));

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -148,6 +148,21 @@ describe("resolveServerConfig", () => {
       vi.stubEnv("GRACKLE_PUBLIC_URL", "https://grackle.home?foo=bar");
       expect(() => resolveServerConfig()).toThrow("bare origin with no path");
     });
+
+    it("throws when the URL embeds userinfo", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "https://user:pass@grackle.home");
+      expect(() => resolveServerConfig()).toThrow("must not contain a username or password");
+    });
+
+    it("trims surrounding whitespace", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "  https://grackle.home  ");
+      expect(resolveServerConfig().publicUrl).toBe("https://grackle.home");
+    });
+
+    it("treats a whitespace-only value as unset", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "   ");
+      expect(resolveServerConfig().publicUrl).toBeUndefined();
+    });
   });
 
   it("returns a frozen object", () => {

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -109,6 +109,47 @@ describe("resolveServerConfig", () => {
     expect(resolveServerConfig().host).toBe("0.0.0.0");
   });
 
+  describe("GRACKLE_PUBLIC_URL", () => {
+    it("is undefined when unset", () => {
+      expect(resolveServerConfig().publicUrl).toBeUndefined();
+    });
+
+    it("accepts an https origin and normalizes it", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "https://grackle.home");
+      expect(resolveServerConfig().publicUrl).toBe("https://grackle.home");
+    });
+
+    it("accepts an http origin", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "http://grackle.home:8080");
+      expect(resolveServerConfig().publicUrl).toBe("http://grackle.home:8080");
+    });
+
+    it("strips a trailing slash via origin normalization", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "https://grackle.home/");
+      expect(resolveServerConfig().publicUrl).toBe("https://grackle.home");
+    });
+
+    it("throws on a non-URL value", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "not-a-url");
+      expect(() => resolveServerConfig()).toThrow("Invalid GRACKLE_PUBLIC_URL");
+    });
+
+    it("throws on a non-http(s) scheme", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "ftp://grackle.home");
+      expect(() => resolveServerConfig()).toThrow("Scheme must be http or https");
+    });
+
+    it("throws when the URL has a path", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "https://grackle.home/grackle");
+      expect(() => resolveServerConfig()).toThrow("bare origin with no path");
+    });
+
+    it("throws when the URL has a query string", () => {
+      vi.stubEnv("GRACKLE_PUBLIC_URL", "https://grackle.home?foo=bar");
+      expect(() => resolveServerConfig()).toThrow("bare origin with no path");
+    });
+  });
+
   it("returns a frozen object", () => {
     const config = resolveServerConfig();
     expect(Object.isFrozen(config)).toBe(true);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_POWERLINE_PORT,
   DEFAULT_SANDBOX_PORT,
 } from "@grackle-ai/common";
+import { parsePublicOrigin } from "@grackle-ai/auth";
 
 /** Validated server configuration resolved from environment variables. */
 export interface ServerConfig {
@@ -85,35 +86,20 @@ function parseFlag(envName: string): boolean {
 /**
  * Parse and validate the canonical public origin from an environment variable.
  *
- * Returns `undefined` when unset. When set, the value must be an absolute
- * http(s) URL with no path, query, or fragment — sub-path reverse-proxy
- * deployments (e.g. `https://example.com/grackle`) are not supported because
- * the OAuth and pairing routes append absolute paths. Throws a clear error on
- * an invalid value so the server fails fast at startup. The returned value is
- * the normalized origin (no trailing slash).
+ * Returns `undefined` when unset or blank. When set, delegates to the shared
+ * {@link parsePublicOrigin} validator: the value must be a bare absolute http(s)
+ * origin (no path/query/fragment/userinfo) — sub-path reverse-proxy deployments
+ * (e.g. `https://example.com/grackle`) are not supported because the OAuth and
+ * pairing routes append absolute paths. Throws a clear error on an invalid value
+ * so the server fails fast at startup. The returned value is the normalized
+ * origin (no trailing slash).
  */
 function parsePublicUrl(envName: string): string | undefined {
   const raw = process.env[envName];
-  if (!raw) {
+  if (!raw?.trim()) {
     return undefined;
   }
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    throw new Error(
-      `Invalid ${envName}: "${raw}". Must be an absolute http(s) origin, e.g. https://grackle.home.`,
-    );
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`Invalid ${envName}: "${raw}". Scheme must be http or https.`);
-  }
-  if ((parsed.pathname !== "" && parsed.pathname !== "/") || parsed.search || parsed.hash) {
-    throw new Error(
-      `Invalid ${envName}: "${raw}". Must be a bare origin with no path, query, or fragment.`,
-    );
-  }
-  return parsed.origin;
+  return parsePublicOrigin(raw, envName).origin;
 }
 
 /**

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -15,6 +15,17 @@ export interface ServerConfig {
   /** MCP server port (GRACKLE_MCP_PORT). */
   mcpPort: number;
   /**
+   * Canonical browser-facing origin (GRACKLE_PUBLIC_URL), e.g.
+   * `https://grackle.home`. When set, it is the source of truth for the
+   * browser-facing scheme + host behind a TLS-terminating reverse proxy: it
+   * drives the OAuth authorization-server metadata scheme/host, the session
+   * cookie `Secure` flag, HSTS emission, the pairing/QR URL, the channel
+   * ingress base URL, and the MCP authorization-server URL. When unset, every
+   * consumer falls back to today's loopback-http behavior. Must be an http(s)
+   * origin with no path/query/fragment.
+   */
+  publicUrl?: string;
+  /**
    * Explicit browser-facing MCP origin (GRACKLE_MCP_ORIGIN), e.g.
    * `https://mcp.example.com`. Used as the trusted asset/CSP origin for
    * broker-captured MCP Apps widgets (so it never depends on the request `Host`).
@@ -72,6 +83,40 @@ function parseFlag(envName: string): boolean {
 }
 
 /**
+ * Parse and validate the canonical public origin from an environment variable.
+ *
+ * Returns `undefined` when unset. When set, the value must be an absolute
+ * http(s) URL with no path, query, or fragment — sub-path reverse-proxy
+ * deployments (e.g. `https://example.com/grackle`) are not supported because
+ * the OAuth and pairing routes append absolute paths. Throws a clear error on
+ * an invalid value so the server fails fast at startup. The returned value is
+ * the normalized origin (no trailing slash).
+ */
+function parsePublicUrl(envName: string): string | undefined {
+  const raw = process.env[envName];
+  if (!raw) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(
+      `Invalid ${envName}: "${raw}". Must be an absolute http(s) origin, e.g. https://grackle.home.`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid ${envName}: "${raw}". Scheme must be http or https.`);
+  }
+  if ((parsed.pathname !== "" && parsed.pathname !== "/") || parsed.search || parsed.hash) {
+    throw new Error(
+      `Invalid ${envName}: "${raw}". Must be a bare origin with no path, query, or fragment.`,
+    );
+  }
+  return parsed.origin;
+}
+
+/**
  * Resolve and validate all server configuration from environment variables.
  * Throws on invalid values so the server fails fast at startup with a clear error.
  */
@@ -80,6 +125,10 @@ export function resolveServerConfig(): ServerConfig {
     grpcPort: parsePort("GRACKLE_PORT", DEFAULT_SERVER_PORT),
     webPort: parsePort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
     mcpPort: parsePort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
+    ...((): { publicUrl?: string } => {
+      const publicUrl = parsePublicUrl("GRACKLE_PUBLIC_URL");
+      return publicUrl ? { publicUrl } : {};
+    })(),
     ...(process.env.GRACKLE_MCP_ORIGIN ? { mcpOrigin: process.env.GRACKLE_MCP_ORIGIN } : {}),
     sandboxPort: parsePort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
     ...(process.env.GRACKLE_SANDBOX_ORIGIN

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -309,7 +309,8 @@ async function main(): Promise<void> {
   const ingressUrlHost = ingressHost.includes(":") ? `[${ingressHost}]` : ingressHost;
   setChannelConfig({
     signingSecret: apiKey,
-    ingressBaseUrl: `http://${ingressUrlHost}:${webPort}`,
+    // Behind a TLS reverse proxy, external callers reach us at the public origin.
+    ingressBaseUrl: config.publicUrl ?? `http://${ingressUrlHost}:${webPort}`,
   });
 
   const webServer = createWebServer({
@@ -321,6 +322,7 @@ async function main(): Promise<void> {
     pluginNames: loaded.pluginNames,
     sandboxPort: config.sandboxPort,
     ...(config.sandboxOrigin !== undefined ? { sandboxOrigin: config.sandboxOrigin } : {}),
+    ...(config.publicUrl !== undefined ? { publicUrl: config.publicUrl } : {}),
     readinessCheck: (): ReadinessResult => {
       const checks: ReadinessResult["checks"] = {};
       try {
@@ -367,7 +369,9 @@ async function main(): Promise<void> {
     const code = generatePairingCode();
     if (code) {
       const pairingHost = isWildcardAddress(bindHost) ? detectLanIp() || "localhost" : bindHost;
-      const pairingUrl = `http://${pairingHost}:${webPort}/pair?code=${code}`;
+      const pairingUrl = config.publicUrl
+        ? `${config.publicUrl}/pair?code=${code}`
+        : `http://${pairingHost}:${webPort}/pair?code=${code}`;
 
       process.stdout.write("\n");
       process.stdout.write("  Open in browser:\n");
@@ -402,10 +406,13 @@ async function main(): Promise<void> {
   });
 
   // --- MCP server (HTTP/1.1, Streamable HTTP) ---
-  // Use dialable host for OAuth URLs (wildcard → 127.0.0.1)
+  // The MCP protected-resource metadata points clients at this authorization
+  // server. Behind a TLS reverse proxy, use the public origin so discovery
+  // carries the right scheme/host; otherwise the dialable loopback host
+  // (wildcard → 127.0.0.1).
   const dialableHost = isWildcardAddress(bindHost) ? "127.0.0.1" : bindHost;
   const dialableUrlHost = dialableHost.includes(":") ? `[${dialableHost}]` : dialableHost;
-  const authServerUrl = `http://${dialableUrlHost}:${webPort}`;
+  const authServerUrl = config.publicUrl ?? `http://${dialableUrlHost}:${webPort}`;
   // Adapt plugin-contributed tools to the concrete ToolDefinition type expected by MCP.
   // Validates shape at startup so runtime failures surface immediately with a clear message.
   const pluginToolGroups: ToolDefinition[][] =

--- a/packages/web-server/src/web-server.test.ts
+++ b/packages/web-server/src/web-server.test.ts
@@ -259,6 +259,35 @@ describe("createWebServer behind a public https origin", () => {
   });
 });
 
+describe("createWebServer sandbox origin in CSP", () => {
+  let server: http.Server;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = createWebServer({
+      apiKey: "x".repeat(64),
+      webPort: 0,
+      bindHost: "127.0.0.1",
+      publicUrl: "https://web.grackle.test",
+      sandboxOrigin: "https://sandbox.grackle.test:8445",
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("passes the sandbox origin to setSecurityHeaders so frame-src allows the widget iframe", async () => {
+    await request(server, "/healthz");
+
+    expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), "web.grackle.test", {
+      hsts: true,
+      sandboxOrigin: "https://sandbox.grackle.test:8445",
+    });
+  });
+});
+
 describe("createWebServer publicUrl validation", () => {
   it("throws a clear error when publicUrl is not a bare origin", () => {
     expect(() =>

--- a/packages/web-server/src/web-server.test.ts
+++ b/packages/web-server/src/web-server.test.ts
@@ -1,22 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "node:http";
 
-// Mock @grackle-ai/auth
-vi.mock("@grackle-ai/auth", () => ({
-  setSecurityHeaders: vi.fn(),
-  validateSessionCookie: vi.fn(() => false),
-  verifyApiKey: vi.fn(() => false),
-  redeemPairingCode: vi.fn(() => false),
-  createSession: vi.fn(() => "grackle_session=test; HttpOnly"),
-  registerClient: vi.fn(),
-  getClient: vi.fn(),
-  createAuthorizationCode: vi.fn(),
-  consumeAuthorizationCode: vi.fn(),
-  createRefreshToken: vi.fn(),
-  consumeRefreshToken: vi.fn(),
-  createOAuthAccessToken: vi.fn(),
-  OAUTH_ACCESS_TOKEN_TTL_MS: 3600000,
-}));
+// Mock @grackle-ai/auth — stub the stateful auth functions, but keep the real
+// pure `parsePublicOrigin` validator so publicUrl validation behaves correctly.
+vi.mock("@grackle-ai/auth", async (importActual) => {
+  const actual = await importActual<typeof import("@grackle-ai/auth")>();
+  return {
+    setSecurityHeaders: vi.fn(),
+    validateSessionCookie: vi.fn(() => false),
+    verifyApiKey: vi.fn(() => false),
+    redeemPairingCode: vi.fn(() => false),
+    createSession: vi.fn(() => "grackle_session=test; HttpOnly"),
+    registerClient: vi.fn(),
+    getClient: vi.fn(),
+    createAuthorizationCode: vi.fn(),
+    consumeAuthorizationCode: vi.fn(),
+    createRefreshToken: vi.fn(),
+    consumeRefreshToken: vi.fn(),
+    createOAuthAccessToken: vi.fn(),
+    OAUTH_ACCESS_TOKEN_TTL_MS: 3600000,
+    parsePublicOrigin: actual.parsePublicOrigin,
+  };
+});
 
 import { createWebServer, isWildcardAddress } from "./web-server.js";
 import {
@@ -243,6 +248,38 @@ describe("createWebServer behind a public https origin", () => {
     expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
       hsts: true,
     });
+  });
+
+  it("derives CSP from the configured public host, not the request Host", async () => {
+    await request(server, "/healthz", { Host: "attacker.example.com" });
+
+    expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), "grackle.home", {
+      hsts: true,
+    });
+  });
+});
+
+describe("createWebServer publicUrl validation", () => {
+  it("throws a clear error when publicUrl is not a bare origin", () => {
+    expect(() =>
+      createWebServer({
+        apiKey: "x".repeat(64),
+        webPort: 0,
+        bindHost: "127.0.0.1",
+        publicUrl: "https://grackle.home/some/path",
+      }),
+    ).toThrow("publicUrl");
+  });
+
+  it("throws when publicUrl is not a valid URL", () => {
+    expect(() =>
+      createWebServer({
+        apiKey: "x".repeat(64),
+        webPort: 0,
+        bindHost: "127.0.0.1",
+        publicUrl: "not-a-url",
+      }),
+    ).toThrow("Invalid publicUrl");
   });
 });
 

--- a/packages/web-server/src/web-server.test.ts
+++ b/packages/web-server/src/web-server.test.ts
@@ -19,7 +19,12 @@ vi.mock("@grackle-ai/auth", () => ({
 }));
 
 import { createWebServer, isWildcardAddress } from "./web-server.js";
-import { validateSessionCookie, redeemPairingCode, createSession } from "@grackle-ai/auth";
+import {
+  validateSessionCookie,
+  redeemPairingCode,
+  createSession,
+  setSecurityHeaders,
+} from "@grackle-ai/auth";
 
 /** Make an HTTP request to the test server. */
 function request(
@@ -167,6 +172,114 @@ describe("createWebServer", () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe("/");
     expect(res.headers["set-cookie"]).toBeDefined();
+  });
+
+  it("creates a non-Secure cookie on a loopback bind (no publicUrl)", async () => {
+    vi.mocked(redeemPairingCode).mockReturnValueOnce(true);
+
+    await request(server, "/pair?code=ABC123");
+
+    expect(createSession).toHaveBeenCalledWith(expect.any(String), { secure: false });
+  });
+
+  it("does not request HSTS on a loopback bind (no publicUrl)", async () => {
+    await request(server, "/healthz");
+
+    expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      hsts: false,
+    });
+  });
+});
+
+describe("createWebServer behind a public https origin", () => {
+  let server: http.Server;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = createWebServer({
+      apiKey: "x".repeat(64),
+      webPort: 0,
+      bindHost: "127.0.0.1",
+      publicUrl: "https://grackle.home",
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("advertises https OAuth metadata endpoints from the public origin", async () => {
+    const res = await request(server, "/.well-known/oauth-authorization-server");
+
+    expect(res.status).toBe(200);
+    const metadata = JSON.parse(res.body);
+    expect(metadata.issuer).toBe("https://grackle.home");
+    expect(metadata.authorization_endpoint).toBe("https://grackle.home/authorize");
+    expect(metadata.token_endpoint).toBe("https://grackle.home/token");
+    expect(metadata.registration_endpoint).toBe("https://grackle.home/register");
+  });
+
+  it("ignores the request Host header for OAuth metadata when publicUrl is set", async () => {
+    const res = await request(server, "/.well-known/oauth-authorization-server", {
+      Host: "attacker.example.com",
+    });
+
+    const metadata = JSON.parse(res.body);
+    expect(metadata.issuer).toBe("https://grackle.home");
+  });
+
+  it("creates a Secure cookie", async () => {
+    vi.mocked(redeemPairingCode).mockReturnValueOnce(true);
+
+    await request(server, "/pair?code=ABC123");
+
+    expect(createSession).toHaveBeenCalledWith(expect.any(String), { secure: true });
+  });
+
+  it("requests HSTS", async () => {
+    await request(server, "/healthz");
+
+    expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      hsts: true,
+    });
+  });
+});
+
+describe("createWebServer behind a public http origin", () => {
+  let server: http.Server;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = createWebServer({
+      apiKey: "x".repeat(64),
+      webPort: 0,
+      bindHost: "0.0.0.0",
+      publicUrl: "http://grackle.home:8080",
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("advertises http OAuth metadata endpoints from the public origin", async () => {
+    const res = await request(server, "/.well-known/oauth-authorization-server");
+
+    const metadata = JSON.parse(res.body);
+    expect(metadata.issuer).toBe("http://grackle.home:8080");
+  });
+
+  it("creates a non-Secure cookie and does not request HSTS for an http public origin", async () => {
+    vi.mocked(redeemPairingCode).mockReturnValueOnce(true);
+
+    await request(server, "/pair?code=ABC123");
+
+    expect(createSession).toHaveBeenCalledWith(expect.any(String), { secure: false });
+    expect(setSecurityHeaders).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      hsts: false,
+    });
   });
 });
 

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -18,6 +18,7 @@ import {
   consumeRefreshToken,
   createOAuthAccessToken,
   OAUTH_ACCESS_TOKEN_TTL_MS,
+  parsePublicOrigin,
 } from "@grackle-ai/auth";
 
 // ─── Options ────────────────────────────────────────────────
@@ -405,11 +406,18 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
   // When GRACKLE_PUBLIC_URL is set it is the source of truth for the
   // browser-facing scheme + host (behind a TLS-terminating reverse proxy).
-  const publicUrlParsed = publicUrl ? new URL(publicUrl) : undefined;
+  // Validate here too (not just in the server's config parser) so a direct
+  // consumer of this exported factory fails fast with a clear error rather than
+  // a low-signal URL exception deep in a request handler.
+  const publicUrlParsed = publicUrl ? parsePublicOrigin(publicUrl, "publicUrl") : undefined;
   const publicIsHttps = publicUrlParsed?.protocol === "https:";
   // Session cookie `Secure`: keyed off the public scheme when configured, else
   // the wildcard-bind heuristic (unchanged for the casual local user).
   const cookieSecure = publicUrlParsed ? publicIsHttps : allowNetwork;
+  // CSP form-action / frame-src host: use the configured public host when set
+  // (consistent with ignoring the spoofable request Host elsewhere); otherwise
+  // fall back to the request Host for the loopback / LAN case.
+  const cspHost = publicUrlParsed ? publicUrlParsed.host : undefined;
 
   /** ConnectRPC handler for browser gRPC calls (Connect protocol over HTTP/1.1). */
   const webConnectHandler = connectRoutes
@@ -418,7 +426,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const handler = async (req: http.IncomingMessage, res: http.ServerResponse): Promise<void> => {
-    setSecurityHeaders(res, req.headers.host, { hsts: publicIsHttps });
+    setSecurityHeaders(res, cspHost ?? req.headers.host, { hsts: publicIsHttps });
 
     let rawPath: string;
     let queryString = "";

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -99,6 +99,16 @@ export interface WebServerOptions {
    */
   sandboxOrigin?: string;
   /**
+   * Canonical browser-facing origin (e.g. `https://grackle.home`), from
+   * `GRACKLE_PUBLIC_URL`. When set, it is the source of truth for the
+   * browser-facing scheme + host behind a TLS-terminating reverse proxy:
+   * the OAuth authorization-server metadata uses its scheme + host, the
+   * session cookie gets the `Secure` flag iff its scheme is https, and HSTS
+   * is emitted iff https. When unset, behavior is unchanged (request-host
+   * derivation for OAuth metadata; cookie `Secure` keyed off the wildcard bind).
+   */
+  publicUrl?: string;
+  /**
    * Inbound channel webhook handler (injected). Verifies the capability token
    * and delivers the message. When omitted, the `/hook` route is disabled.
    */
@@ -384,6 +394,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
     pluginNames,
     sandboxPort,
     sandboxOrigin,
+    publicUrl,
     handleWebhook,
   } = options;
   const distDir = webDistDir ?? resolveWebDistDir();
@@ -392,6 +403,14 @@ export function createWebServer(options: WebServerOptions): http.Server {
   const urlHost = dialableHost.includes(":") ? `[${dialableHost}]` : dialableHost;
   const webBaseUrl = `http://${urlHost}:${webPort}`;
 
+  // When GRACKLE_PUBLIC_URL is set it is the source of truth for the
+  // browser-facing scheme + host (behind a TLS-terminating reverse proxy).
+  const publicUrlParsed = publicUrl ? new URL(publicUrl) : undefined;
+  const publicIsHttps = publicUrlParsed?.protocol === "https:";
+  // Session cookie `Secure`: keyed off the public scheme when configured, else
+  // the wildcard-bind heuristic (unchanged for the casual local user).
+  const cookieSecure = publicUrlParsed ? publicIsHttps : allowNetwork;
+
   /** ConnectRPC handler for browser gRPC calls (Connect protocol over HTTP/1.1). */
   const webConnectHandler = connectRoutes
     ? connectNodeAdapter({ routes: connectRoutes })
@@ -399,7 +418,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const handler = async (req: http.IncomingMessage, res: http.ServerResponse): Promise<void> => {
-    setSecurityHeaders(res, req.headers.host);
+    setSecurityHeaders(res, req.headers.host, { hsts: publicIsHttps });
 
     let rawPath: string;
     let queryString = "";
@@ -455,11 +474,16 @@ export function createWebServer(options: WebServerOptions): http.Server {
     }
 
     // --- OAuth Authorization Server Metadata (no auth) ---
-    // Derive base URL from request Host header so URLs match the origin the
-    // browser is on — avoids CSP form-action 'self' mismatch (#1180).
+    // When GRACKLE_PUBLIC_URL is set, advertise its scheme + host so OAuth
+    // clients reaching us over https (behind a TLS proxy) get https endpoints
+    // (RFC 8414). Otherwise derive the base URL from the request Host header so
+    // URLs match the origin the browser is on — avoids CSP form-action 'self'
+    // mismatch (#1180).
     if (rawPath === "/.well-known/oauth-authorization-server") {
       const requestHost = req.headers.host || `${urlHost}:${webPort}`;
-      const baseUrl = `http://${requestHost}`;
+      const baseUrl = publicUrlParsed
+        ? `${publicUrlParsed.protocol}//${publicUrlParsed.host}`
+        : `http://${requestHost}`;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
@@ -709,7 +733,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
           }
 
           // Pairing succeeded — also create a browser session
-          const setCookie = createSession(apiKey, { secure: allowNetwork });
+          const setCookie = createSession(apiKey, { secure: cookieSecure });
           responseHeaders["Set-Cookie"] = setCookie;
           hasPairedSession = true;
         }
@@ -822,7 +846,7 @@ export function createWebServer(options: WebServerOptions): http.Server {
       if (code) {
         const remoteIp = getRemoteIp(req);
         if (redeemPairingCode(code, remoteIp)) {
-          const setCookie = createSession(apiKey, { secure: allowNetwork });
+          const setCookie = createSession(apiKey, { secure: cookieSecure });
           res.writeHead(302, {
             Location: "/",
             "Set-Cookie": setCookie,

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -426,7 +426,10 @@ export function createWebServer(options: WebServerOptions): http.Server {
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const handler = async (req: http.IncomingMessage, res: http.ServerResponse): Promise<void> => {
-    setSecurityHeaders(res, cspHost ?? req.headers.host, { hsts: publicIsHttps });
+    setSecurityHeaders(res, cspHost ?? req.headers.host, {
+      hsts: publicIsHttps,
+      ...(sandboxOrigin !== undefined ? { sandboxOrigin } : {}),
+    });
 
     let rawPath: string;
     let queryString = "";


### PR DESCRIPTION
@
Closes #1371.

## Problem

Behind a TLS-terminating reverse proxy (e.g. Caddy), the web/MCP servers inferred the browser-facing scheme from the **bind address** / **request `Host` header**, hardcoding `http://`. This caused:

1. **OAuth metadata advertised `http://` endpoints** — MCP OAuth clients doing RFC 8414 discovery got downgrade/mixed-content `authorization_endpoint` / `token_endpoint` / `registration_endpoint`. (The one that actively breaks.)
2. **`Secure` cookie keyed off bind address, not channel scheme.**
3. **No HSTS** even when effectively served over https.
4. **Pairing/QR URL + channel ingress base URL hardcoded `http://`.**

Remediation path for draft advisory **GHSA-wcpf-6gwv-47c8** (Pattern E: *TLS gated on bind-host, not channel*).

## Change

Add a canonical external-origin config — **`GRACKLE_PUBLIC_URL`** (`--public-url`), e.g. `https://grackle.home`. When set it is the source of truth for the browser-facing scheme + host:

- OAuth authorization-server metadata uses its scheme + host
- session cookie `Secure` flag = (public scheme is https)
- emit `Strict-Transport-Security` (1yr, no `includeSubDomains`) when https
- pairing/QR URL + channel webhook ingress base URL use it
- the MCP server `authorizationServerUrl` derives from it (explicit non-loopback origin advertised verbatim)

We do **not** auto-trust `X-Forwarded-Proto`. When `GRACKLE_PUBLIC_URL` is unset, behavior is unchanged (loopback http defaults), so the casual local user is unaffected.

### MCP resource/audience fix (scope expansion beyond the issue body)

The MCP server `resource` URL is also the OAuth **audience** — changing only the advertised scheme would have caused tokens to be rejected by the hardcoded `http://127.0.0.1:<localPort>` audience check in `auth-middleware.ts`. So this PR also makes **`GRACKLE_MCP_ORIGIN`** drive the MCP OAuth resource identifier / token audience (RFC 9728), with `authenticateMcpRequest` gaining an `expectedResource` option. Security is preserved: the default path still never trusts the spoofable `Host` header; the configured path uses a static operator-provided origin.

## Files

- `packages/server/src/config.ts` — parse + validate `GRACKLE_PUBLIC_URL` (http(s) origin, no path)
- `packages/web-server/src/web-server.ts` — OAuth metadata scheme/host, cookie `Secure`, HSTS
- `packages/auth/src/security-headers.ts` — HSTS header + `SecurityHeaderOptions`
- `packages/auth/src/auth-middleware.ts` — `expectedResource` audience validation
- `packages/auth/src/session.ts` — TSDoc (secure-flag source)
- `packages/mcp/src/mcp-server.ts` — resource/audience from `GRACKLE_MCP_ORIGIN`; explicit auth origin
- `packages/server/src/index.ts` — thread `publicUrl` into web/MCP/ingress/pairing
- `packages/cli/src/commands/serve.ts` — `--public-url` flag
- `.env.example`, `packages/cli/README.md` — docs

## Tests

- **config**: `GRACKLE_PUBLIC_URL` parse/validation (valid http/https, invalid scheme/path/query, unset).
- **web-server**: OAuth metadata https endpoints + Secure cookie + HSTS when public origin set; unchanged fallback when unset; request-Host ignored when set.
- **security-headers**: HSTS present iff `{ hsts: true }`.
- **auth-middleware**: `expectedResource` match/mismatch/trailing-slash.
- **mcp-server**: protected-resource metadata `resource` = `GRACKLE_MCP_ORIGIN`; explicit auth server advertised verbatim, ignoring request Host.
- **cli**: `--public-url` sets `GRACKLE_PUBLIC_URL`; unset by default.

All affected package suites pass locally (auth 102, mcp 284, web-server 42, server 119, cli 30). `rush build` clean (no warnings); `rush format:check` clean; `rush change --verify` passes.

## Manual testing

Not yet run behind a live Caddy+TLS stack (no proxy available in this session). The change is config-gated and fully covered by unit tests asserting the https/Secure/HSTS behavior; recommend a manual Caddy smoke test (MCP OAuth discovery returns https; login cookie is `Secure`) before/after merge.

## Out of scope (separate tickets)

- **Tier 2:** native TLS via `GRACKLE_TLS_CERT`/`GRACKLE_TLS_KEY` (the no-proxy `--allow-network` remediation).
- **#844:** h2c upgrade — recommend closing.
@