### PR TITLE
Hide AppNav on fleet-altitude pages

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-hide-appnav-on-fleet-pages_2026-05-31-16-53.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-hide-appnav-on-fleet-pages_2026-05-31-16-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Hide the workbench tab bar on fleet-altitude pages (Coordination, Schedules); clicking Code in the context rail navigates home",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -152,11 +152,6 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
     };
   }, []);
 
-  // Selecting a context is inert in Phase 0 (Code is the only/default context);
-  // it just dismisses the mobile drawer. Agent contexts + real switching arrive
-  // in #1417.
-  const handleSelectContext = useCallback(() => setContextNavOpen(false), []);
-
   // Fleet/overview altitude (#1415): the `fleet`-group tabs (Coordination today)
   // are pulled out of the view bar and rendered at the top of the context rail.
   // Data-driven from `tabs`, so any future `fleet` tab appears here automatically.
@@ -167,6 +162,13 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
   );
   const activeView = getActiveView(location.pathname);
   const activeFleetId = fleetTabs.some((t) => t.view === activeView) ? activeView : undefined;
+
+  const handleSelectContext = useCallback(() => {
+    if (activeFleetId) {
+      navigate("/");
+    }
+    setContextNavOpen(false);
+  }, [activeFleetId, navigate]);
   const handleSelectFleet = useCallback(
     (id: string) => {
       const tab = fleetTabs.find((t) => t.view === id);
@@ -235,9 +237,7 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
           />
         )}
         <div className={styles.contextPane}>
-          {/* Fleet tabs (Coordination) live at the fleet altitude in the context
-              rail (#1415); the view bar shows only workbench + global tabs. */}
-          <AppNav tabs={tabs} groups={["workbench", "global"]} />
+          {!activeFleetId && <AppNav tabs={tabs} groups={["workbench", "global"]} />}
           <div className={styles.body}>
             {hasSidebar && (
               <div className={styles.sidebarWrapper} data-sidebar-open={sidebarOpen}>

--- a/tests/e2e-tests/tests/context-nav.spec.ts
+++ b/tests/e2e-tests/tests/context-nav.spec.ts
@@ -99,6 +99,33 @@ test.describe("Context nav (context axis)", { tag: ["@webui", "@smoke"] }, () =>
     await toggle.click();
     await expect(rail).toHaveAttribute("data-collapsed", "false");
   });
+
+  test("AppNav is hidden on fleet pages", async ({ appPage }) => {
+    const page = appPage;
+    await page.goto("/");
+    await waitForConnected(page);
+
+    // View bar is visible on workbench pages.
+    await expect(page.getByTestId("sidebar-nav")).toBeVisible();
+
+    // Navigate to a fleet page — the view bar should disappear.
+    await page.getByTestId("context-nav").getByTestId("sidebar-tab-coordination").click();
+    await expect(page).toHaveURL(/\/coordination/);
+    await expect(page.getByTestId("sidebar-nav")).toHaveCount(0);
+  });
+
+  test("clicking Code from a fleet page navigates back to the workbench", async ({ appPage }) => {
+    const page = appPage;
+    await page.goto("/coordination");
+    await waitForConnected(page);
+
+    await expect(page.getByTestId("coordination-page")).toBeVisible();
+
+    // Clicking the Code context should navigate home.
+    await page.getByTestId("context-code").click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId("sidebar-nav")).toBeVisible();
+  });
 });
 
 test.describe("Context nav drawer (mobile)", { tag: ["@webui"] }, () => {


### PR DESCRIPTION
## Summary
- Fleet-altitude pages (Coordination, Schedules) no longer show the workbench tab bar — they sit above the Code context and don't need its view tabs
- Clicking the Code context in the left rail now navigates home (`/`) when on a fleet page, giving a clear way back to the workbench
- Adds two E2E tests: AppNav hidden on fleet pages, and Code-click navigation from fleet pages

## Test plan
- [ ] Navigate to Coordination — AppNav should be hidden
- [ ] Navigate to Schedules — AppNav should be hidden
- [ ] Click Code in left rail from a fleet page — should navigate to `/`
- [ ] On `/`, AppNav renders normally with Dashboard/Tasks/etc.
- [ ] E2E: `context-nav.spec.ts` passes
- [ ] E2E: `coordination.spec.ts` passes
- [ ] E2E: `schedule.spec.ts` passes