### PR TITLE
Fix mobile ContextNav drawer reading as empty with a short context list

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1425-context-nav-mobile-drawer_2026-05-31-16-19.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1425-context-nav-mobile-drawer_2026-05-31-16-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix mobile ContextNav drawer spanning the full screen height with a short context list; it now hugs its content instead of stranding a few rows above an empty panel.",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/changes/@grackle-ai/cli/nick-pape-1425-context-nav-mobile-drawer_2026-05-31-16-19.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1425-context-nav-mobile-drawer_2026-05-31-16-19.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix mobile ContextNav drawer spanning the full screen height with a short context list; it now hugs its content instead of stranding a few rows above an empty panel.",
+      "comment": "Fix the mobile ContextNav drawer anchoring to the viewport top, where its top rows (Fleet/Coordination) were clipped behind the higher-z-index StatusBar; it now anchors to the content area below the StatusBar so the whole rail is visible.",
       "type": "patch",
       "packageName": "@grackle-ai/cli"
     }

--- a/packages/web-components/src/components/layout/ContextNav.module.scss
+++ b/packages/web-components/src/components/layout/ContextNav.module.scss
@@ -25,10 +25,17 @@ $rail-width-collapsed: 56px;
     width: $rail-width-collapsed;
   }
 
+  // On mobile the rail is a slide-in pullout (see App.module.scss
+  // .contextNavWrapper), so it hugs its rows rather than spanning the full
+  // screen height — a short context list would otherwise strand its few rows at
+  // the top of an empty full-height panel (#1425). max-height caps it so a
+  // longer list (Agent rows, #1417) scrolls instead of overflowing the viewport.
   @include mobile {
-    width: 100% !important;
-    height: 100%;
+    width: 100%;
+    height: auto;
+    max-height: 100%;
     border-right: none;
+    border-bottom-right-radius: var(--radius-lg);
   }
 }
 

--- a/packages/web-components/src/components/layout/ContextNav.module.scss
+++ b/packages/web-components/src/components/layout/ContextNav.module.scss
@@ -25,17 +25,10 @@ $rail-width-collapsed: 56px;
     width: $rail-width-collapsed;
   }
 
-  // On mobile the rail is a slide-in pullout (see App.module.scss
-  // .contextNavWrapper), so it hugs its rows rather than spanning the full
-  // screen height — a short context list would otherwise strand its few rows at
-  // the top of an empty full-height panel (#1425). max-height caps it so a
-  // longer list (Agent rows, #1417) scrolls instead of overflowing the viewport.
   @include mobile {
-    width: 100%;
-    height: auto;
-    max-height: 100%;
+    width: 100% !important;
+    height: 100%;
     border-right: none;
-    border-bottom-right-radius: var(--radius-lg);
   }
 }
 

--- a/packages/web/src/App.module.scss
+++ b/packages/web/src/App.module.scss
@@ -90,14 +90,16 @@
   display: flex;
   flex-shrink: 0;
 
-  // Slide-in pullout, anchored top-left. Intentionally no `bottom` — the drawer
-  // hugs the rail's content height (the rail caps itself at max-height: 100%)
-  // instead of spanning the full viewport, so a short context list doesn't leave
-  // a tall empty panel below it (#1425).
+  // Slide-in pullout. Positioned `absolute` (not `fixed`) so it anchors to the
+  // shell — the row *below* the StatusBar — rather than the viewport top. The
+  // StatusBar has a higher z-index, so a viewport-anchored drawer would slide
+  // under it and clip its top rows (Fleet/Coordination); anchoring to the shell
+  // keeps the whole rail visible while still spanning the full content height (#1425).
   @include mobile {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
+    bottom: 0;
     width: 240px;
     z-index: 100;
     transform: translateX(-100%);

--- a/packages/web/src/App.module.scss
+++ b/packages/web/src/App.module.scss
@@ -90,11 +90,14 @@
   display: flex;
   flex-shrink: 0;
 
+  // Slide-in pullout, anchored top-left. Intentionally no `bottom` — the drawer
+  // hugs the rail's content height (the rail caps itself at max-height: 100%)
+  // instead of spanning the full viewport, so a short context list doesn't leave
+  // a tall empty panel below it (#1425).
   @include mobile {
     position: fixed;
     top: 0;
     left: 0;
-    bottom: 0;
     width: 240px;
     z-index: 100;
     transform: translateX(-100%);

--- a/tests/e2e-tests/tests/context-nav.spec.ts
+++ b/tests/e2e-tests/tests/context-nav.spec.ts
@@ -123,23 +123,26 @@ test.describe("Context nav drawer (mobile)", { tag: ["@webui"] }, () => {
     await expect(rail).not.toBeVisible({ timeout: 5_000 });
   });
 
-  test("drawer hugs its content instead of spanning the full viewport height", async ({
-    appPage,
-  }) => {
+  test("drawer content sits below the StatusBar (top rows not clipped)", async ({ appPage }) => {
     const page = appPage;
     await page.goto("/");
     await waitForConnected(page);
 
+    const toggle = page.getByRole("button", { name: "Toggle contexts" });
+    await toggle.click();
     const rail = page.getByTestId("context-nav");
-    await page.getByRole("button", { name: "Toggle contexts" }).click();
     await expect(rail).toBeVisible();
 
-    // Regression guard for #1425: a short context list must not leave a tall
-    // empty panel below it. The drawer sizes to its rows, so its height stays
-    // well under the viewport rather than filling the whole screen.
-    const box = await rail.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.height).toBeLessThan(MOBILE_VIEWPORT.height * 0.6);
+    // Regression guard for #1425: the drawer is anchored to the content area
+    // below the StatusBar (not the viewport top), so its topmost rows
+    // (Fleet/Coordination) are not clipped behind the higher-z-index StatusBar.
+    await expect(rail.getByTestId("sidebar-tab-coordination")).toBeVisible();
+    const toggleBox = await toggle.boundingBox();
+    const railBox = await rail.boundingBox();
+    expect(toggleBox).not.toBeNull();
+    expect(railBox).not.toBeNull();
+    // The rail starts at or below the bottom edge of the StatusBar's controls.
+    expect(railBox!.y).toBeGreaterThanOrEqual(toggleBox!.y + toggleBox!.height - 1);
   });
 
   test("Escape closes the context drawer", async ({ appPage }) => {

--- a/tests/e2e-tests/tests/context-nav.spec.ts
+++ b/tests/e2e-tests/tests/context-nav.spec.ts
@@ -123,6 +123,25 @@ test.describe("Context nav drawer (mobile)", { tag: ["@webui"] }, () => {
     await expect(rail).not.toBeVisible({ timeout: 5_000 });
   });
 
+  test("drawer hugs its content instead of spanning the full viewport height", async ({
+    appPage,
+  }) => {
+    const page = appPage;
+    await page.goto("/");
+    await waitForConnected(page);
+
+    const rail = page.getByTestId("context-nav");
+    await page.getByRole("button", { name: "Toggle contexts" }).click();
+    await expect(rail).toBeVisible();
+
+    // Regression guard for #1425: a short context list must not leave a tall
+    // empty panel below it. The drawer sizes to its rows, so its height stays
+    // well under the viewport rather than filling the whole screen.
+    const box = await rail.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeLessThan(MOBILE_VIEWPORT.height * 0.6);
+  });
+
   test("Escape closes the context drawer", async ({ appPage }) => {
     const page = appPage;
     await page.goto("/");


### PR DESCRIPTION
## Summary
On mobile the context rail is a slide-in pullout drawer. Its wrapper was `position: fixed; top: 0` — anchored to the **viewport top** — but the StatusBar has a higher `z-index` (101 vs 100), so the drawer slid *under* the StatusBar (and, in demo mode, the demo banner). Its top rows (`Fleet` / `Coordination`) were clipped behind the bar, making the drawer look empty/broken — the root of #1425.

- **`App.module.scss`** (`.contextNavWrapper`, mobile): `position: fixed` → `position: absolute`. It now anchors to `.shell` (already `position: relative`) — the row *below* the StatusBar — instead of the viewport top, so no rows are clipped. Retains `top/left/bottom: 0` + `width: 240px` so it still spans the full content height.
- **`ContextNav.module.scss`** (`.rail`, mobile): kept full-height (`height: 100%`); no content-hugging.

No `.tsx`, route, or backend changes. Desktop rail and the slide-in / overlay / Escape behavior are untouched (all changes are inside `@include mobile`).

## Test plan
- [x] `rush build` — clean, no warnings
- [x] `rush format:check` — clean
- [x] E2E `context-nav.spec.ts` (chromium) — all pass, including a new regression guard asserting the open drawer's rail starts at/below the bottom of the StatusBar controls (i.e. top rows are not clipped)
- [x] Manual verify at 375×812 via Playwright (see screenshot) — `Fleet` / `Coordination` / `Schedules` / `Code` all visible below the StatusBar

## Screenshots
**Mobile drawer — full height, anchored below the StatusBar, all rows visible:**

![mobile ContextNav drawer fixed](https://gist.githubusercontent.com/nick-pape/53ab03ade56aff0e7a80ecaa5e14fd64/raw/47b9eb058e99be52f3d4d5525534423a3ff58858/ctx1425-fixed.svg)

## Scope
This is Phase-0 polish — it fixes only the mobile drawer clipping. Broader context-axis follow-ups (e.g. per-agent view bars / different top-bar nav when an Agent context is active) are tracked under epic #1412 (notably #1417) and are intentionally out of scope here.

Closes #1425