### PR TITLE
Fix 6 layout/nav bugs from dogfooding session

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-layout-nav-fixes_2026-05-31-22-25.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-layout-nav-fixes_2026-05-31-22-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "placeholder",
+      "type": "none",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/layout/BottomStatusBar.tsx
+++ b/packages/web-components/src/components/layout/BottomStatusBar.tsx
@@ -184,35 +184,37 @@ export function BottomStatusBar({
   // --- session mode ---
   if (sessionId) {
     const session = sessions.find((s) => s.id === sessionId);
-    const isEnded = session?.status === "stopped";
-    const isActive = session !== undefined && !isEnded;
 
-    // Active session — ChatInput on the page handles this; return empty
-    if (isActive) {
-      return <></>;
-    }
-
-    if (isEnded) {
+    if (!session) {
       return (
         <div className={styles.bar}>
-          <span className={`${styles.statusText} ${styles.hintText}`}>
-            Session {session.endReason || session.status}
-          </span>
-          <button
-            onClick={() => navigate(newChatUrl(session.environmentId))}
-            className={styles.btnPrimary}
-          >
-            + New Chat
-          </button>
+          <span className={styles.hintText}>Loading...</span>
         </div>
       );
     }
+
+    const isEnded = session.status === "stopped";
+
+    // Active session — ChatInput on the page handles this; return empty
+    if (!isEnded) {
+      return <></>;
+    }
+
+    return (
+      <div className={styles.bar}>
+        <span className={`${styles.statusText} ${styles.hintText}`}>
+          Session {session.endReason || session.status}
+        </span>
+        <button
+          onClick={() => navigate(newChatUrl(session.environmentId))}
+          className={styles.btnPrimary}
+        >
+          + New Chat
+        </button>
+      </div>
+    );
   }
 
-  // fallback
-  return (
-    <div className={styles.bar}>
-      <span className={styles.hintText}>Loading...</span>
-    </div>
-  );
+  // No task or session context on this route — nothing to display.
+  return <></>;
 }

--- a/packages/web-components/src/components/layout/ContextNav.module.scss
+++ b/packages/web-components/src/components/layout/ContextNav.module.scss
@@ -63,8 +63,8 @@ $rail-width-collapsed: 56px;
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
-  flex: 1;
   min-height: 0;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -171,7 +171,7 @@ $rail-width-collapsed: 56px;
   gap: var(--space-sm);
   width: 100%;
   padding: var(--space-sm) var(--space-md);
-  margin-top: var(--space-xs);
+  margin-top: auto;
   border: none;
   border-top: 1px solid var(--border-subtle);
   background: transparent;

--- a/packages/web-components/src/components/layout/ContextNav.tsx
+++ b/packages/web-components/src/components/layout/ContextNav.tsx
@@ -182,14 +182,16 @@ export function ContextNav({
         aria-orientation="vertical"
         onKeyDown={handleKeyDown}
       >
-        {contexts.map((context) => {
+        {contexts.map((context, index) => {
           const isActive = context.id === activeContextId;
+          const hasActiveContext = contexts.some((c) => c.id === activeContextId);
+          const isFocusable = isActive || (!hasActiveContext && index === 0);
           const button = (
             <button
               role="tab"
               type="button"
               aria-selected={isActive}
-              tabIndex={isActive ? 0 : -1}
+              tabIndex={isFocusable ? 0 : -1}
               className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
               onClick={() => onSelectContext(context.id)}
               data-testid={context.testId}

--- a/packages/web-components/src/components/layout/ContextNav.tsx
+++ b/packages/web-components/src/components/layout/ContextNav.tsx
@@ -212,11 +212,22 @@ export function ContextNav({
             </div>
           );
         })}
-      </div>
-
-      {onCreateAgent &&
-        (collapsed ? (
-          <Tooltip text={createAgentLabel} placement="right" inline={false}>
+        {onCreateAgent &&
+          (collapsed ? (
+            <Tooltip text={createAgentLabel} placement="right" inline={false}>
+              <button
+                type="button"
+                className={styles.createAgent}
+                onClick={onCreateAgent}
+                aria-label={createAgentLabel}
+                data-testid="context-nav-create-agent"
+              >
+                <span className={styles.tabIcon} aria-hidden="true">
+                  <Plus size={ICON_LG} />
+                </span>
+              </button>
+            </Tooltip>
+          ) : (
             <button
               type="button"
               className={styles.createAgent}
@@ -227,22 +238,10 @@ export function ContextNav({
               <span className={styles.tabIcon} aria-hidden="true">
                 <Plus size={ICON_LG} />
               </span>
+              <span className={styles.tabLabel}>{createAgentLabel}</span>
             </button>
-          </Tooltip>
-        ) : (
-          <button
-            type="button"
-            className={styles.createAgent}
-            onClick={onCreateAgent}
-            aria-label={createAgentLabel}
-            data-testid="context-nav-create-agent"
-          >
-            <span className={styles.tabIcon} aria-hidden="true">
-              <Plus size={ICON_LG} />
-            </span>
-            <span className={styles.tabLabel}>{createAgentLabel}</span>
-          </button>
-        ))}
+          ))}
+      </div>
 
       {onToggleCollapsed && (
         <button

--- a/packages/web-components/src/components/schedules/ScheduleManager.module.scss
+++ b/packages/web-components/src/components/schedules/ScheduleManager.module.scss
@@ -5,6 +5,10 @@
 // =============================================================================
 
 .container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
   padding: var(--space-lg);
   max-width: 800px;
   color: var(--text-primary);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -203,8 +203,19 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
     [agents],
   );
 
+  // Fleet/overview altitude (#1415): the `fleet`-group tabs (Coordination today)
+  // are pulled out of the view bar and rendered at the top of the context rail.
+  // Data-driven from `tabs`, so any future `fleet` tab appears here automatically.
+  const fleetTabs = useMemo(() => tabs.filter((t) => t.group === "fleet"), [tabs]);
+  const fleetItems = useMemo<ContextItem[]>(
+    () => fleetTabs.map((t) => ({ id: t.view, label: t.label, icon: t.icon, testId: t.testId })),
+    [fleetTabs],
+  );
+  const activeView = getActiveView(location.pathname);
+  const activeFleetId = fleetTabs.some((t) => t.view === activeView) ? activeView : undefined;
+
   // Derive the active context from the route: `/agents/:id` activates that agent
-  // row; everything else falls back to the default `Code` context.
+  // row; fleet pages deselect all contexts; everything else falls back to `Code`.
   // `decodeURIComponent` throws on malformed percent-encoding (e.g. `/agents/%E0`),
   // which would otherwise crash the shell while deriving `activeContextId`.
   const agentRouteMatch = location.pathname.match(/^\/agents\/([^/]+)$/);
@@ -218,7 +229,9 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
   }
   const activeContextId = activeAgentId
     ? `${AGENT_CONTEXT_PREFIX}${activeAgentId}`
-    : DEFAULT_CONTEXT_ID;
+    : activeFleetId
+      ? ""
+      : DEFAULT_CONTEXT_ID;
 
   // Selecting a context navigates: agent rows open the agent view; `Code` returns
   // to the default landing route. Always dismiss the mobile drawer.
@@ -239,17 +252,6 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
     setContextNavOpen(false);
     navigate("/agents/new");
   }, [navigate]);
-
-  // Fleet/overview altitude (#1415): the `fleet`-group tabs (Coordination today)
-  // are pulled out of the view bar and rendered at the top of the context rail.
-  // Data-driven from `tabs`, so any future `fleet` tab appears here automatically.
-  const fleetTabs = useMemo(() => tabs.filter((t) => t.group === "fleet"), [tabs]);
-  const fleetItems = useMemo<ContextItem[]>(
-    () => fleetTabs.map((t) => ({ id: t.view, label: t.label, icon: t.icon, testId: t.testId })),
-    [fleetTabs],
-  );
-  const activeView = getActiveView(location.pathname);
-  const activeFleetId = fleetTabs.some((t) => t.view === activeView) ? activeView : undefined;
 
   const handleSelectFleet = useCallback(
     (id: string) => {
@@ -320,7 +322,9 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
           />
         )}
         <div className={styles.contextPane}>
-          {!activeFleetId && <AppNav tabs={tabs} groups={["workbench", "global"]} />}
+          {!activeFleetId && !location.pathname.startsWith("/agents/") && (
+            <AppNav tabs={tabs} groups={["workbench", "global"]} />
+          )}
           <div className={styles.body}>
             {hasSidebar && (
               <div className={styles.sidebarWrapper} data-sidebar-open={sidebarOpen}>

--- a/packages/web/src/pages/SessionsListPage.module.scss
+++ b/packages/web/src/pages/SessionsListPage.module.scss
@@ -5,6 +5,7 @@
 .page {
   display: flex;
   flex-direction: column;
+  width: 100%;
   height: 100%;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- **Agent top nav**: Hide AppNav on all `/agents/*` routes so agent pages don't show the Code workbench tabs
- **Fleet context deselection**: Deselect the Code context tab when a fleet page (Coordination, Schedules) is active
- **Schedules layout**: Fix ScheduleManager container not filling viewport height (status bar was floating up)
- **Sessions width**: Add `width: 100%` to SessionsListPage so content stretches full width
- **Perpetual Loading**: Change BottomStatusBar fallback from "Loading..." to empty fragment; add explicit loading state for sessions
- **Create Agent position**: Move +Create Agent button inside the tabList so it sits directly after the last agent, not pinned to the rail bottom

## Test plan
- [x] Verified all 6 fixes visually in the running app via Playwright
- [x] 537 unit tests pass (257 web-components + 280 web)
- [x] Full `rush build` succeeds with no warnings

## Screenshots

### Dashboard — Create Agent after agents, no Loading bar
![Dashboard](https://gist.githubusercontent.com/nick-pape/9d04c53f8fcc746f6d37780f0ce59e35/raw/ss-dashboard.svg)

### Coordination — Fleet highlighted, Code deselected, no Loading bar
![Coordination](https://gist.githubusercontent.com/nick-pape/9d04c53f8fcc746f6d37780f0ce59e35/raw/ss-coordination.svg)

### Schedules — Fleet highlighted, content fills viewport
![Schedules](https://gist.githubusercontent.com/nick-pape/9d04c53f8fcc746f6d37780f0ce59e35/raw/ss-schedules.svg)

### Agent detail — No AppNav, agent selected
![Agent detail](https://gist.githubusercontent.com/nick-pape/9d04c53f8fcc746f6d37780f0ce59e35/raw/ss-agent-detail.svg)

### Sessions — Full width
![Sessions](https://gist.githubusercontent.com/nick-pape/9d04c53f8fcc746f6d37780f0ce59e35/raw/ss-sessions.svg)