### PR TITLE
Reconcile stranded RUNNING subagent children (#1386)

### DIFF
--- a/common/api/plugin-core.public.api.md
+++ b/common/api/plugin-core.public.api.md
@@ -65,6 +65,9 @@ export function createRootTaskBootSubscriber(ctx: PluginContext, deps: RootTaskB
 export function createSigchldSubscriber(ctx: PluginContext): Disposable_2;
 
 // @public
+export function createSubagentReconciliationPhase(deps: SubagentReconciliationDeps): ReconciliationPhase;
+
+// @public
 export interface DispatchPhaseDeps {
     dequeueEntry: (taskId: string) => void;
     environmentExists: (environmentId: string) => boolean;
@@ -158,6 +161,13 @@ export function setChannelConfig(next: ChannelConfig): void;
 
 // @public
 export function setLoadedPluginNames(names: Set<string>): void;
+
+// @public
+export interface SubagentReconciliationDeps {
+    getSession: (id: string) => SessionRow | undefined;
+    interruptChildSession: (childSessionId: string) => void;
+    listRunningSubagentChildren: () => SessionRow[];
+}
 
 export { toDialableHost }
 

--- a/common/changes/@grackle-ai/cli/nick-pape-1386-reconcile-subagent-children_2026-05-30-00-00.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1386-reconcile-subagent-children_2026-05-30-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a subagent-reconciliation phase that interrupts stranded RUNNING subagent child sessions (#1075) once their parent session reaches a terminal state, so a background/polled child whose parent stream ended is never left RUNNING forever (#1386).",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -545,10 +545,10 @@ export function processEventStream(
       // NOT be interrupted here even if their handle/result never arrived (e.g.
       // the stream ended right after the spawn tool_use).
       //
-      // Known limitation (#1386): a background/polled child whose parent stream
-      // ends before a terminal poll stays RUNNING in the DB. It is excluded from
-      // all env/task/concurrency queries so it is harmless, but never reaches a
-      // terminal state — a reconciliation sweep is tracked as a follow-up.
+      // A background/polled child whose parent stream ends before a terminal poll
+      // would otherwise stay RUNNING here. That case is reaped out-of-band by the
+      // `subagent-reconciliation` phase (#1386), which interrupts any RUNNING
+      // subagent child once its parent session reaches a terminal state.
       for (const link of delegationByToolCall.values()) {
         if (!link.isBackground && !link.isPoll) {
           interruptChildSession(link.childId);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,9 @@ export * as pipeDelivery from "./pipe-delivery.js";
 // ─── Individual Exports for Plugin-Core ──────────────────────
 export { processEventStream, publishWidgetEvent } from "./event-processor.js";
 export type { WidgetEventPayload, PublishWidgetEvent } from "./event-processor.js";
+// #1386: the subagent-reconciliation phase (plugin-core) uses this to reap
+// stranded RUNNING subagent children whose parent session has gone terminal.
+export { interruptChildSession } from "./subagent-session.js";
 export { createEventStream } from "./event-hub.js";
 export { RESERVED_PREFIXES, isReservedStreamName, LIFECYCLE_PREFIX } from "./stream-names.js";
 export { subscribeStreamMessages } from "./stream-message-bus.js";

--- a/packages/database/src/session-store.test.ts
+++ b/packages/database/src/session-store.test.ts
@@ -330,4 +330,48 @@ describe("session-store", () => {
       expect(sessionStore.countActiveGlobal()).toBe(2);
     });
   });
+
+  describe("listRunningSubagentChildren", () => {
+    it("returns an empty array when no sessions exist", () => {
+      expect(sessionStore.listRunningSubagentChildren()).toEqual([]);
+    });
+
+    it("returns only RUNNING subagent children, excluding terminal ones and non-subagent runtimes", () => {
+      // A running subagent child — should match.
+      sessionStore.createSession(
+        "sub-running",
+        "test-env",
+        "subagent",
+        "p",
+        "m",
+        "/tmp/sub",
+        "",
+        "",
+        "parent-1",
+      );
+      sessionStore.updateSessionStatus("sub-running", "running");
+
+      // A terminal subagent child — should NOT match.
+      sessionStore.createSession(
+        "sub-stopped",
+        "test-env",
+        "subagent",
+        "p",
+        "m",
+        "/tmp/sub2",
+        "",
+        "",
+        "parent-1",
+      );
+      sessionStore.updateSession("sub-stopped", "stopped", undefined, undefined, "completed");
+
+      // A RUNNING non-subagent session — should NOT match.
+      sessionStore.createSession("real-running", "test-env", "claude-code", "p", "m", "/tmp/real");
+      sessionStore.updateSessionStatus("real-running", "running");
+
+      const rows = sessionStore.listRunningSubagentChildren();
+      expect(rows.map((r) => r.id)).toEqual(["sub-running"]);
+      expect(rows[0].parentSessionId).toBe("parent-1");
+    });
+  });
 });

--- a/packages/database/src/session-store.ts
+++ b/packages/database/src/session-store.ts
@@ -354,6 +354,20 @@ export function countActiveForEnvironment(environmentId: string): number {
 }
 
 /**
+ * List all materialized subagent child sessions (#1075) currently in RUNNING.
+ * Drives the subagent-reconciliation sweep (#1386), which interrupts those whose
+ * parent session has reached a terminal state (so a background/polled child whose
+ * parent stream ended is never left stranded RUNNING forever).
+ */
+export function listRunningSubagentChildren(): SessionRow[] {
+  return db
+    .select()
+    .from(sessions)
+    .where(and(eq(sessions.runtime, SUBAGENT_RUNTIME), eq(sessions.status, SESSION_STATUS.RUNNING)))
+    .all();
+}
+
+/**
  * Count all active (pending/running/idle) sessions across the entire server.
  * Excludes subagent children (#1075) so they don't consume global concurrency.
  */

--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -25,6 +25,8 @@ export type { OrphanPhaseDeps } from "./orphan-phase.js";
 export { lifecycleCleanupPhase } from "./lifecycle-cleanup.js";
 export { createEnvironmentReconciliationPhase } from "./environment-reconciliation.js";
 export type { EnvironmentReconciliationDeps } from "./environment-reconciliation.js";
+export { createSubagentReconciliationPhase } from "./subagent-reconciliation.js";
+export type { SubagentReconciliationDeps } from "./subagent-reconciliation.js";
 
 // ─── Plugin Registry ────────────────────────────────────────
 export { setLoadedPluginNames, PLUGIN_REGISTRY } from "./plugin-registry.js";

--- a/packages/plugin-core/src/subagent-reconciliation.test.ts
+++ b/packages/plugin-core/src/subagent-reconciliation.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SessionRow } from "@grackle-ai/database";
+import {
+  createSubagentReconciliationPhase,
+  type SubagentReconciliationDeps,
+} from "./subagent-reconciliation.js";
+
+vi.mock("@grackle-ai/core", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+/** Minimal SessionRow factory — only the fields the phase reads need to be real. */
+function row(overrides: Partial<SessionRow>): SessionRow {
+  return {
+    id: "id",
+    environmentId: "env",
+    runtime: "subagent",
+    runtimeSessionId: null,
+    prompt: "",
+    model: "",
+    status: "running",
+    logPath: null,
+    turns: 0,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    suspendedAt: null,
+    endedAt: null,
+    endReason: null,
+    error: null,
+    taskId: "",
+    personaId: "",
+    parentSessionId: "parent-1",
+    pipeMode: "",
+    inputTokens: 0,
+    outputTokens: 0,
+    costMillicents: 0,
+    sigtermSentAt: null,
+    ...overrides,
+  } as SessionRow;
+}
+
+function makeDeps(overrides?: Partial<SubagentReconciliationDeps>): SubagentReconciliationDeps {
+  return {
+    listRunningSubagentChildren: vi.fn(() => []),
+    getSession: vi.fn(() => undefined),
+    interruptChildSession: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("subagent reconciliation phase", () => {
+  it("interrupts a running child whose parent is STOPPED", async () => {
+    const child = row({ id: "child-1", parentSessionId: "parent-1" });
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [child]),
+      getSession: vi.fn(() => row({ id: "parent-1", runtime: "claude-code", status: "stopped" })),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).toHaveBeenCalledWith("child-1");
+  });
+
+  it("leaves a child whose parent is still RUNNING", async () => {
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [
+        row({ id: "child-1", parentSessionId: "parent-1" }),
+      ]),
+      getSession: vi.fn(() => row({ id: "parent-1", runtime: "claude-code", status: "running" })),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).not.toHaveBeenCalled();
+  });
+
+  it("leaves a child whose parent is IDLE (waiting input)", async () => {
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [
+        row({ id: "child-1", parentSessionId: "parent-1" }),
+      ]),
+      getSession: vi.fn(() => row({ id: "parent-1", runtime: "claude-code", status: "idle" })),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).not.toHaveBeenCalled();
+  });
+
+  it("leaves a child whose parent is SUSPENDED (recoverable)", async () => {
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [
+        row({ id: "child-1", parentSessionId: "parent-1" }),
+      ]),
+      getSession: vi.fn(() => row({ id: "parent-1", runtime: "claude-code", status: "suspended" })),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).not.toHaveBeenCalled();
+  });
+
+  it("interrupts a child whose parent no longer exists", async () => {
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [row({ id: "child-1", parentSessionId: "gone" })]),
+      getSession: vi.fn(() => undefined),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).toHaveBeenCalledWith("child-1");
+  });
+
+  it("interrupts a child with no parent reference", async () => {
+    const getSession = vi.fn(() => undefined);
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [row({ id: "child-1", parentSessionId: "" })]),
+      getSession,
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).toHaveBeenCalledWith("child-1");
+    // An empty parentSessionId must not even trigger a lookup.
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there are no running subagent children", async () => {
+    const deps = makeDeps();
+    await createSubagentReconciliationPhase(deps).execute();
+    expect(deps.interruptChildSession).not.toHaveBeenCalled();
+  });
+
+  it("interrupts only the stranded children among a mixed set", async () => {
+    const children = [
+      row({ id: "stranded-1", parentSessionId: "p-stopped" }),
+      row({ id: "alive", parentSessionId: "p-running" }),
+      row({ id: "stranded-2", parentSessionId: "p-gone" }),
+    ];
+    const parents: Record<string, SessionRow | undefined> = {
+      "p-stopped": row({ id: "p-stopped", runtime: "claude-code", status: "stopped" }),
+      "p-running": row({ id: "p-running", runtime: "claude-code", status: "running" }),
+      "p-gone": undefined,
+    };
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => children),
+      getSession: vi.fn((id: string) => parents[id]),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).toHaveBeenCalledTimes(2);
+    expect(deps.interruptChildSession).toHaveBeenCalledWith("stranded-1");
+    expect(deps.interruptChildSession).toHaveBeenCalledWith("stranded-2");
+    expect(deps.interruptChildSession).not.toHaveBeenCalledWith("alive");
+  });
+
+  it("continues after an individual interrupt failure", async () => {
+    const deps = makeDeps({
+      listRunningSubagentChildren: vi.fn(() => [
+        row({ id: "child-1", parentSessionId: "p-stopped" }),
+        row({ id: "child-2", parentSessionId: "p-stopped" }),
+      ]),
+      getSession: vi.fn(() => row({ id: "p-stopped", runtime: "claude-code", status: "stopped" })),
+      interruptChildSession: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("DB error");
+        })
+        .mockImplementationOnce(() => {}),
+    });
+
+    await createSubagentReconciliationPhase(deps).execute();
+
+    expect(deps.interruptChildSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/plugin-core/src/subagent-reconciliation.ts
+++ b/packages/plugin-core/src/subagent-reconciliation.ts
@@ -1,0 +1,83 @@
+/**
+ * Subagent reconciliation phase (#1386) — reaps stranded RUNNING subagent
+ * children left behind by #1075.
+ *
+ * A materialized subagent child (`runtime="subagent"`) is only ever closed
+ * through its parent session's event stream. A background/polled child (Copilot
+ * `task` + `read_agent`) whose parent stream ends before a terminal poll lands is
+ * deliberately NOT interrupted by the stream's `finally` block — so it can be
+ * left `RUNNING` forever.
+ *
+ * Once the parent session reaches a terminal state, its stream has ended and the
+ * child can never be updated again (the parent stream is the child's only
+ * mutator), so the child is definitively stranded. This phase interrupts those
+ * children. A merely idle/running parent (still alive) or a SUSPENDED parent
+ * (recoverable — its resumed stream may still legitimately close the child) is
+ * left untouched.
+ *
+ * @module
+ */
+
+import { TERMINAL_SESSION_STATUSES } from "@grackle-ai/common";
+import type { SessionStatus } from "@grackle-ai/common";
+import type { SessionRow } from "@grackle-ai/database";
+import { logger } from "@grackle-ai/core";
+import type { ReconciliationPhase } from "@grackle-ai/core";
+
+/** Dependencies injected into the subagent reconciliation phase for testability. */
+export interface SubagentReconciliationDeps {
+  /** List all materialized subagent child sessions currently in RUNNING. */
+  listRunningSubagentChildren: () => SessionRow[];
+  /** Resolve a session by id (used to look up each child's parent). */
+  getSession: (id: string) => SessionRow | undefined;
+  /** Mark a stranded child interrupted (terminal). Idempotent. */
+  interruptChildSession: (childSessionId: string) => void;
+}
+
+/**
+ * Create the subagent reconciliation phase.
+ *
+ * @param deps - Injected dependencies for testability.
+ * @returns A ReconciliationPhase that can be registered with the ReconciliationManager.
+ */
+export function createSubagentReconciliationPhase(
+  deps: SubagentReconciliationDeps,
+): ReconciliationPhase {
+  return {
+    name: "subagent-reconciliation",
+    execute: async () => {
+      let interrupted = 0;
+
+      for (const child of deps.listRunningSubagentChildren()) {
+        const parent = child.parentSessionId ? deps.getSession(child.parentSessionId) : undefined;
+        const parentGone = parent === undefined;
+        const parentTerminal =
+          parent !== undefined && TERMINAL_SESSION_STATUSES.has(parent.status as SessionStatus);
+
+        // Leave the child be while the parent is alive (running/idle) or merely
+        // SUSPENDED (recoverable — a resumed stream may still close the child).
+        if (!parentGone && !parentTerminal) {
+          continue;
+        }
+
+        try {
+          deps.interruptChildSession(child.id);
+          interrupted++;
+        } catch (err) {
+          logger.error(
+            { err, childId: child.id, parentSessionId: child.parentSessionId },
+            "Subagent reconciliation: failed to interrupt stranded child",
+          );
+        }
+      }
+
+      if (interrupted > 0) {
+        logger.info(
+          { interrupted },
+          "Subagent reconciliation: interrupted %d stranded child session(s)",
+          interrupted,
+        );
+      }
+    },
+  };
+}

--- a/packages/server/src/core-plugin.test.ts
+++ b/packages/server/src/core-plugin.test.ts
@@ -17,6 +17,7 @@ vi.mock("@grackle-ai/core", () => ({
   listConnections: vi.fn(() => new Map()),
   removeConnection: vi.fn(),
   hasCapacity: vi.fn(() => true),
+  interruptChildSession: vi.fn(),
 }));
 
 vi.mock("@grackle-ai/plugin-core", () => ({
@@ -34,6 +35,10 @@ vi.mock("@grackle-ai/plugin-core", () => ({
   lifecycleCleanupPhase: { name: "lifecycle-cleanup", execute: vi.fn() },
   createEnvironmentReconciliationPhase: vi.fn(() => ({
     name: "environment-status",
+    execute: vi.fn(),
+  })),
+  createSubagentReconciliationPhase: vi.fn(() => ({
+    name: "subagent-reconciliation",
     execute: vi.fn(),
   })),
 }));
@@ -64,6 +69,8 @@ vi.mock("@grackle-ai/database", () => ({
     listSessionsForTask: vi.fn(),
     getLatestSessionForTask: vi.fn(),
     countActiveForEnvironment: vi.fn(),
+    listRunningSubagentChildren: vi.fn(() => []),
+    getSession: vi.fn(),
   },
   settingsStore: { getSetting: vi.fn() },
   dispatchQueueStore: { listPending: vi.fn(() => []), dequeue: vi.fn() },
@@ -126,6 +133,7 @@ describe("createCorePlugin", () => {
     expect(names).toContain("dispatch");
     expect(names).not.toContain("cron");
     expect(names).toContain("lifecycle-cleanup");
+    expect(names).toContain("subagent-reconciliation");
     expect(names).toContain("environment-status");
     // orphan-reparent belongs to the orchestration plugin
     expect(names).not.toContain("orphan-reparent");

--- a/packages/server/src/reconciliation-setup.test.ts
+++ b/packages/server/src/reconciliation-setup.test.ts
@@ -12,6 +12,7 @@ vi.mock("@grackle-ai/core", () => ({
   computeTaskStatus: vi.fn(() => ({ status: "not_started", latestSessionId: undefined })),
   resolveDispatchEnvironment: vi.fn(),
   resolveAncestorEnvironmentId: vi.fn(),
+  interruptChildSession: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
@@ -24,6 +25,10 @@ vi.mock("@grackle-ai/plugin-core", () => ({
   lifecycleCleanupPhase: { name: "lifecycle-cleanup", execute: async () => {} },
   createEnvironmentReconciliationPhase: vi.fn(() => ({
     name: "environment-status",
+    execute: async () => {},
+  })),
+  createSubagentReconciliationPhase: vi.fn(() => ({
+    name: "subagent-reconciliation",
     execute: async () => {},
   })),
 }));
@@ -64,6 +69,8 @@ vi.mock("@grackle-ai/database", () => ({
     countActiveForEnvironment: vi.fn(() => 0),
     getActiveSessionsForTask: vi.fn(() => []),
     listSessionsForTask: vi.fn(() => []),
+    listRunningSubagentChildren: vi.fn(() => []),
+    getSession: vi.fn(),
   },
   settingsStore: {
     getSetting: vi.fn(),
@@ -85,13 +92,18 @@ beforeEach(() => {
 });
 
 describe("createCoreReconciliationPhases", () => {
-  it("returns dispatch, lifecycle-cleanup, and environment-status phases (no cron, no knowledge-health, no orphan-reparent)", () => {
+  it("returns dispatch, lifecycle-cleanup, subagent-reconciliation, and environment-status phases (no cron, no knowledge-health, no orphan-reparent)", () => {
     const phases = createCoreReconciliationPhases();
     const names = phases.map((p) => p.name);
-    expect(names).toEqual(["dispatch", "lifecycle-cleanup", "environment-status"]);
+    expect(names).toEqual([
+      "dispatch",
+      "lifecycle-cleanup",
+      "subagent-reconciliation",
+      "environment-status",
+    ]);
     expect(names).not.toContain("cron");
     expect(names).not.toContain("orphan-reparent");
     expect(names).not.toContain("knowledge-health");
-    expect(phases).toHaveLength(3);
+    expect(phases).toHaveLength(4);
   });
 });

--- a/packages/server/src/reconciliation-setup.ts
+++ b/packages/server/src/reconciliation-setup.ts
@@ -9,12 +9,14 @@ import {
   resolveDispatchEnvironment,
   resolveAncestorEnvironmentId,
   findFirstConnectedEnvironment,
+  interruptChildSession,
 } from "@grackle-ai/core";
 import type { ReconciliationPhase } from "@grackle-ai/core";
 import {
   createDispatchPhase,
   lifecycleCleanupPhase,
   createEnvironmentReconciliationPhase,
+  createSubagentReconciliationPhase,
 } from "@grackle-ai/plugin-core";
 import { TASK_STATUS, ROOT_TASK_ID } from "@grackle-ai/common";
 import {
@@ -97,9 +99,16 @@ export function createCoreReconciliationPhases(): ReconciliationPhase[] {
     },
   });
 
+  const subagentReconciliationPhase = createSubagentReconciliationPhase({
+    listRunningSubagentChildren: sessionStore.listRunningSubagentChildren,
+    getSession: sessionStore.getSession,
+    interruptChildSession,
+  });
+
   const phases: ReconciliationPhase[] = [
     dispatchPhase,
     lifecycleCleanupPhase,
+    subagentReconciliationPhase,
     environmentReconciliationPhase,
   ];
 


### PR DESCRIPTION
Closes #1386.

## Problem

#1075 materializes subagent delegations (Claude Code `Agent`, Copilot `task`/`read_agent`) as virtual child sessions (`runtime="subagent"`, `taskId=""`, attached via `parentSessionId`). A child is only ever closed through its **parent session's event stream**.

A **background/polled** child (Copilot `task` + `read_agent`) is deliberately *not* interrupted by the stream's `finally` block — it runs independently of the parent stream. So if the parent stream ends before a terminal `read_agent` poll lands, the child stays `RUNNING` forever. It's harmless (every env/task/concurrency query excludes `SUBAGENT_RUNTIME`), but it never reaches a terminal state.

## Fix

Add a `subagent-reconciliation` phase to the existing `ReconciliationManager` (10s ticker). On each tick it lists `RUNNING` subagent children and interrupts any whose **parent session has reached a terminal (`STOPPED`) state** — or whose parent no longer exists.

Once the parent is `STOPPED`, its stream has ended and the parent stream is the child's *only* mutator, so the child is **definitively** stranded — making an immediate, grace-free sweep safe.

Parents that are merely `RUNNING`/`IDLE` (alive) or **`SUSPENDED`** are left alone. `SUSPENDED` is the key case: it's recoverable, and a resumed stream may still legitimately close the child via a late poll — sweeping it would lose the real result. Triggering only on `STOPPED` (`TERMINAL_SESSION_STATUSES`) handles this cleanly.

## Changes

- **database**: `listRunningSubagentChildren()` query.
- **core**: export the existing idempotent `interruptChildSession` primitive; refresh the now-stale `#1386 follow-up` comment in `event-processor.ts`.
- **plugin-core**: `createSubagentReconciliationPhase` (injected deps, mirrors `orphan-phase`).
- **server**: wire the phase into `createCoreReconciliationPhases`.

## Tests

- **Query** (`session-store.test.ts`, real in-memory DB): returns only `RUNNING` subagent children; excludes terminal children and `RUNNING` non-subagent sessions.
- **Phase** (`subagent-reconciliation.test.ts`, 9 cases): `STOPPED` parent → interrupt; `RUNNING`/`IDLE`/`SUSPENDED` parent → skip; missing parent / no parent ref → interrupt; empty list; mixed set; continues after an individual interrupt failure.
- **Wiring** (`reconciliation-setup.test.ts`, `core-plugin.test.ts`): phase registered in the core phase list.

All affected packages build clean (only the expected api-extractor report update) and `rushx test` is green in `database`/`plugin-core`/`server`.
