### PR TITLE
Playwright E2E coverage + real merged repo-wide total (#1383)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,18 @@
 # Enable demo mode in the web UI (compiled in at build time).
 # VITE_DEMO_MODE=false
 
+# ── Testing (Playwright E2E) ──────────────────────────────────────
+# Number of parallel Playwright workers per shard. Defaults to 2 in CI, else
+# min(4, cpuCount/2). Accepts an integer or a percentage (e.g. "50%").
+# E2E_WORKERS=
+
+# Collect V8 code coverage during the E2E run. When "true", each test's
+# coverage is source-mapped back to packages/web/src and written to
+# tests/e2e-tests/coverage/lcov.info for the combined-coverage merge.
+# Off by default so local TDD runs stay fast. Requires the web bundle to be
+# built with source maps (always emitted; see packages/web/vite.config.ts).
+# E2E_COVERAGE=false
+
 # ── Third-Party Providers ─────────────────────────────────────────
 # OpenAI API key for the Codex runtime.
 # OPENAI_API_KEY=

--- a/.github/actions/run-e2e-shard/action.yml
+++ b/.github/actions/run-e2e-shard/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Override E2E_WORKERS (number of Playwright workers per shard)
     required: false
     default: ""
+  coverage-artifact-name:
+    description: Name for the uploaded E2E coverage artifact (empty = skip coverage collection)
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -76,6 +80,9 @@ runs:
       working-directory: tests/e2e-tests
       env:
         E2E_WORKERS: ${{ inputs.workers }}
+        # Enable Playwright V8 coverage collection only when a coverage artifact
+        # name is supplied (the global teardown writes coverage/lcov.info).
+        E2E_COVERAGE: ${{ inputs.coverage-artifact-name != '' && 'true' || '' }}
       run: |
         ARGS="--project=${{ inputs.project }}"
         if [ -n "${{ inputs.shard }}" ]; then
@@ -91,3 +98,12 @@ runs:
         path: tests/e2e-tests/test-results/e2e-results.xml
         if-no-files-found: ignore
         retention-days: 30
+
+    - name: Upload E2E coverage
+      if: always() && inputs.coverage-artifact-name != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.coverage-artifact-name }}
+        path: tests/e2e-tests/coverage/lcov.info
+        if-no-files-found: warn
+        retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,16 @@ jobs:
           path: coverage-input/e2e
           merge-multiple: false
 
+      # Guard that E2E coverage actually landed: web unit tests already cover
+      # packages/web/src, so the merge's --require-source check alone can't tell
+      # E2E coverage apart. Assert at least one E2E lcov was downloaded.
+      - name: Verify E2E coverage artifacts present
+        run: |
+          if [ -z "$(find coverage-input/e2e -name lcov.info -print -quit 2>/dev/null)" ]; then
+            echo "::error::No E2E coverage lcov found — E2E coverage did not land."
+            exit 1
+          fi
+
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           project: chromium
           shard: "${{ matrix.shard }}/3"
           artifact-name: "e2e-results-chromium-${{ matrix.shard }}"
+          coverage-artifact-name: "e2e-coverage-chromium-${{ matrix.shard }}"
 
   e2e-knowledge:
     runs-on: ubuntu-latest
@@ -155,6 +156,7 @@ jobs:
         with:
           project: knowledge
           artifact-name: "e2e-results-knowledge"
+          coverage-artifact-name: "e2e-coverage-knowledge"
 
   report:
     runs-on: ubuntu-latest
@@ -192,3 +194,57 @@ jobs:
           path: "test-results/**/*.xml"
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+  # Union per-suite lcov (unit from `build`, E2E from the shards) into one
+  # repo-wide total and surface it in the job summary (#1383).
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [build, e2e-chromium, e2e-knowledge]
+    if: always() && needs.build.result == 'success'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download unit coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage-input/unit
+
+      - name: Download E2E coverage
+        uses: actions/download-artifact@v4
+        with:
+          pattern: e2e-coverage-*
+          path: coverage-input/e2e
+          merge-multiple: false
+
+      - name: Rush install
+        run: node common/scripts/install-run-rush.js install
+
+      - name: Build coverage-merge
+        run: node common/scripts/install-run-rush.js build -t @grackle-ai/coverage-merge
+
+      - name: Merge coverage and write combined total
+        run: |
+          node scripts/coverage-merge/dist/index.js coverage-input \
+            --out coverage/combined/lcov.info \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --require-source packages/web/src
+
+      - name: Upload combined coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-coverage
+          path: coverage/combined/lcov.info
+          if-no-files-found: warn
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,16 @@ npx buf generate
 `rush test` collects unit-test coverage via Vitest's v8 provider. Reports land in each package's `coverage/` directory (`lcov.info`, `coverage-summary.json`, and an `index.html` for browser viewing). CI uploads them as a single `coverage` artifact on the `build` job. The shared config lives at `rigs/heft-rig/vitest-base.mjs` — per-package `vitest.config.ts` files just call `createVitestConfig()` and add overrides if needed.
 
 - **Per-package thresholds enforced** ([#1326](https://github.com/nick-pape/grackle/issues/1326)). Floors for each metric (branches/lines/functions/statements) live in `rigs/heft-rig/coverage-thresholds.json`. CI fails if any package drops below its floor. Frozen — no auto-ratchet; bump by hand when a package's real coverage climbs and you want to lock the new floor in.
-- **Unit tests only** ([#1327](https://github.com/nick-pape/grackle/issues/1327)) — Storybook interaction tests and Playwright E2E aren't yet instrumented.
 - Excluded by default: `src/gen/**` (proto), `src/vendor/**` (vendored AHP), `src/mocks/**`, `*.stories.tsx`, `*.test.{ts,tsx}`.
 - New packages without a thresholds entry log a one-line warning and run unenforced. Add an entry once the package has a stable baseline.
+
+#### Combined coverage (unit + E2E)
+
+Beyond the per-package unit floors, CI computes a **real repo-wide merged total** that unions Vitest unit coverage with Playwright E2E coverage ([#1383](https://github.com/nick-pape/grackle/issues/1383); Storybook is the follow-up [#1384](https://github.com/nick-pape/grackle/issues/1384)).
+
+- **E2E coverage** is opt-in via `E2E_COVERAGE=true`. When set, the `page` fixture (`tests/e2e-tests/tests/fixtures.ts`) collects V8 coverage per test; a Playwright `globalTeardown` runs monocart-coverage-reports to write `tests/e2e-tests/coverage/lcov.info`, source-mapped back to `packages/web/src` via `coverage-options.ts` (which resolves `.map` files from `packages/web/dist` on disk, since the per-worker servers are gone by teardown). The web bundle always emits external source maps (`packages/web/vite.config.ts`) — external, so they don't count toward the Vite chunk-size gate.
+- **Merge.** `scripts/coverage-merge` (`@grackle-ai/coverage-merge`) unions every `*/coverage/lcov.info` into one combined lcov + total, normalizing `SF:` paths to repo-relative POSIX so the same web file from unit and E2E collapses to one key (a line is covered if any suite hit it). The CI `coverage` job downloads the unit + per-shard E2E artifacts, merges, prints the total to `$GITHUB_STEP_SUMMARY`, and uploads `combined-coverage`. `--require-source packages/web/src` makes the job fail loudly if E2E coverage didn't land.
+- The combined total is **informational** — not yet a PR gate.
 
 ### Storybook Component Tests
 

--- a/common/changes/@grackle-ai/cli/nick-pape-1327b-e2e-coverage_2026-05-29.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1327b-e2e-coverage_2026-05-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@grackle-ai/cli",
+      "comment": "Add Playwright E2E V8 coverage collection and a coverage-merge step that unions unit + E2E lcov into one repo-wide total (#1383).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@grackle-ai/cli"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1531,6 +1531,24 @@ importers:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@22.19.15)(jiti@1.21.7)(sass@1.98.0)(terser@5.46.1)
 
+  ../../scripts/coverage-merge:
+    devDependencies:
+      '@grackle-ai/heft-rig':
+        specifier: workspace:*
+        version: link:../../rigs/heft-rig
+      '@rushstack/heft':
+        specifier: 1.2.7
+        version: 1.2.7(@types/node@22.19.15)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.0.1)(sass@1.98.0)(terser@5.46.1))
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.0.1)(sass@1.98.0)(terser@5.46.1)
+
   ../../scripts/github-import:
     dependencies:
       '@connectrpc/connect':
@@ -1585,6 +1603,9 @@ importers:
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.58.2
+      monocart-coverage-reports:
+        specifier: ~2.12.12
+        version: 2.12.12
 
 packages:
 
@@ -5078,6 +5099,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -5692,6 +5717,10 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -5753,6 +5782,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  console-grid@2.2.4:
+    resolution: {integrity: sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -6468,6 +6500,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  eight-colors@1.3.3:
+    resolution: {integrity: sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==}
+
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
 
@@ -6927,6 +6962,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  foreground-child@4.0.3:
+    resolution: {integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==}
+    engines: {node: '>=16'}
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -8154,6 +8193,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  lz-utils@2.1.1:
+    resolution: {integrity: sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==}
+
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
@@ -8516,6 +8558,13 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  monocart-coverage-reports@2.12.12:
+    resolution: {integrity: sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==}
+    hasBin: true
+
+  monocart-locator@1.0.3:
+    resolution: {integrity: sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==}
 
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
@@ -15704,6 +15753,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
@@ -16418,6 +16471,8 @@ snapshots:
 
   commander@13.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@3.0.2: {}
@@ -16477,6 +16532,8 @@ snapshots:
   connect-history-api-fallback@2.0.0: {}
 
   consola@3.4.2: {}
+
+  console-grid@2.2.4: {}
 
   content-disposition@0.5.2: {}
 
@@ -17141,6 +17198,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  eight-colors@1.3.3: {}
+
   electron-to-chromium@1.5.321: {}
 
   emittery@0.13.1: {}
@@ -17789,6 +17848,10 @@ snapshots:
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  foreground-child@4.0.3:
+    dependencies:
       signal-exit: 4.1.0
 
   form-data-encoder@2.1.4: {}
@@ -19299,6 +19362,8 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  lz-utils@2.1.1: {}
+
   magic-string@0.27.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -19962,6 +20027,23 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  monocart-coverage-reports@2.12.12:
+    dependencies:
+      acorn: 8.16.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      console-grid: 2.2.4
+      eight-colors: 1.3.3
+      foreground-child: 4.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      lz-utils: 2.1.1
+      monocart-locator: 1.0.3
+
+  monocart-locator@1.0.3: {}
 
   motion-dom@11.18.1:
     dependencies:

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
   },
   build: {
     chunkSizeWarningLimit: 800,
+    // Emit external source maps (separate `*.js.map` files). These let the
+    // Playwright E2E coverage pass map V8 coverage of the minified bundle back
+    // to `packages/web/src/**` source (#1383). External maps (not `inline`)
+    // are NOT counted toward `chunkSizeWarningLimit`, so they don't trip the
+    // warnings-as-errors CI gate; inline maps would. The repo is public OSS, so
+    // shipping maps leaks nothing. `@grackle-ai/web-server` serves any dist
+    // file, so the `.map` files are reachable when the app is served.
+    sourcemap: true,
     // Never inline font files as base64 `data:` URIs. Vite inlines assets under
     // ~4 KB by default, which would emit small self-hosted font subsets (e.g.
     // JetBrains Mono's tiny cyrillic-ext subset) as `data:font/woff2;base64,...`.

--- a/rigs/heft-rig/coverage-thresholds.json
+++ b/rigs/heft-rig/coverage-thresholds.json
@@ -59,6 +59,12 @@
     "lines": 95,
     "statements": 95
   },
+  "@grackle-ai/coverage-merge": {
+    "branches": 90,
+    "functions": 100,
+    "lines": 80,
+    "statements": 80
+  },
   "@grackle-ai/core": {
     "branches": 80,
     "functions": 90,

--- a/rush.json
+++ b/rush.json
@@ -202,6 +202,10 @@
     {
       "packageName": "@grackle-ai/github-import",
       "projectFolder": "scripts/github-import"
+    },
+    {
+      "packageName": "@grackle-ai/coverage-merge",
+      "projectFolder": "scripts/coverage-merge"
     }
   ]
 }

--- a/scripts/coverage-merge/README.md
+++ b/scripts/coverage-merge/README.md
@@ -1,0 +1,33 @@
+# @grackle-ai/coverage-merge
+
+Unions per-suite lcov coverage into a single repo-wide total.
+
+Grackle collects coverage from three suites that each write their own
+`coverage/lcov.info`:
+
+- **Vitest unit** — one per package (`packages/*/coverage/lcov.info`, `scripts/*/coverage/lcov.info`).
+- **Storybook interaction** — `packages/web-components/coverage/lcov.info` (added in a follow-up ticket).
+- **Playwright E2E** — `tests/e2e-tests/coverage/lcov.info` (one per shard).
+
+Because the same source file (e.g. `packages/web/src/App.tsx`) is exercised by
+more than one suite, a simple concatenation double-counts. This tool **unions**
+the records: per-line/-function/-branch hit counts are summed across suites and
+an item counts as covered when any suite executed it. Source paths are
+normalized to repo-root-relative POSIX so the same file from different suites
+collapses to one key.
+
+## Usage
+
+```bash
+node scripts/coverage-merge/dist/index.js [roots...] \
+  --out coverage/combined/lcov.info \
+  --summary "$GITHUB_STEP_SUMMARY" \
+  --require-source packages/web/src
+```
+
+- `roots...` — directories to scan recursively for `lcov.info` (default: cwd). `node_modules`, `dist`, `.git`, `.rush` are skipped.
+- `--out <file>` — combined lcov output path (default `coverage/combined/lcov.info`).
+- `--summary <md-file>` — append a Markdown summary table (used to write `$GITHUB_STEP_SUMMARY` in CI).
+- `--require-source <substring>` — exit non-zero if no merged source path contains the substring (CI guard that expected coverage actually landed).
+
+The combined total (lines / functions / branches) is printed to stdout.

--- a/scripts/coverage-merge/config/rig.json
+++ b/scripts/coverage-merge/config/rig.json
@@ -1,0 +1,3 @@
+{
+  "rigPackageName": "@grackle-ai/heft-rig"
+}

--- a/scripts/coverage-merge/config/rush-project.json
+++ b/scripts/coverage-merge/config/rush-project.json
@@ -1,0 +1,12 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "_phase:build",
+      "outputFolderNames": ["dist"]
+    },
+    {
+      "operationName": "_phase:test",
+      "outputFolderNames": ["coverage"]
+    }
+  ]
+}

--- a/scripts/coverage-merge/package.json
+++ b/scripts/coverage-merge/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@grackle-ai/coverage-merge",
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=22.0.0 <24.0.0"
+  },
+  "private": true,
+  "description": "Union per-suite lcov coverage (unit + Storybook + E2E) into one repo-wide total",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "coverage-merge": "dist/index.js"
+  },
+  "scripts": {
+    "build": "heft build --clean",
+    "test": "vitest run",
+    "clean": "heft clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "vitest run --coverage"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@grackle-ai/heft-rig": "workspace:*",
+    "@rushstack/heft": "1.2.7",
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.1",
+    "vitest": "^3.1.1"
+  }
+}

--- a/scripts/coverage-merge/src/index.ts
+++ b/scripts/coverage-merge/src/index.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// CLI entry: scan one or more roots for `lcov.info` files (unit, Storybook,
+// E2E), union them into a single repo-wide lcov + total, and print the result.
+//
+// Usage:
+//   coverage-merge [roots...] [--out <file>] [--summary <md-file>]
+//                  [--require-source <substring>]
+//
+// Defaults: scans the current working directory; writes the combined lcov to
+// `coverage/combined/lcov.info`. `--require-source` exits non-zero if no merged
+// source path contains the substring (CI guard that expected coverage landed,
+// e.g. `packages/web/src`). The merge/render logic lives in `run.ts`.
+
+import { writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { join, dirname, resolve, relative, sep } from "node:path";
+
+import { writeLcov } from "./merge.js";
+import {
+  LCOV_FILENAME,
+  findLcovFiles,
+  mergeLcovFiles,
+  hasSourceMatching,
+  renderTextTable,
+  renderMarkdown,
+  type MergeResult,
+} from "./run.js";
+
+/** Parsed command-line options. */
+interface CliOptions {
+  roots: string[];
+  out: string;
+  summary: string | undefined;
+  requireSource: string | undefined;
+}
+
+/** Parse argv (excluding node + script) into {@link CliOptions}. */
+function parseArgs(argv: string[]): CliOptions {
+  const roots: string[] = [];
+  let out: string = join("coverage", "combined", LCOV_FILENAME);
+  let summary: string | undefined;
+  let requireSource: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg: string = argv[i];
+    if (arg === "--out") {
+      out = argv[++i];
+    } else if (arg === "--summary") {
+      summary = argv[++i];
+    } else if (arg === "--require-source") {
+      requireSource = argv[++i];
+    } else {
+      roots.push(arg);
+    }
+  }
+  if (roots.length === 0) {
+    roots.push(process.cwd());
+  }
+  return { roots, out, summary, requireSource };
+}
+
+/** Program entry point. */
+function main(): void {
+  const options: CliOptions = parseArgs(process.argv.slice(2));
+  const outAbs: string = resolve(options.out);
+
+  const lcovFiles: string[] = [];
+  for (const root of options.roots) {
+    lcovFiles.push(...findLcovFiles(resolve(root), outAbs));
+  }
+
+  if (lcovFiles.length === 0) {
+    process.stderr.write(
+      `[coverage-merge] No ${LCOV_FILENAME} files found under: ${options.roots.join(", ")}\n`,
+    );
+    process.exit(1);
+  }
+
+  for (const file of lcovFiles) {
+    process.stdout.write(
+      `[coverage-merge] + ${relative(process.cwd(), file).split(sep).join("/")}\n`,
+    );
+  }
+
+  const result: MergeResult = mergeLcovFiles(lcovFiles);
+
+  mkdirSync(dirname(outAbs), { recursive: true });
+  writeFileSync(outAbs, writeLcov(result.merged), "utf8");
+
+  process.stdout.write(`\n${renderTextTable(result, result.merged.size)}\n`);
+  process.stdout.write(`\n[coverage-merge] Combined lcov written to ${options.out}\n`);
+
+  if (options.summary) {
+    appendFileSync(options.summary, renderMarkdown(result, result.merged.size), "utf8");
+  }
+
+  if (options.requireSource && !hasSourceMatching(result.merged, options.requireSource)) {
+    process.stderr.write(
+      `[coverage-merge] ERROR: no merged source path contains "${options.requireSource}". ` +
+        `Expected coverage was not produced (e.g. E2E coverage did not land).\n`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/coverage-merge/src/merge.test.ts
+++ b/scripts/coverage-merge/src/merge.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  normalizeSourcePath,
+  parseLcov,
+  unionFileCoverage,
+  mergeCoverageMaps,
+  summarize,
+  formatPercent,
+  writeLcov,
+  type FileCoverage,
+} from "./merge.js";
+
+describe("normalizeSourcePath", () => {
+  it("strips an absolute POSIX CI prefix down to the repo anchor", () => {
+    expect(normalizeSourcePath("/home/runner/work/grackle/grackle/packages/web/src/App.tsx")).toBe(
+      "packages/web/src/App.tsx",
+    );
+  });
+
+  it("strips an absolute Windows prefix and normalizes separators", () => {
+    expect(normalizeSourcePath("C:\\Users\\nickp\\src\\grackle\\packages\\auth\\src\\key.ts")).toBe(
+      "packages/auth/src/key.ts",
+    );
+  });
+
+  it("leaves an already-relative repo path unchanged", () => {
+    expect(normalizeSourcePath("packages/web/src/components/Foo.tsx")).toBe(
+      "packages/web/src/components/Foo.tsx",
+    );
+  });
+
+  it("uses the last anchor when one appears in the absolute prefix too", () => {
+    expect(normalizeSourcePath("/home/packages/grackle/packages/web/src/x.ts")).toBe(
+      "packages/web/src/x.ts",
+    );
+  });
+
+  it("normalizes tests/ and scripts/ anchors", () => {
+    expect(normalizeSourcePath("/abs/tests/e2e-tests/foo.ts")).toBe("tests/e2e-tests/foo.ts");
+    expect(normalizeSourcePath("/abs/scripts/coverage-merge/src/index.ts")).toBe(
+      "scripts/coverage-merge/src/index.ts",
+    );
+  });
+
+  it("falls back to the cleaned path when no anchor is present", () => {
+    expect(normalizeSourcePath("/opt/weird/file.ts")).toBe("/opt/weird/file.ts");
+  });
+
+  it("resolves a Vitest package-relative path against the lcov's package root", () => {
+    // <pkg>/coverage/lcov.info → <pkg>, so src/foo.ts → packages/web/src/foo.ts.
+    expect(normalizeSourcePath("src/App.tsx", "/abs/packages/web/coverage/lcov.info")).toBe(
+      "packages/web/src/App.tsx",
+    );
+    expect(
+      normalizeSourcePath(
+        "src\\merge.ts",
+        "C:\\repo\\scripts\\coverage-merge\\coverage\\lcov.info",
+      ),
+    ).toBe("scripts/coverage-merge/src/merge.ts");
+  });
+
+  it("ignores the lcov path when the SF is already repo-relative or absolute", () => {
+    expect(
+      normalizeSourcePath("packages/web/src/App.tsx", "/abs/tests/e2e-tests/coverage/lcov.info"),
+    ).toBe("packages/web/src/App.tsx");
+    expect(
+      normalizeSourcePath("/x/packages/web/src/App.tsx", "/abs/tests/e2e-tests/coverage/lcov.info"),
+    ).toBe("packages/web/src/App.tsx");
+  });
+});
+
+describe("parseLcov", () => {
+  const sample: string = [
+    "TN:",
+    "SF:/abs/packages/web/src/App.tsx",
+    "FN:10,render",
+    "FNDA:3,render",
+    "FNF:1",
+    "FNH:1",
+    "BRDA:12,0,0,2",
+    "BRDA:12,0,1,-",
+    "BRF:2",
+    "BRH:1",
+    "DA:10,3",
+    "DA:11,0",
+    "LF:2",
+    "LH:1",
+    "end_of_record",
+    "",
+  ].join("\n");
+
+  it("parses a single record keyed by normalized path", () => {
+    const map = parseLcov(sample);
+    expect([...map.keys()]).toEqual(["packages/web/src/App.tsx"]);
+    const cov = map.get("packages/web/src/App.tsx")!;
+    expect(cov.functionLines.get("render")).toBe(10);
+    expect(cov.functionHits.get("render")).toBe(3);
+    expect(cov.lineHits.get(10)).toBe(3);
+    expect(cov.lineHits.get(11)).toBe(0);
+    expect(cov.branchHits.get("12,0,0")).toBe(2);
+    expect(cov.branchHits.get("12,0,1")).toBeUndefined();
+  });
+
+  it("handles function names containing commas", () => {
+    const lcov = [
+      "SF:packages/x/src/a.ts",
+      "FN:1,Foo<A,B>",
+      "FNDA:5,Foo<A,B>",
+      "end_of_record",
+    ].join("\n");
+    const cov = parseLcov(lcov).get("packages/x/src/a.ts")!;
+    expect(cov.functionLines.get("Foo<A,B>")).toBe(1);
+    expect(cov.functionHits.get("Foo<A,B>")).toBe(5);
+  });
+
+  it("unions duplicate records for the same path within one file", () => {
+    const lcov = [
+      "SF:packages/x/src/a.ts",
+      "DA:1,1",
+      "end_of_record",
+      "SF:/other/packages/x/src/a.ts",
+      "DA:1,2",
+      "DA:2,0",
+      "end_of_record",
+    ].join("\n");
+    const cov = parseLcov(lcov).get("packages/x/src/a.ts")!;
+    expect(cov.lineHits.get(1)).toBe(3);
+    expect(cov.lineHits.get(2)).toBe(0);
+  });
+
+  it("returns an empty map for empty input", () => {
+    expect(parseLcov("").size).toBe(0);
+  });
+});
+
+describe("unionFileCoverage", () => {
+  it("sums line and function hits and merges branch taken counts", () => {
+    const a: FileCoverage = {
+      path: "packages/web/src/App.tsx",
+      functionLines: new Map([["render", 10]]),
+      functionHits: new Map([["render", 0]]),
+      lineHits: new Map([
+        [10, 0],
+        [11, 1],
+      ]),
+      branchHits: new Map([["12,0,0", undefined]]),
+    };
+    const b: FileCoverage = {
+      path: "packages/web/src/App.tsx",
+      functionLines: new Map([["render", 10]]),
+      functionHits: new Map([["render", 4]]),
+      lineHits: new Map([[10, 2]]),
+      branchHits: new Map([["12,0,0", 3]]),
+    };
+    const merged = unionFileCoverage(a, b);
+    expect(merged.functionHits.get("render")).toBe(4);
+    expect(merged.lineHits.get(10)).toBe(2);
+    expect(merged.lineHits.get(11)).toBe(1);
+    expect(merged.branchHits.get("12,0,0")).toBe(3);
+  });
+});
+
+describe("mergeCoverageMaps + summarize", () => {
+  it("unions overlapping web coverage from unit and e2e (a line hit by either counts)", () => {
+    // Unit covers line 10 of App; E2E covers line 11. Union => both lines hit.
+    const unit = parseLcov(
+      ["SF:packages/web/src/App.tsx", "DA:10,1", "DA:11,0", "end_of_record"].join("\n"),
+    );
+    const e2e = parseLcov(
+      ["SF:/runner/packages/web/src/App.tsx", "DA:10,0", "DA:11,5", "end_of_record"].join("\n"),
+    );
+    const merged = mergeCoverageMaps([unit, e2e]);
+    expect(merged.size).toBe(1);
+    const summary = summarize(merged);
+    expect(summary.lines).toEqual({ found: 2, hit: 2 });
+  });
+
+  it("keeps non-overlapping files separate and sums totals", () => {
+    const a = parseLcov(["SF:packages/a/src/x.ts", "DA:1,1", "end_of_record"].join("\n"));
+    const b = parseLcov(["SF:packages/b/src/y.ts", "DA:1,0", "end_of_record"].join("\n"));
+    const summary = summarize(mergeCoverageMaps([a, b]));
+    expect(summary.lines).toEqual({ found: 2, hit: 1 });
+  });
+
+  it("counts function and branch coverage across the union", () => {
+    const m = parseLcov(
+      [
+        "SF:packages/a/src/x.ts",
+        "FN:1,f",
+        "FNDA:0,f",
+        "FN:2,g",
+        "FNDA:2,g",
+        "BRDA:3,0,0,1",
+        "BRDA:3,0,1,0",
+        "DA:1,0",
+        "end_of_record",
+      ].join("\n"),
+    );
+    const summary = summarize(m);
+    expect(summary.functions).toEqual({ found: 2, hit: 1 });
+    expect(summary.branches).toEqual({ found: 2, hit: 1 });
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats to one decimal place", () => {
+    expect(formatPercent({ found: 1000, hit: 831 })).toBe("83.1%");
+    expect(formatPercent({ found: 3, hit: 3 })).toBe("100.0%");
+  });
+
+  it("returns n/a for an empty metric", () => {
+    expect(formatPercent({ found: 0, hit: 0 })).toBe("n/a");
+  });
+});
+
+describe("writeLcov", () => {
+  it("round-trips through parseLcov with recomputed counters", () => {
+    const original = parseLcov(
+      [
+        "SF:packages/web/src/App.tsx",
+        "FN:10,render",
+        "FNDA:3,render",
+        "BRDA:12,0,0,2",
+        "BRDA:12,0,1,-",
+        "DA:10,3",
+        "DA:11,0",
+        "end_of_record",
+      ].join("\n"),
+    );
+    const text = writeLcov(original);
+    expect(text).toContain("SF:packages/web/src/App.tsx");
+    expect(text).toContain("LF:2");
+    expect(text).toContain("LH:1");
+    expect(text).toContain("FNF:1");
+    expect(text).toContain("FNH:1");
+    expect(text).toContain("BRF:2");
+    expect(text).toContain("BRH:1");
+    // Re-parsing the serialized output yields identical coverage.
+    const reparsed = parseLcov(text);
+    expect(summarize(reparsed)).toEqual(summarize(original));
+  });
+
+  it("emits deterministic sorted output and empty string for empty input", () => {
+    expect(writeLcov(new Map())).toBe("");
+  });
+});

--- a/scripts/coverage-merge/src/merge.ts
+++ b/scripts/coverage-merge/src/merge.ts
@@ -1,0 +1,366 @@
+// Pure functions for unioning lcov coverage across multiple test suites
+// (Vitest unit, Storybook interaction, Playwright E2E) into one repo-wide
+// total. Kept free of any filesystem/CLI concerns so they are trivially
+// unit-testable; the I/O wrapper lives in `index.ts`.
+//
+// Why union (not concat): the same source file is exercised by several suites
+// (e.g. `packages/web/src/...` is hit by both unit tests and E2E). A line is
+// "covered" if ANY suite executed it, so per-line/-function/-branch hit counts
+// are summed and a line counts as hit when its total is > 0.
+
+/** Top-level repo directories that anchor a repo-relative source path. */
+const REPO_ANCHORS: readonly string[] = ["packages", "scripts", "tests", "apps", "rigs"];
+
+/** Per-file coverage extracted from (and re-emitted to) lcov. */
+export interface FileCoverage {
+  /** Repo-root-relative POSIX path, e.g. `packages/web/src/App.tsx`. */
+  path: string;
+  /** Function definition line keyed by function name (from `FN:`). */
+  functionLines: Map<string, number>;
+  /** Execution count keyed by function name (from `FNDA:`). */
+  functionHits: Map<string, number>;
+  /** Execution count keyed by line number (from `DA:`). */
+  lineHits: Map<number, number>;
+  /**
+   * Branch "taken" counts keyed by `line,block,branch` (from `BRDA:`). A value
+   * of `undefined` represents lcov's `-` (branch never reached), distinct from
+   * `0` (reached but this path not taken).
+   */
+  branchHits: Map<string, number | undefined>;
+}
+
+/** Aggregate hit/found totals for one coverage metric. */
+export interface MetricTotal {
+  /** Number of distinct items (lines, functions, or branches) found. */
+  found: number;
+  /** Number of those items hit at least once. */
+  hit: number;
+}
+
+/** Repo-wide coverage totals across lines, functions, and branches. */
+export interface CoverageSummary {
+  lines: MetricTotal;
+  functions: MetricTotal;
+  branches: MetricTotal;
+}
+
+/** Take the substring beginning at the last top-level repo anchor, else return unchanged. */
+function stripToAnchor(posix: string): string {
+  let anchorIndex: number = -1;
+  for (const anchor of REPO_ANCHORS) {
+    const needle: string = `/${anchor}/`;
+    const idx: number = posix.lastIndexOf(needle);
+    if (idx !== -1 && idx + 1 > anchorIndex) {
+      // +1 to skip the leading slash so the result starts with the anchor.
+      anchorIndex = idx + 1;
+    }
+    // Also handle a path that already starts with the anchor (no leading slash).
+    if (anchorIndex === -1 && posix.startsWith(`${anchor}/`)) {
+      anchorIndex = 0;
+    }
+  }
+  return anchorIndex >= 0 ? posix.slice(anchorIndex) : posix;
+}
+
+/** Return the parent directory of a POSIX path (empty string at the root). */
+function parentDir(posix: string): string {
+  const idx: number = posix.lastIndexOf("/");
+  return idx <= 0 ? "" : posix.slice(0, idx);
+}
+
+/**
+ * Normalize an lcov `SF:` path to a repo-root-relative POSIX path so the same
+ * source file produces an identical key regardless of which suite emitted it.
+ *
+ * Two source conventions are reconciled:
+ *  - **Absolute or already-repo-relative** paths (Playwright E2E via monocart
+ *    emits `packages/web/src/...`; some reporters emit absolute CI paths) are
+ *    reduced to the substring at the last repo anchor (`packages/`, ...).
+ *  - **Package-relative** paths (Vitest's v8 lcov writes `src/foo.ts` relative
+ *    to the package dir) are resolved against the package root inferred from the
+ *    lcov file's location (`<pkg>/coverage/lcov.info` → `<pkg>`), then anchored.
+ *
+ * @param sfPath - The raw path from an lcov `SF:` line.
+ * @param lcovFilePath - Path of the lcov file the `SF:` came from, used to
+ *   resolve package-relative paths. Optional (best-effort when omitted).
+ * @returns The repo-relative POSIX path.
+ */
+export function normalizeSourcePath(sfPath: string, lcovFilePath?: string): string {
+  const posix: string = sfPath.replace(/\\/g, "/").trim();
+  const anchored: string = stripToAnchor(posix);
+  // An anchor was found (repo-relative or absolute-with-anchor), or the path is
+  // absolute — use the anchored form directly.
+  if (anchored !== posix || posix.startsWith("/") || /^[a-zA-Z]:\//.test(posix)) {
+    return anchored;
+  }
+  // Package-relative (e.g. Vitest's `src/foo.ts`): resolve against the package
+  // root derived from `<pkg>/coverage/lcov.info`.
+  if (lcovFilePath) {
+    const lcovPosix: string = lcovFilePath.replace(/\\/g, "/");
+    const pkgRoot: string = parentDir(parentDir(lcovPosix));
+    if (pkgRoot.length > 0) {
+      return stripToAnchor(`${pkgRoot}/${posix}`);
+    }
+  }
+  return anchored;
+}
+
+/**
+ * Parse lcov text into per-file coverage keyed by normalized source path.
+ * Records for the same path appearing more than once (within or across files)
+ * are merged via {@link unionFileCoverage}.
+ *
+ * @param lcov - The contents of an `lcov.info` file.
+ * @param lcovFilePath - Path of the file (used to resolve package-relative
+ *   `SF:` paths like Vitest's `src/foo.ts`). Optional.
+ * @returns A map of normalized source path to its parsed coverage.
+ */
+export function parseLcov(lcov: string, lcovFilePath?: string): Map<string, FileCoverage> {
+  const files: Map<string, FileCoverage> = new Map();
+  let current: FileCoverage | undefined;
+
+  for (const rawLine of lcov.split(/\r?\n/)) {
+    const line: string = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    const colon: number = line.indexOf(":");
+    const tag: string = colon === -1 ? line : line.slice(0, colon);
+    const value: string = colon === -1 ? "" : line.slice(colon + 1);
+
+    switch (tag) {
+      case "SF": {
+        current = {
+          path: normalizeSourcePath(value, lcovFilePath),
+          functionLines: new Map(),
+          functionHits: new Map(),
+          lineHits: new Map(),
+          branchHits: new Map(),
+        };
+        break;
+      }
+      case "FN": {
+        // FN:<line>,<name> (name may itself contain commas, so split once).
+        if (current) {
+          const comma: number = value.indexOf(",");
+          if (comma !== -1) {
+            const defLine: number = Number.parseInt(value.slice(0, comma), 10);
+            const name: string = value.slice(comma + 1);
+            if (!Number.isNaN(defLine)) {
+              current.functionLines.set(name, defLine);
+            }
+          }
+        }
+        break;
+      }
+      case "FNDA": {
+        // FNDA:<hits>,<name>
+        if (current) {
+          const comma: number = value.indexOf(",");
+          if (comma !== -1) {
+            const hits: number = Number.parseInt(value.slice(0, comma), 10);
+            const name: string = value.slice(comma + 1);
+            const prev: number = current.functionHits.get(name) ?? 0;
+            current.functionHits.set(name, prev + (Number.isNaN(hits) ? 0 : hits));
+          }
+        }
+        break;
+      }
+      case "DA": {
+        // DA:<line>,<hits>[,<checksum>]
+        if (current) {
+          const parts: string[] = value.split(",");
+          const lineNo: number = Number.parseInt(parts[0], 10);
+          const hits: number = Number.parseInt(parts[1], 10);
+          if (!Number.isNaN(lineNo)) {
+            const prev: number = current.lineHits.get(lineNo) ?? 0;
+            current.lineHits.set(lineNo, prev + (Number.isNaN(hits) ? 0 : hits));
+          }
+        }
+        break;
+      }
+      case "BRDA": {
+        // BRDA:<line>,<block>,<branch>,<taken> where taken is a number or "-".
+        if (current) {
+          const parts: string[] = value.split(",");
+          if (parts.length >= 4) {
+            const key: string = `${parts[0]},${parts[1]},${parts[2]}`;
+            const takenRaw: string = parts[3];
+            const taken: number | undefined =
+              takenRaw === "-" ? undefined : Number.parseInt(takenRaw, 10);
+            const prev: number | undefined = current.branchHits.get(key);
+            current.branchHits.set(key, addBranchTaken(prev, taken));
+          }
+        }
+        break;
+      }
+      case "end_of_record": {
+        if (current) {
+          const existing: FileCoverage | undefined = files.get(current.path);
+          files.set(current.path, existing ? unionFileCoverage(existing, current) : current);
+          current = undefined;
+        }
+        break;
+      }
+      default: {
+        // LF/LH/FNF/FNH/BRF/BRH/TN are recomputed on write — ignore on read.
+        break;
+      }
+    }
+  }
+
+  return files;
+}
+
+/** Sum two lcov branch "taken" values, preserving `-` (undefined) only when both are unreached. */
+function addBranchTaken(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined && b === undefined) {
+    return undefined;
+  }
+  return (a ?? 0) + (b ?? 0);
+}
+
+/** Union two coverage records for the same source file (sum all hit counts). */
+export function unionFileCoverage(a: FileCoverage, b: FileCoverage): FileCoverage {
+  const merged: FileCoverage = {
+    path: a.path,
+    functionLines: new Map(a.functionLines),
+    functionHits: new Map(a.functionHits),
+    lineHits: new Map(a.lineHits),
+    branchHits: new Map(a.branchHits),
+  };
+  for (const [name, defLine] of b.functionLines) {
+    merged.functionLines.set(name, defLine);
+  }
+  for (const [name, hits] of b.functionHits) {
+    merged.functionHits.set(name, (merged.functionHits.get(name) ?? 0) + hits);
+  }
+  for (const [lineNo, hits] of b.lineHits) {
+    merged.lineHits.set(lineNo, (merged.lineHits.get(lineNo) ?? 0) + hits);
+  }
+  for (const [key, taken] of b.branchHits) {
+    merged.branchHits.set(key, addBranchTaken(merged.branchHits.get(key), taken));
+  }
+  return merged;
+}
+
+/** Union many parsed lcov maps into one, merging records that share a path. */
+export function mergeCoverageMaps(
+  maps: ReadonlyArray<Map<string, FileCoverage>>,
+): Map<string, FileCoverage> {
+  const result: Map<string, FileCoverage> = new Map();
+  for (const map of maps) {
+    for (const [path, cov] of map) {
+      const existing: FileCoverage | undefined = result.get(path);
+      result.set(path, existing ? unionFileCoverage(existing, cov) : cov);
+    }
+  }
+  return result;
+}
+
+/** Compute repo-wide line/function/branch totals from merged coverage. */
+export function summarize(files: Map<string, FileCoverage>): CoverageSummary {
+  const summary: CoverageSummary = {
+    lines: { found: 0, hit: 0 },
+    functions: { found: 0, hit: 0 },
+    branches: { found: 0, hit: 0 },
+  };
+  for (const cov of files.values()) {
+    for (const hits of cov.lineHits.values()) {
+      summary.lines.found += 1;
+      if (hits > 0) {
+        summary.lines.hit += 1;
+      }
+    }
+    for (const hits of cov.functionHits.values()) {
+      summary.functions.found += 1;
+      if (hits > 0) {
+        summary.functions.hit += 1;
+      }
+    }
+    for (const taken of cov.branchHits.values()) {
+      summary.branches.found += 1;
+      if (taken !== undefined && taken > 0) {
+        summary.branches.hit += 1;
+      }
+    }
+  }
+  return summary;
+}
+
+/** Format a {@link MetricTotal} as a percentage string with one decimal (e.g. `83.1%`). */
+export function formatPercent(metric: MetricTotal): string {
+  const PERCENT_DECIMALS: number = 1;
+  if (metric.found === 0) {
+    return "n/a";
+  }
+  return `${((metric.hit / metric.found) * 100).toFixed(PERCENT_DECIMALS)}%`;
+}
+
+/**
+ * Serialize merged coverage back to lcov text. Files are emitted in sorted path
+ * order for deterministic output; the recomputed `LF/LH/FNF/FNH/BRF/BRH`
+ * counters reflect the unioned totals.
+ */
+export function writeLcov(files: Map<string, FileCoverage>): string {
+  const out: string[] = [];
+  const sortedPaths: string[] = [...files.keys()].sort();
+  for (const path of sortedPaths) {
+    const cov: FileCoverage = files.get(path)!;
+    out.push("TN:");
+    out.push(`SF:${path}`);
+
+    const fnNames: string[] = [...cov.functionLines.keys()].sort();
+    for (const name of fnNames) {
+      out.push(`FN:${cov.functionLines.get(name)!},${name}`);
+    }
+    let fnHit: number = 0;
+    for (const name of fnNames) {
+      const hits: number = cov.functionHits.get(name) ?? 0;
+      out.push(`FNDA:${hits},${name}`);
+      if (hits > 0) {
+        fnHit += 1;
+      }
+    }
+    out.push(`FNF:${fnNames.length}`);
+    out.push(`FNH:${fnHit}`);
+
+    const branchKeys: string[] = [...cov.branchHits.keys()].sort(compareBranchKeys);
+    let brHit: number = 0;
+    for (const key of branchKeys) {
+      const taken: number | undefined = cov.branchHits.get(key);
+      out.push(`BRDA:${key},${taken === undefined ? "-" : taken}`);
+      if (taken !== undefined && taken > 0) {
+        brHit += 1;
+      }
+    }
+    out.push(`BRF:${branchKeys.length}`);
+    out.push(`BRH:${brHit}`);
+
+    const lineNumbers: number[] = [...cov.lineHits.keys()].sort((x, y) => x - y);
+    let lineHit: number = 0;
+    for (const lineNo of lineNumbers) {
+      const hits: number = cov.lineHits.get(lineNo) ?? 0;
+      out.push(`DA:${lineNo},${hits}`);
+      if (hits > 0) {
+        lineHit += 1;
+      }
+    }
+    out.push(`LF:${lineNumbers.length}`);
+    out.push(`LH:${lineHit}`);
+    out.push("end_of_record");
+  }
+  return out.join("\n") + (out.length > 0 ? "\n" : "");
+}
+
+/** Sort `line,block,branch` branch keys numerically by each component. */
+function compareBranchKeys(a: string, b: string): number {
+  const pa: number[] = a.split(",").map((n) => Number.parseInt(n, 10));
+  const pb: number[] = b.split(",").map((n) => Number.parseInt(n, 10));
+  for (let i = 0; i < pa.length; i++) {
+    if (pa[i] !== pb[i]) {
+      return pa[i] - pb[i];
+    }
+  }
+  return 0;
+}

--- a/scripts/coverage-merge/src/run.test.ts
+++ b/scripts/coverage-merge/src/run.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import {
+  findLcovFiles,
+  mergeLcovFiles,
+  hasSourceMatching,
+  renderTextTable,
+  renderMarkdown,
+} from "./run.js";
+
+// Vitest writes PACKAGE-RELATIVE SF paths (resolved via the lcov's location,
+// here <dir>/packages/web/coverage/lcov.info → packages/web/src/App.tsx).
+const UNIT_LCOV: string = [
+  "SF:src/App.tsx",
+  "FN:10,render",
+  "FNDA:1,render",
+  "DA:10,1",
+  "DA:11,0",
+  "end_of_record",
+  "",
+].join("\n");
+
+// monocart (E2E) writes REPO-RELATIVE SF paths. Same file, different line hit —
+// normalization must collapse both conventions onto one key so they union.
+const E2E_LCOV: string = [
+  "SF:packages/web/src/App.tsx",
+  "DA:10,0",
+  "DA:11,3",
+  "end_of_record",
+  "",
+].join("\n");
+
+describe("run helpers (with real filesystem)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "covmerge-"));
+    mkdirSync(join(dir, "packages", "web", "coverage"), { recursive: true });
+    mkdirSync(join(dir, "tests", "e2e-tests", "coverage"), { recursive: true });
+    mkdirSync(join(dir, "node_modules", "pkg", "coverage"), { recursive: true });
+    writeFileSync(join(dir, "packages", "web", "coverage", "lcov.info"), UNIT_LCOV);
+    writeFileSync(join(dir, "tests", "e2e-tests", "coverage", "lcov.info"), E2E_LCOV);
+    // Decoy under node_modules must be skipped.
+    writeFileSync(join(dir, "node_modules", "pkg", "coverage", "lcov.info"), UNIT_LCOV);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("finds lcov files but skips node_modules and the output file", () => {
+    const outAbs: string = join(dir, "packages", "web", "coverage", "lcov.info");
+    const files: string[] = findLcovFiles(dir, outAbs);
+    // node_modules decoy skipped; the excluded output file skipped; only e2e remains.
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain(join("tests", "e2e-tests"));
+  });
+
+  it("finds all non-node_modules lcov files when nothing is excluded", () => {
+    const files: string[] = findLcovFiles(dir);
+    expect(files).toHaveLength(2);
+  });
+
+  it("unions unit + e2e coverage of the same web file (line hit by either counts)", () => {
+    const files: string[] = findLcovFiles(dir);
+    const result = mergeLcovFiles(files);
+    expect(result.fileCount).toBe(2);
+    // One merged source file (App.tsx), both lines now covered.
+    expect(result.merged.size).toBe(1);
+    expect(result.summary.lines).toEqual({ found: 2, hit: 2 });
+    expect(result.summary.functions).toEqual({ found: 1, hit: 1 });
+  });
+
+  it("hasSourceMatching detects web source presence", () => {
+    const result = mergeLcovFiles(findLcovFiles(dir));
+    expect(hasSourceMatching(result.merged, "packages/web/src")).toBe(true);
+    expect(hasSourceMatching(result.merged, "packages/server/src")).toBe(false);
+  });
+
+  it("renders text and markdown summaries", () => {
+    const result = mergeLcovFiles(findLcovFiles(dir));
+    const text: string = renderTextTable(result, result.merged.size);
+    expect(text).toContain("Lines:");
+    expect(text).toContain("100.0%");
+    const md: string = renderMarkdown(result, result.merged.size);
+    expect(md).toContain("| Lines | 100.0% | 2 / 2 |");
+    expect(md).toContain("Combined coverage");
+  });
+
+  it("returns empty for a directory with no lcov files", () => {
+    const empty: string = mkdtempSync(join(tmpdir(), "covmerge-empty-"));
+    try {
+      expect(findLcovFiles(empty)).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/coverage-merge/src/run.ts
+++ b/scripts/coverage-merge/src/run.ts
@@ -1,0 +1,123 @@
+// Filesystem + rendering helpers for the coverage-merge CLI, split out from
+// `index.ts` so they are unit-testable without spawning a child process
+// (index.ts itself is a thin argv/exit shell that calls these).
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  parseLcov,
+  mergeCoverageMaps,
+  summarize,
+  formatPercent,
+  type FileCoverage,
+  type CoverageSummary,
+} from "./merge.js";
+
+/** Directory names never descended into while scanning for lcov files. */
+const SKIP_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+  ".rush",
+  "dist",
+  "lib",
+  "temp",
+]);
+
+/** The lcov filename produced by every suite's coverage reporter. */
+export const LCOV_FILENAME: string = "lcov.info";
+
+/** Result of merging a set of lcov files. */
+export interface MergeResult {
+  /** Unioned per-file coverage keyed by repo-relative source path. */
+  merged: Map<string, FileCoverage>;
+  /** Repo-wide line/function/branch totals. */
+  summary: CoverageSummary;
+  /** Number of lcov files merged. */
+  fileCount: number;
+}
+
+/**
+ * Recursively collect absolute paths of every `lcov.info` under `root`,
+ * skipping {@link SKIP_DIRS} and the merge output file itself.
+ *
+ * @param root - Directory to scan.
+ * @param excludeAbs - Absolute path to skip (the combined output), or undefined.
+ * @returns Absolute paths of discovered lcov files.
+ */
+export function findLcovFiles(root: string, excludeAbs?: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full: string = join(dir, entry);
+      let isDir: boolean;
+      try {
+        isDir = statSync(full).isDirectory();
+      } catch {
+        continue;
+      }
+      if (isDir) {
+        if (!SKIP_DIRS.has(entry)) {
+          walk(full);
+        }
+      } else if (entry === LCOV_FILENAME && resolve(full) !== excludeAbs) {
+        found.push(full);
+      }
+    }
+  };
+  walk(root);
+  return found;
+}
+
+/** Parse and union a set of lcov files into one merged coverage map + summary. */
+export function mergeLcovFiles(files: readonly string[]): MergeResult {
+  const maps: Array<Map<string, FileCoverage>> = files.map((file) =>
+    parseLcov(readFileSync(file, "utf8"), file),
+  );
+  const merged: Map<string, FileCoverage> = mergeCoverageMaps(maps);
+  return { merged, summary: summarize(merged), fileCount: files.length };
+}
+
+/** True if any merged source path contains `substring` (CI "did coverage land" guard). */
+export function hasSourceMatching(merged: Map<string, FileCoverage>, substring: string): boolean {
+  for (const path of merged.keys()) {
+    if (path.includes(substring)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Render the summary as an aligned plain-text block for stdout/logs. */
+export function renderTextTable(result: MergeResult, sourceCount: number): string {
+  const { summary, fileCount } = result;
+  return [
+    `Combined coverage across ${fileCount} lcov file(s), ${sourceCount} source file(s):`,
+    `  Lines:     ${formatPercent(summary.lines)}  (${summary.lines.hit}/${summary.lines.found})`,
+    `  Functions: ${formatPercent(summary.functions)}  (${summary.functions.hit}/${summary.functions.found})`,
+    `  Branches:  ${formatPercent(summary.branches)}  (${summary.branches.hit}/${summary.branches.found})`,
+  ].join("\n");
+}
+
+/** Render the summary as a GitHub-flavored Markdown table for the job summary. */
+export function renderMarkdown(result: MergeResult, sourceCount: number): string {
+  const { summary, fileCount } = result;
+  return [
+    "## Combined coverage (unit + Storybook + E2E)",
+    "",
+    `Merged ${fileCount} lcov file(s) covering ${sourceCount} source file(s).`,
+    "",
+    "| Metric | Coverage | Hit / Found |",
+    "| --- | --- | --- |",
+    `| Lines | ${formatPercent(summary.lines)} | ${summary.lines.hit} / ${summary.lines.found} |`,
+    `| Functions | ${formatPercent(summary.functions)} | ${summary.functions.hit} / ${summary.functions.found} |`,
+    `| Branches | ${formatPercent(summary.branches)} | ${summary.branches.hit} / ${summary.branches.found} |`,
+    "",
+  ].join("\n");
+}

--- a/scripts/coverage-merge/tsconfig.json
+++ b/scripts/coverage-merge/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/@grackle-ai/heft-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/scripts/coverage-merge/vitest.config.ts
+++ b/scripts/coverage-merge/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createVitestConfig } from "@grackle-ai/heft-rig/vitest-base.mjs";
+
+export default createVitestConfig();

--- a/tests/e2e-tests/coverage-global-setup.ts
+++ b/tests/e2e-tests/coverage-global-setup.ts
@@ -1,0 +1,14 @@
+// Playwright globalSetup: clear any stale monocart coverage cache before a run
+// so repeated local runs don't accumulate data. No-op unless E2E_COVERAGE=true.
+
+import { CoverageReport } from "monocart-coverage-reports";
+
+import { coverageOptions } from "./coverage-options.js";
+import { COVERAGE_ENABLED } from "./coverage-helpers.js";
+
+export default function globalSetup(): void {
+  if (!COVERAGE_ENABLED) {
+    return;
+  }
+  new CoverageReport(coverageOptions).cleanCache();
+}

--- a/tests/e2e-tests/coverage-global-teardown.ts
+++ b/tests/e2e-tests/coverage-global-teardown.ts
@@ -1,0 +1,15 @@
+// Playwright globalTeardown: aggregate every worker's cached V8 coverage into
+// `coverage/lcov.info` (source-mapped back to packages/web/src). Runs once per
+// shard after all that shard's specs complete. No-op unless E2E_COVERAGE=true.
+
+import { CoverageReport } from "monocart-coverage-reports";
+
+import { coverageOptions } from "./coverage-options.js";
+import { COVERAGE_ENABLED } from "./coverage-helpers.js";
+
+export default async function globalTeardown(): Promise<void> {
+  if (!COVERAGE_ENABLED) {
+    return;
+  }
+  await new CoverageReport(coverageOptions).generate();
+}

--- a/tests/e2e-tests/coverage-helpers.ts
+++ b/tests/e2e-tests/coverage-helpers.ts
@@ -1,0 +1,36 @@
+// Per-test V8 coverage collection helpers, used by the `page` fixture.
+//
+// Collection is opt-in via `E2E_COVERAGE=true` so local TDD runs stay fast and
+// the Chromium-only `page.coverage` API is never touched when disabled. Any
+// failure here is logged and swallowed — coverage must never fail a test.
+
+import { CoverageReport } from "monocart-coverage-reports";
+import type { Page } from "@playwright/test";
+
+import { coverageOptions } from "./coverage-options.js";
+
+/** Whether E2E coverage collection is enabled for this run. */
+export const COVERAGE_ENABLED: boolean = process.env.E2E_COVERAGE === "true";
+
+/** Begin V8 JS coverage on a fresh page (before it navigates). No-op when disabled. */
+export async function startCoverage(page: Page): Promise<void> {
+  if (!COVERAGE_ENABLED) {
+    return;
+  }
+  // `resetOnNavigation: false` keeps coverage across the `appPage` goto("/").
+  await page.coverage.startJSCoverage({ resetOnNavigation: false });
+}
+
+/** Stop coverage and append it to the shared monocart cache. No-op when disabled. */
+export async function collectCoverage(page: Page): Promise<void> {
+  if (!COVERAGE_ENABLED) {
+    return;
+  }
+  try {
+    const coverage = await page.coverage.stopJSCoverage();
+    const report: CoverageReport = new CoverageReport(coverageOptions);
+    await report.add(coverage);
+  } catch (err: unknown) {
+    process.stderr.write(`[e2e-coverage] failed to collect coverage: ${String(err)}\n`);
+  }
+}

--- a/tests/e2e-tests/coverage-options.ts
+++ b/tests/e2e-tests/coverage-options.ts
@@ -1,0 +1,105 @@
+// Shared monocart-coverage-reports options for the E2E V8 coverage pass.
+//
+// The same options object MUST be used by every process that participates in a
+// run (the per-test `add()` in worker processes and the `generate()` in global
+// teardown) so they share the `<outputDir>/.cache` directory. See monocart's
+// "Multiprocessing Support".
+//
+// Coverage is collected only when `E2E_COVERAGE=true`; see `coverage-helpers.ts`.
+
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { CoverageReportOptions } from "monocart-coverage-reports";
+
+/** Absolute path to the built web bundle that the E2E stack serves. */
+const WEB_DIST_DIR: string = fileURLToPath(new URL("../../packages/web/dist/", import.meta.url));
+
+/**
+ * Resolve a source map from the local `packages/web/dist` on disk rather than
+ * fetching it over HTTP. `generate()` runs in global teardown AFTER every
+ * per-worker Grackle server has been torn down, so the served `*.js.map` URLs
+ * are no longer reachable — but the dist files remain on disk. Without this,
+ * V8 coverage would stay at the minified-bundle level and never map back to
+ * `packages/web/src/**`.
+ */
+async function resolveSourceMapFromDist(
+  url: string,
+  defaultResolver: (u: string) => Promise<unknown>,
+): Promise<unknown> {
+  // `url` may be an absolute http(s) URL (served map) or a relative path; try
+  // both the full pathname under dist and the basename under dist/assets.
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    pathname = url;
+  }
+  pathname = decodeURIComponent(pathname).replace(/^\/+/, "");
+  const candidates: string[] = [
+    join(WEB_DIST_DIR, pathname),
+    join(WEB_DIST_DIR, "assets", basename(pathname)),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(await readFile(candidate, "utf8"));
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return defaultResolver(url);
+}
+
+/**
+ * Keep only first-party web UI source unpacked from the bundle's source maps.
+ * Vite emits sources relative to each package root, so the web app shows up as
+ * `src/...` and the web-components package as `web-components/src/...`; bundled
+ * dependencies show up under `node_modules/`, `common/`, `ahp/`, etc. Drop
+ * everything but the two first-party `src` trees (and test/story/generated files
+ * to mirror the Vitest `exclude` set).
+ */
+function isFirstPartyWebSource(sourcePath: string): boolean {
+  const p: string = sourcePath.replace(/\\/g, "/");
+  // Accept both the raw Vite form (`src/...`, `web-components/src/...`) and the
+  // repo-relative form (`packages/web/src/...`) in case `sourcePath` rewriting
+  // runs before this filter.
+  const isWebApp: boolean = p.startsWith("src/") || p.includes("packages/web/src/");
+  const isWebComponents: boolean =
+    p.startsWith("web-components/src/") || p.includes("packages/web-components/src/");
+  if (!isWebApp && !isWebComponents) {
+    return false;
+  }
+  if (p.includes("/node_modules/") || p.includes("/gen/")) {
+    return false;
+  }
+  return !/\.(test|stories)\.[cm]?[jt]sx?$/.test(p);
+}
+
+/**
+ * Rewrite a first-party source path to a repo-root-relative key so the E2E lcov
+ * unions cleanly with the per-package Vitest lcov in `@grackle-ai/coverage-merge`
+ * (`src/App.tsx` → `packages/web/src/App.tsx`).
+ */
+function toRepoRelativePath(filePath: string): string {
+  const p: string = filePath.replace(/\\/g, "/");
+  if (p.startsWith("src/")) {
+    return `packages/web/${p}`;
+  }
+  if (p.startsWith("web-components/src/")) {
+    return `packages/${p}`;
+  }
+  return p;
+}
+
+/** Coverage report options shared across all processes of one E2E run. */
+export const coverageOptions: CoverageReportOptions = {
+  name: "Grackle E2E Coverage",
+  outputDir: fileURLToPath(new URL("./coverage/", import.meta.url)),
+  // `lcovonly` emits `coverage/lcov.info`, which the merge step consumes.
+  reports: ["lcovonly", "console-summary"],
+  logging: "info",
+  sourceFilter: isFirstPartyWebSource,
+  sourcePath: toRepoRelativePath,
+  sourceMapResolver: resolveSourceMapFromDist,
+};

--- a/tests/e2e-tests/coverage-options.ts
+++ b/tests/e2e-tests/coverage-options.ts
@@ -16,6 +16,9 @@ import type { CoverageReportOptions } from "monocart-coverage-reports";
 /** Absolute path to the built web bundle that the E2E stack serves. */
 const WEB_DIST_DIR: string = fileURLToPath(new URL("../../packages/web/dist/", import.meta.url));
 
+/** monocart's source-map resolver signature, derived to match exactly. */
+type SourceMapResolver = NonNullable<CoverageReportOptions["sourceMapResolver"]>;
+
 /**
  * Resolve a source map from the local `packages/web/dist` on disk rather than
  * fetching it over HTTP. `generate()` runs in global teardown AFTER every
@@ -24,10 +27,7 @@ const WEB_DIST_DIR: string = fileURLToPath(new URL("../../packages/web/dist/", i
  * V8 coverage would stay at the minified-bundle level and never map back to
  * `packages/web/src/**`.
  */
-async function resolveSourceMapFromDist(
-  url: string,
-  defaultResolver: (u: string) => Promise<unknown>,
-): Promise<unknown> {
+const resolveSourceMapFromDist: SourceMapResolver = async (url, defaultResolver) => {
   // `url` may be an absolute http(s) URL (served map) or a relative path; try
   // both the full pathname under dist and the basename under dist/assets.
   let pathname: string;
@@ -49,7 +49,7 @@ async function resolveSourceMapFromDist(
     }
   }
   return defaultResolver(url);
-}
+};
 
 /**
  * Keep only first-party web UI source unpacked from the bundle's source maps.

--- a/tests/e2e-tests/package.json
+++ b/tests/e2e-tests/package.json
@@ -20,6 +20,7 @@
     "@grackle-ai/common": "workspace:*",
     "@grackle-ai/server": "workspace:*",
     "@grackle-ai/web": "workspace:*",
-    "@playwright/test": "^1.49.0"
+    "@playwright/test": "^1.49.0",
+    "monocart-coverage-reports": "~2.12.12"
   }
 }

--- a/tests/e2e-tests/playwright.config.ts
+++ b/tests/e2e-tests/playwright.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   fullyParallel: true,
+  // Coverage hooks are no-ops unless E2E_COVERAGE=true (see coverage-helpers.ts).
+  // globalSetup clears stale monocart cache; globalTeardown aggregates each
+  // worker's V8 coverage into coverage/lcov.info, source-mapped to web src.
+  globalSetup: "./coverage-global-setup.ts",
+  globalTeardown: "./coverage-global-teardown.ts",
   reporter: [["list"], ["junit", { outputFile: "test-results/e2e-results.xml" }]],
   projects: [
     {

--- a/tests/e2e-tests/tests/fixtures.ts
+++ b/tests/e2e-tests/tests/fixtures.ts
@@ -11,6 +11,7 @@ import {
   patchWsForStubRuntime,
   getWorkspaceId,
 } from "./helpers.js";
+import { startCoverage, collectCoverage } from "../coverage-helpers.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScenarioStep = Record<string, any>;
@@ -105,7 +106,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     await use(`http://127.0.0.1:${workerServer.webPort}`);
   },
 
-  // Inject the session cookie into every page context automatically
+  // Inject the session cookie into every page context automatically, and
+  // (when E2E_COVERAGE=true) collect V8 coverage for the whole test. Coverage
+  // starts here, before `appPage` navigates, so the initial app load is
+  // captured; it is appended to the shared monocart cache on teardown.
   page: async ({ page, baseURL, workerServer }, use) => {
     const eqIdx = workerServer.pairingCookie.indexOf("=");
     const cookieName = workerServer.pairingCookie.slice(0, eqIdx);
@@ -117,7 +121,12 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         url: baseURL!,
       },
     ]);
-    await use(page);
+    await startCoverage(page);
+    try {
+      await use(page);
+    } finally {
+      await collectCoverage(page);
+    }
   },
 
   grackle: async ({ baseURL, workerServer }, use) => {

--- a/tests/e2e-tests/tsconfig.json
+++ b/tests/e2e-tests/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["tests/**/*.ts", "playwright.config.ts"]
+  "include": ["tests/**/*.ts", "playwright.config.ts", "coverage-*.ts"]
 }


### PR DESCRIPTION
## Summary

Extends the coverage rollout (#1326) beyond Vitest unit tests to **Playwright E2E**, and produces the first **real repo-wide merged total** by unioning per-suite lcov (a line counts as covered if *any* suite hit it).

- **Source maps** — `packages/web/vite.config.ts` now emits external source maps so E2E V8 coverage maps back to `packages/web(-components)/src`. External (not inline) so they don't count toward the Vite chunk-size CI gate; the repo is public OSS.
- **E2E collection** — opt-in via `E2E_COVERAGE=true`. The shared `page` fixture collects V8 coverage per test; a Playwright `globalTeardown` runs monocart-coverage-reports to write `tests/e2e-tests/coverage/lcov.info`. A disk-based `sourceMapResolver` reads `.map` files from `packages/web/dist` (the per-worker servers are gone by teardown, so HTTP fetch isn't an option).
- **Merge** — new `scripts/coverage-merge` (`@grackle-ai/coverage-merge`) unions every `*/coverage/lcov.info` into one combined lcov + total, normalizing `SF:` paths so Vitest's package-relative (`src/foo.ts`) and monocart's repo-relative (`packages/web/src/foo.ts`) keys collapse to one.
- **CI** — each E2E shard uploads an `e2e-coverage-*` artifact; a new `coverage` job merges unit + E2E, prints the real total to the job summary, uploads `combined-coverage`, and fails loudly via `--require-source packages/web/src` if E2E coverage didn't land.

Storybook coverage is the sibling follow-up (#1384), which plugs into the same merge layer with no rework.

> Note: the original #1327 plan assumed Codecov per-flag flags + a sticky comment. This repo never adopted Codecov — we compute a true merged total locally instead. The original also claimed Vite already emitted prod source maps; it did not (fixed here).

## Test plan

- [x] `@grackle-ai/coverage-merge` unit tests pass (26 tests, incl. the two path-normalization conventions).
- [x] Local E2E smoke: one spec with `E2E_COVERAGE=true` produces lcov mapped to `packages/web/src` (proves disk-based sourcemap resolution at teardown).
- [x] Full local chromium E2E suite: **230 passed** with coverage on — no regression; multi-worker cache aggregation works.
- [x] Local merge: unions 189 source files; `--require-source packages/web/src` exits 0.
- [x] `rush build` clean (no chunk-size / warnings-as-errors).
- [ ] CI `coverage` job prints the combined total to the job summary and uploads `combined-coverage`.

Closes #1383