### PR TITLE
Agent task ownership: agent_id on tasks, root task auto-create, cascade delete (#1418)

### DIFF
--- a/common/api/auth.public.api.md
+++ b/common/api/auth.public.api.md
@@ -34,6 +34,7 @@ export type AuthContext = {
     workspaceId?: string;
     personaId: string;
     taskSessionId: string;
+    agentId?: string;
 } | {
     type: "oauth";
     clientId: string;
@@ -107,7 +108,9 @@ export function createOAuthAccessToken(clientId: string, resource: string, signi
 export function createRefreshToken(clientId: string, resource: string): string;
 
 // @public
-export function createScopedToken(claims: Pick<ScopedTokenClaims, "sub" | "pid" | "per" | "sid">, signingSecret: string, ttlMs?: number): string;
+export function createScopedToken(claims: Pick<ScopedTokenClaims, "sub" | "pid" | "per" | "sid"> & {
+    agt?: string;
+}, signingSecret: string, ttlMs?: number): string;
 
 // @public
 export function createSession(apiKey: string, options?: {
@@ -178,6 +181,7 @@ export function revokeTask(taskId: string): void;
 
 // @public
 export interface ScopedTokenClaims {
+    agt?: string;
     exp: number;
     iat: number;
     per: string;
@@ -242,7 +246,7 @@ export const WEB_CONTENT_SECURITY_POLICY: string;
 
 // Warnings were encountered during analysis:
 //
-// src/scoped-token.ts:178:1 - (ae-internal-missing-underscore) The name "clearRevocations" should be prefixed with an underscore because the declaration is marked as @internal
+// src/scoped-token.ts:189:1 - (ae-internal-missing-underscore) The name "clearRevocations" should be prefixed with an underscore because the declaration is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -57,6 +57,7 @@ type Agent = Message<"grackle.Agent"> & {
     primaryPersonaId: string;
     createdAt: string;
     updatedAt: string;
+    environmentId: string;
 };
 
 // @public
@@ -440,6 +441,7 @@ type CreateAgentRequest = Message<"grackle.CreateAgentRequest"> & {
     name: string;
     avatar: string;
     primaryPersonaId: string;
+    environmentId: string;
 };
 
 // @public
@@ -3344,6 +3346,8 @@ type Task = Message<"grackle.Task"> & {
     tokenBudget: number;
     costBudgetMillicents: number;
     injectKnowledge: boolean;
+    agentId: string;
+    kind: string;
 };
 
 // @public

--- a/common/api/plugin-core.public.api.md
+++ b/common/api/plugin-core.public.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { AgentRow } from '@grackle-ai/database';
 import { cleanupLifecycleStream } from '@grackle-ai/core';
 import type { ConnectRouter } from '@connectrpc/connect';
 import type { DispatchQueueRow } from '@grackle-ai/database';
@@ -24,12 +25,38 @@ import { VALID_PIPE_MODES } from '@grackle-ai/core';
 import { validatePipeInputs } from '@grackle-ai/core';
 
 // @public
+export interface AgentRootTaskBootDeps {
+    getAgent: (id: string) => AgentRow | undefined;
+    getRootTaskForAgent: (agentId: string) => TaskRow | undefined;
+    insertTask: (fields: {
+        id: string;
+        title: string;
+        description: string;
+        branch: string;
+        dependsOn: string[];
+        parentTaskId: string;
+        depth: number;
+        canDecompose: boolean;
+        injectKnowledge: boolean;
+        defaultPersonaId: string;
+        tokenBudget: number;
+        costBudgetMillicents: number;
+        agentId?: string;
+        kind?: string;
+    }) => void;
+    newId: () => string;
+}
+
+// @public
 export interface ChannelConfig {
     ingressBaseUrl: string;
     signingSecret: string;
 }
 
 export { cleanupLifecycleStream }
+
+// @public
+export function createAgentRootTaskSubscriber(ctx: PluginContext, deps: AgentRootTaskBootDeps): Disposable_2;
 
 // @public
 export function createCoreCollector(): ServiceCollector;
@@ -94,6 +121,11 @@ export interface EnvironmentReconciliationDeps {
     removeConnection: (environmentId: string) => void;
     updateEnvironmentStatus: (id: string, status: EnvironmentStatus) => void;
 }
+
+// @public
+export function handleAgentCreated(deps: AgentRootTaskBootDeps, payload: {
+    agentId: string;
+}): void;
 
 // @public
 export interface IngestBody {

--- a/common/changes/@grackle-ai/cli/nick-pape-1418-agent-task-ownership_2026-06-01-00-27.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1418-agent-task-ownership_2026-06-01-00-27.json
@@ -1,9 +1,44 @@
 {
   "changes": [
     {
-      "comment": "Agent task ownership: agent_id on tasks, root task auto-create, cascade delete (#1418)",
-      "type": "patch",
-      "packageName": "@grackle-ai/cli"
+      "packageName": "@grackle-ai/cli",
+      "comment": "`grackle agent create` now requires `--environment <id>`; `agent show` displays the agent's home environment (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/common",
+      "comment": "Add Task.agent_id, Task.kind, Agent.environment_id, CreateAgentRequest.environment_id to the proto (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/auth",
+      "comment": "Add optional `agt` claim to scoped tokens and `agentId` to the scoped AuthContext, preserving backwards compatibility with tokens minted before #1418.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/core",
+      "comment": "Thread `agt: task.agentId` into the scoped MCP token at `task-session.startTaskSession` (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/database",
+      "comment": "Migration v21 adds `tasks.agent_id`, `tasks.kind`, `agents.environment_id` + indices; stamps the system root task with `kind='root'`. New `agentStore.getAgentsByEnvironment`, `taskStore.getRootTaskForAgent`, `taskStore.getTasksForAgent`. `agentStore.createAgent` requires `environmentId` (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/powerline",
+      "comment": "Lockstep version bump for the Agent task-ownership feature (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/server",
+      "comment": "Wire the `agent.created → auto-create root task` subscriber into `event-subscribers.ts` (#1418).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/web-server",
+      "comment": "Lockstep version bump for the Agent task-ownership feature (#1418).",
+      "type": "patch"
     }
   ],
   "packageName": "@grackle-ai/cli",

--- a/common/changes/@grackle-ai/cli/nick-pape-1418-agent-task-ownership_2026-06-01-00-27.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1418-agent-task-ownership_2026-06-01-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Agent task ownership: agent_id on tasks, root task auto-create, cascade delete (#1418)",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/auth/src/auth-context.ts
+++ b/packages/auth/src/auth-context.ts
@@ -13,5 +13,11 @@ export type AuthContext =
       workspaceId?: string;
       personaId: string;
       taskSessionId: string;
+      /**
+       * Owning Grackle Agent id (#1418). Present when the task was spawned
+       * under an Agent's principal. Distinct from the ACP runtime "agent id"
+       * used in session metadata.
+       */
+      agentId?: string;
     }
   | { type: "oauth"; clientId: string };

--- a/packages/auth/src/auth-middleware.test.ts
+++ b/packages/auth/src/auth-middleware.test.ts
@@ -39,8 +39,13 @@ describe("authenticateMcpRequest", () => {
     expect(result).toEqual({ type: "api-key" });
   });
 
-  /** Valid scoped token returns scoped auth context with claims. */
-  test("valid scoped token returns scoped context", () => {
+  /**
+   * Valid scoped token (no `agt` claim) returns scoped auth context with
+   * the legacy shape — `agentId` is OMITTED from the object entirely, not
+   * present-with-undefined. This keeps the AuthContext byte-for-byte
+   * compatible for tokens minted before #1418 added the `agt` claim.
+   */
+  test("valid scoped token returns scoped context without agentId key", () => {
     const token = createScopedToken(CLAIMS, API_KEY);
     const req = mockRequest(`Bearer ${token}`);
     const result = authenticateMcpRequest(req, API_KEY);
@@ -50,8 +55,10 @@ describe("authenticateMcpRequest", () => {
       workspaceId: "workspace-1",
       personaId: "persona-1",
       taskSessionId: "session-1",
-      agentId: undefined,
     });
+    // Explicit shape check — agentId must not be present at all on
+    // legacy tokens (Object.keys() would expose a spurious key otherwise).
+    expect(Object.keys(result!)).not.toContain("agentId");
   });
 
   /** Scoped token minted with `agt` exposes `agentId` on the context (#1418). */

--- a/packages/auth/src/auth-middleware.test.ts
+++ b/packages/auth/src/auth-middleware.test.ts
@@ -50,6 +50,22 @@ describe("authenticateMcpRequest", () => {
       workspaceId: "workspace-1",
       personaId: "persona-1",
       taskSessionId: "session-1",
+      agentId: undefined,
+    });
+  });
+
+  /** Scoped token minted with `agt` exposes `agentId` on the context (#1418). */
+  test("scoped token with agt populates agentId on the context", () => {
+    const token = createScopedToken({ ...CLAIMS, agt: "agent-42" }, API_KEY);
+    const req = mockRequest(`Bearer ${token}`);
+    const result = authenticateMcpRequest(req, API_KEY);
+    expect(result).toEqual({
+      type: "scoped",
+      taskId: "task-1",
+      workspaceId: "workspace-1",
+      personaId: "persona-1",
+      taskSessionId: "session-1",
+      agentId: "agent-42",
     });
   });
 

--- a/packages/auth/src/auth-middleware.ts
+++ b/packages/auth/src/auth-middleware.ts
@@ -134,13 +134,19 @@ export function authenticateMcpRequest(
     if (isRevokedTask(claims.sub)) {
       return undefined;
     }
+    // Only include `agentId` when the claim is actually present so the
+    // AuthContext shape for legacy scoped tokens (minted before #1418
+    // added the `agt` claim) is byte-for-byte unchanged. Spreading a
+    // conditional object preserves backwards compatibility for any code
+    // doing `Object.keys(ctx)` or deep-equality checks against legacy
+    // contexts.
     return {
       type: "scoped",
       taskId: claims.sub,
       workspaceId: claims.pid || undefined,
       personaId: claims.per,
       taskSessionId: claims.sid,
-      agentId: claims.agt,
+      ...(claims.agt !== undefined ? { agentId: claims.agt } : {}),
     };
   }
 

--- a/packages/auth/src/auth-middleware.ts
+++ b/packages/auth/src/auth-middleware.ts
@@ -140,6 +140,7 @@ export function authenticateMcpRequest(
       workspaceId: claims.pid || undefined,
       personaId: claims.per,
       taskSessionId: claims.sid,
+      agentId: claims.agt,
     };
   }
 

--- a/packages/auth/src/scoped-token.test.ts
+++ b/packages/auth/src/scoped-token.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
+import { createHmac } from "node:crypto";
 import {
   createScopedToken,
   verifyScopedToken,
@@ -145,5 +146,43 @@ describe("scoped-token", () => {
     revokeTask("task-recent");
     pruneRevocations();
     expect(isRevokedTask("task-recent")).toBe(true);
+  });
+
+  // ── #1418: optional `agt` claim ──────────────────────────────────────
+
+  /** A token minted with `agt` round-trips with `agt` set on verify. */
+  test("createScopedToken with agt round-trips", () => {
+    const token = createScopedToken({ ...CLAIMS, agt: "agent-1" }, SIGNING_SECRET);
+    const claims = verifyScopedToken(token, SIGNING_SECRET);
+    expect(claims).toBeDefined();
+    expect(claims!.agt).toBe("agent-1");
+  });
+
+  /** A token minted without `agt` is still valid and has `agt === undefined`. */
+  test("createScopedToken without agt round-trips with agt undefined", () => {
+    const token = createScopedToken(CLAIMS, SIGNING_SECRET);
+    const claims = verifyScopedToken(token, SIGNING_SECRET);
+    expect(claims).toBeDefined();
+    expect(claims!.agt).toBeUndefined();
+  });
+
+  /** A crafted token with a non-string `agt` is rejected. */
+  test("verifyScopedToken rejects a non-string agt claim", () => {
+    const now = Math.floor(Date.now() / 1000);
+    // Manually craft a payload with agt as a number.
+    const payload = {
+      sub: "task-x",
+      pid: "ws",
+      per: "p",
+      sid: "s",
+      agt: 42,
+      iat: now,
+      exp: now + 3600,
+    };
+    const payloadStr = JSON.stringify(payload);
+    const payloadEncoded = Buffer.from(payloadStr, "utf8").toString("base64url");
+    const sig = createHmac("sha256", SIGNING_SECRET).update(payloadEncoded).digest("base64url");
+    const token = `${payloadEncoded}.${sig}`;
+    expect(verifyScopedToken(token, SIGNING_SECRET)).toBeUndefined();
   });
 });

--- a/packages/auth/src/scoped-token.ts
+++ b/packages/auth/src/scoped-token.ts
@@ -13,6 +13,12 @@ export interface ScopedTokenClaims {
   per: string;
   /** Session ID. */
   sid: string;
+  /**
+   * Owning Grackle Agent id (#1418). Optional — present when the task was
+   * spawned under an Agent's principal. Distinct from the ACP runtime
+   * "agent id" inside session metadata.
+   */
+  agt?: string;
   /** Issued-at time (epoch seconds). */
   iat: number;
   /** Expiry time (epoch seconds). */
@@ -51,7 +57,7 @@ function sign(payload: string, secret: string): Buffer {
  * the revoke-on-terminal-state wiring.
  */
 export function createScopedToken(
-  claims: Pick<ScopedTokenClaims, "sub" | "pid" | "per" | "sid">,
+  claims: Pick<ScopedTokenClaims, "sub" | "pid" | "per" | "sid"> & { agt?: string },
   signingSecret: string,
   ttlMs: number = DEFAULT_TTL_MS,
 ): string {
@@ -130,6 +136,11 @@ export function verifyScopedToken(
     !Number.isFinite(claims.iat) ||
     !Number.isFinite(claims.exp)
   ) {
+    return undefined;
+  }
+  // `agt` is optional (#1418). When present it must be a string; tokens
+  // minted before this field existed simply omit it.
+  if (claims.agt !== undefined && typeof claims.agt !== "string") {
     return undefined;
   }
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -79,6 +79,7 @@ export function registerAgentCommands(program: Command): void {
       console.log(`Name:     ${a.name}`);
       console.log(`Avatar:   ${a.avatar || "-"}`);
       console.log(`Persona:  ${a.primaryPersonaId || "-"}`);
+      console.log(`Env:      ${a.environmentId || "-"}`);
       console.log(`Created:  ${a.createdAt}`);
       console.log(`Updated:  ${a.updatedAt}`);
     });
@@ -86,17 +87,21 @@ export function registerAgentCommands(program: Command): void {
   agent
     .command("create <name>")
     .description("Create an agent")
+    .requiredOption("--environment <id>", "Home environment id (where the agent lives)")
     .option("--avatar <value>", "Avatar: emoji, URL, or base64 data URI", "")
     .option("--persona <id>", "Primary persona id", "")
-    .action(async (name: string, opts: { avatar: string; persona: string }) => {
-      const { orchestration } = createGrackleClients();
-      const res = await orchestration.createAgent({
-        name,
-        avatar: opts.avatar,
-        primaryPersonaId: opts.persona,
-      });
-      console.log(chalk.green(`Created agent ${chalk.bold(res.name)} (${res.id})`));
-    });
+    .action(
+      async (name: string, opts: { avatar: string; persona: string; environment: string }) => {
+        const { orchestration } = createGrackleClients();
+        const res = await orchestration.createAgent({
+          name,
+          avatar: opts.avatar,
+          primaryPersonaId: opts.persona,
+          environmentId: opts.environment,
+        });
+        console.log(chalk.green(`Created agent ${chalk.bold(res.name)} (${res.id})`));
+      },
+    );
 
   agent
     .command("edit <id>")

--- a/packages/common/src/proto/grackle/grackle_types.proto
+++ b/packages/common/src/proto/grackle/grackle_types.proto
@@ -571,6 +571,8 @@ message Task {
   int32 token_budget = 25; // Total token cap (input + output); 0 = unlimited
   int32 cost_budget_millicents = 26; // Cost cap in millicents ($0.00001 units); 0 = unlimited
   bool inject_knowledge = 27; // Inject knowledge-graph context at spawn (#1259); defaults true
+  string agent_id = 28; // Owning Grackle Agent (#1418); empty = user-driven (not the ACP runtime agent id)
+  string kind = 29; // Discriminator (#1418): task | root | schedule_rule | schedule_fire | channel_config | channel_thread
 }
 
 message TaskList {
@@ -907,6 +909,7 @@ message Agent {
   string primary_persona_id = 4; // Reference into the Persona Library (#1413)
   string created_at = 5;
   string updated_at = 6;
+  string environment_id = 7; // The Agent's home environment (#1418)
 }
 
 message AgentList {
@@ -921,6 +924,7 @@ message CreateAgentRequest {
   string name = 1;
   string avatar = 2;
   string primary_persona_id = 3;
+  string environment_id = 4; // Required (#1418) — validated at the handler layer
 }
 
 message UpdateAgentRequest {

--- a/packages/core/src/event-processor.test.ts
+++ b/packages/core/src/event-processor.test.ts
@@ -105,7 +105,9 @@ function applySchema(): void {
       workpad   TEXT NOT NULL DEFAULT '',
       schedule_id TEXT NOT NULL DEFAULT '',
       token_budget  INTEGER NOT NULL DEFAULT 0,
-      cost_budget_millicents INTEGER NOT NULL DEFAULT 0
+      cost_budget_millicents INTEGER NOT NULL DEFAULT 0,
+      agent_id      TEXT,
+      kind          TEXT NOT NULL DEFAULT 'task'
     );
 
     CREATE TABLE IF NOT EXISTS sessions (

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -206,6 +206,9 @@ export async function startTaskSession(
       pid: freshTask.workspaceId || "",
       per: resolved.personaId,
       sid: sessionId,
+      // #1418: agent-owned tasks carry the agent_id through to the scoped
+      // token so MCP requests can be attributed to the principal.
+      agt: freshTask.agentId || undefined,
     },
     loadOrCreateApiKey(grackleHome),
   );

--- a/packages/database/src/agent-store.test.ts
+++ b/packages/database/src/agent-store.test.ts
@@ -19,6 +19,7 @@ function applySchema(): void {
       name               TEXT NOT NULL UNIQUE,
       avatar             TEXT NOT NULL DEFAULT '',
       primary_persona_id TEXT NOT NULL DEFAULT '',
+      environment_id     TEXT NOT NULL DEFAULT '',
       created_at         TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
     );

--- a/packages/database/src/agent-store.test.ts
+++ b/packages/database/src/agent-store.test.ts
@@ -33,44 +33,59 @@ describe("agent-store", () => {
   });
 
   it("creates and retrieves an agent", () => {
-    agentStore.createAgent("a1", "Refactor Bot", "🐦", "p1");
+    agentStore.createAgent("a1", "Refactor Bot", "🐦", "p1", "local");
     const a = agentStore.getAgent("a1");
     expect(a?.name).toBe("Refactor Bot");
     expect(a?.avatar).toBe("🐦");
     expect(a?.primaryPersonaId).toBe("p1");
+    expect(a?.environmentId).toBe("local");
   });
 
   it("retrieves an agent by name", () => {
-    agentStore.createAgent("a2", "ByName", "", "");
+    agentStore.createAgent("a2", "ByName", "", "", "env-x");
     const a = agentStore.getAgentByName("ByName");
     expect(a?.id).toBe("a2");
   });
 
   it("enforces a unique name", () => {
-    agentStore.createAgent("a3", "Dupe", "", "");
-    expect(() => agentStore.createAgent("a4", "Dupe", "", "")).toThrow();
+    agentStore.createAgent("a3", "Dupe", "", "", "env-x");
+    expect(() => agentStore.createAgent("a4", "Dupe", "", "", "env-x")).toThrow();
   });
 
   it("lists all agents ordered by name", () => {
-    agentStore.createAgent("a5", "Zeta", "", "");
-    agentStore.createAgent("a6", "Alpha", "", "");
+    agentStore.createAgent("a5", "Zeta", "", "", "env-x");
+    agentStore.createAgent("a6", "Alpha", "", "", "env-x");
     const all = agentStore.listAgents();
     expect(all.map((a) => a.name)).toEqual(["Alpha", "Zeta"]);
   });
 
   it("updates only the provided fields", () => {
-    agentStore.createAgent("a7", "Before", "x", "p1");
+    agentStore.createAgent("a7", "Before", "x", "p1", "env-x");
     agentStore.updateAgent("a7", { name: "After", primaryPersonaId: "p2" });
     const a = agentStore.getAgent("a7");
     expect(a?.name).toBe("After");
     expect(a?.primaryPersonaId).toBe("p2");
     // avatar was not passed → unchanged
     expect(a?.avatar).toBe("x");
+    // environmentId was not in updateAgent's surface → unchanged
+    expect(a?.environmentId).toBe("env-x");
   });
 
   it("deletes an agent", () => {
-    agentStore.createAgent("a8", "Doomed", "", "");
+    agentStore.createAgent("a8", "Doomed", "", "", "env-x");
     agentStore.deleteAgent("a8");
     expect(agentStore.getAgent("a8")).toBeUndefined();
+  });
+
+  it("lists agents by environment, sorted by name", () => {
+    agentStore.createAgent("a-z", "Zeta", "", "", "env-a");
+    agentStore.createAgent("a-a", "Alpha", "", "", "env-a");
+    agentStore.createAgent("b-c", "Charlie", "", "", "env-b");
+    const aEnv = agentStore.getAgentsByEnvironment("env-a");
+    expect(aEnv.map((a) => a.name)).toEqual(["Alpha", "Zeta"]);
+    const bEnv = agentStore.getAgentsByEnvironment("env-b");
+    expect(bEnv.map((a) => a.name)).toEqual(["Charlie"]);
+    const empty = agentStore.getAgentsByEnvironment("env-none");
+    expect(empty).toEqual([]);
   });
 });

--- a/packages/database/src/agent-store.ts
+++ b/packages/database/src/agent-store.ts
@@ -4,12 +4,19 @@ import { eq, asc, sql } from "drizzle-orm";
 
 export type { AgentRow };
 
-/** Insert a new agent record. */
+/**
+ * Insert a new agent record.
+ *
+ * `environmentId` is required (the Agent's home environment, #1418).
+ * Validation that the environment exists happens at the handler layer;
+ * the store accepts any non-empty string.
+ */
 export function createAgent(
   id: string,
   name: string,
   avatar: string,
   primaryPersonaId: string,
+  environmentId: string,
 ): void {
   db.insert(agents)
     .values({
@@ -17,6 +24,7 @@ export function createAgent(
       name,
       avatar,
       primaryPersonaId,
+      environmentId,
     })
     .run();
 }
@@ -62,4 +70,14 @@ export function updateAgent(
 /** Delete an agent by ID. */
 export function deleteAgent(id: string): void {
   db.delete(agents).where(eq(agents.id, id)).run();
+}
+
+/** Return all agents in a given environment, ordered by name. */
+export function getAgentsByEnvironment(environmentId: string): AgentRow[] {
+  return db
+    .select()
+    .from(agents)
+    .where(eq(agents.environmentId, environmentId))
+    .orderBy(asc(agents.name))
+    .all();
 }

--- a/packages/database/src/db-seed.test.ts
+++ b/packages/database/src/db-seed.test.ts
@@ -49,7 +49,9 @@ function createSchema(db: InstanceType<typeof Database>): void {
       workpad        TEXT NOT NULL DEFAULT '',
       schedule_id    TEXT NOT NULL DEFAULT '',
       token_budget  INTEGER NOT NULL DEFAULT 0,
-      cost_budget_millicents INTEGER NOT NULL DEFAULT 0
+      cost_budget_millicents INTEGER NOT NULL DEFAULT 0,
+      agent_id       TEXT,
+      kind           TEXT NOT NULL DEFAULT 'task'
     );
 
     CREATE TABLE IF NOT EXISTS settings (

--- a/packages/database/src/db-seed.ts
+++ b/packages/database/src/db-seed.ts
@@ -161,11 +161,13 @@ IMPORTANT: The PR is the deliverable, but a PR with failing CI or unresolved rev
   }
 
   // Seed: create root task (well-known "system" task) if it doesn't exist.
+  // `kind='root'` matches the v21 migration's UPDATE — fresh installs and
+  // migrated installs both end up with the system root tagged consistently.
   conn
     .prepare(
       `
-      INSERT OR IGNORE INTO tasks (id, workspace_id, title, description, status, branch, parent_task_id, depth, can_decompose, default_persona_id)
-      VALUES (?, NULL, 'System', '', 'not_started', 'system', '', 0, 1, ?)
+      INSERT OR IGNORE INTO tasks (id, workspace_id, title, description, status, branch, parent_task_id, depth, can_decompose, default_persona_id, kind)
+      VALUES (?, NULL, 'System', '', 'not_started', 'system', '', 0, 1, ?, 'root')
     `,
     )
     .run(ROOT_TASK_ID, SYSTEM_PERSONA_ID);

--- a/packages/database/src/db.test.ts
+++ b/packages/database/src/db.test.ts
@@ -353,6 +353,87 @@ describe("initDatabase", () => {
       primary_persona_id: "claude-code",
     });
   });
+
+  it("migration v21 — adds tasks.agent_id + tasks.kind + agents.environment_id (#1418)", () => {
+    const mem = new Database(":memory:");
+    mem.pragma("foreign_keys = ON");
+
+    // Step 1: create the current schema so all tables exist.
+    initDatabase(mem);
+
+    // Step 2: simulate a pre-v21 database — drop indices FIRST (SQLite
+    // refuses DROP COLUMN if an index references the column), then the
+    // columns, then rewind user_version.
+    mem.exec("DROP INDEX IF EXISTS idx_tasks_agent_id");
+    mem.exec("DROP INDEX IF EXISTS idx_tasks_kind");
+    mem.exec("DROP INDEX IF EXISTS idx_agents_environment_id");
+    mem.exec("ALTER TABLE tasks DROP COLUMN agent_id");
+    mem.exec("ALTER TABLE tasks DROP COLUMN kind");
+    mem.exec("ALTER TABLE agents DROP COLUMN environment_id");
+    mem.pragma("user_version = 20");
+
+    // Sanity: columns gone.
+    const preTaskCols = mem.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+    expect(preTaskCols.map((c) => c.name)).not.toContain("agent_id");
+    expect(preTaskCols.map((c) => c.name)).not.toContain("kind");
+
+    // Step 3: run migration.
+    initDatabase(mem);
+
+    // Assert: schema version advanced to current.
+    expect(getUserVersion(mem)).toBe(CURRENT_VERSION);
+
+    // Assert: columns exist.
+    const taskCols = mem.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+    expect(taskCols.map((c) => c.name)).toContain("agent_id");
+    expect(taskCols.map((c) => c.name)).toContain("kind");
+    const agentCols = mem.prepare("PRAGMA table_info(agents)").all() as Array<{ name: string }>;
+    expect(agentCols.map((c) => c.name)).toContain("environment_id");
+
+    // Assert: indices exist.
+    const indices = mem
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('idx_tasks_agent_id', 'idx_tasks_kind', 'idx_agents_environment_id')",
+      )
+      .all() as Array<{ name: string }>;
+    expect(indices.map((i) => i.name).sort()).toEqual([
+      "idx_agents_environment_id",
+      "idx_tasks_agent_id",
+      "idx_tasks_kind",
+    ]);
+
+    // Assert: a task row round-trips with the new columns. The FK requires
+    // the referenced agent to exist.
+    mem
+      .prepare(
+        "INSERT INTO agents (id, name, primary_persona_id, environment_id) VALUES (?, ?, ?, ?)",
+      )
+      .run("a1", "Refactor Bot", "claude-code", "local");
+    mem
+      .prepare(
+        "INSERT INTO tasks (id, title, kind, agent_id, parent_task_id) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("t1", "A task", "task", "a1", "");
+    const taskRow = mem.prepare("SELECT id, kind, agent_id FROM tasks WHERE id = 't1'").get() as
+      | Record<string, unknown>
+      | undefined;
+    expect(taskRow).toMatchObject({ id: "t1", kind: "task", agent_id: "a1" });
+
+    // Assert: existing tasks (the system root, seeded earlier) got kind='root'
+    // via the migration's UPDATE. Note: seedDatabase wasn't called here, so the
+    // system root doesn't exist yet — instead, exercise the UPDATE path by
+    // inserting a 'system' row before re-running.
+    mem.exec("DELETE FROM tasks WHERE id = 'system'");
+    mem.prepare("INSERT INTO tasks (id, title, kind) VALUES ('system', 'System', 'task')").run();
+    // Re-run initDatabase: the migration is already at CURRENT_VERSION so the
+    // UPDATE inside the v21 `up` won't re-fire. Instead, manually invoke the
+    // same SQL to prove it's idempotent and correctly targeted.
+    mem.exec("UPDATE tasks SET kind = 'root' WHERE id = 'system' AND kind = 'task'");
+    const sys = mem.prepare("SELECT kind FROM tasks WHERE id = 'system'").get() as
+      | { kind: string }
+      | undefined;
+    expect(sys?.kind).toBe("root");
+  });
 });
 
 describe("checkDatabaseIntegrity", () => {

--- a/packages/database/src/db.ts
+++ b/packages/database/src/db.ts
@@ -404,6 +404,47 @@ const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    version: 21,
+    name: "agent-task-ownership",
+    up: (conn) => {
+      // Agent task ownership (#1418, epic #1412): Agent becomes the principal
+      // that owns tasks. Adds `tasks.agent_id` (nullable FK), `tasks.kind`
+      // discriminator (reserved values root | schedule_rule | schedule_fire |
+      // channel_config | channel_thread), and `agents.environment_id` (the
+      // Agent's home environment — required at the handler layer; defaults
+      // to '' at the column level so the ALTER succeeds on existing rows).
+      const taskCols = conn.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+      if (!taskCols.some((c) => c.name === "agent_id")) {
+        // Nullable FK so today's user-driven tasks (agent_id = NULL) keep
+        // working unchanged. Per repo convention (see schema.ts) FKs are
+        // declared but ON DELETE CASCADE is not used; application-level
+        // cleanup runs in agent-handlers.deleteAgent.
+        conn.exec("ALTER TABLE tasks ADD COLUMN agent_id TEXT REFERENCES agents(id)");
+      }
+      if (!taskCols.some((c) => c.name === "kind")) {
+        conn.exec("ALTER TABLE tasks ADD COLUMN kind TEXT NOT NULL DEFAULT 'task'");
+      }
+
+      const agentCols = conn.prepare("PRAGMA table_info(agents)").all() as Array<{
+        name: string;
+      }>;
+      if (!agentCols.some((c) => c.name === "environment_id")) {
+        conn.exec("ALTER TABLE agents ADD COLUMN environment_id TEXT NOT NULL DEFAULT ''");
+      }
+
+      // Stamp the long-standing system root task with kind='root' so the
+      // discriminator is consistent across fresh installs (see db-seed.ts)
+      // and migrated installs.
+      conn.exec("UPDATE tasks SET kind = 'root' WHERE id = 'system' AND kind = 'task'");
+
+      // Indices: agent_id is the merged-feed lookup key (#1419); kind is the
+      // chip filter; environment_id supports listing agents per environment.
+      conn.exec("CREATE INDEX IF NOT EXISTS idx_tasks_agent_id ON tasks(agent_id)");
+      conn.exec("CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)");
+      conn.exec("CREATE INDEX IF NOT EXISTS idx_agents_environment_id ON agents(environment_id)");
+    },
+  },
 ];
 
 /** The highest schema version defined by BASELINE + MIGRATIONS. */

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -52,6 +52,8 @@ export type {
   NewChannelGrant,
   StreamMessageRow,
   SessionActionRow,
+  AgentRow,
+  NewAgent,
 } from "./schema.js";
 
 // ─── Stores ────────────────────────────────────────────────

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -177,6 +177,20 @@ export const tasks = sqliteTable("tasks", {
   scheduleId: text("schedule_id").notNull().default(""),
   tokenBudget: integer("token_budget").notNull().default(0),
   costBudgetMillicents: integer("cost_budget_millicents").notNull().default(0),
+  /**
+   * Owning Agent (#1418, epic #1412). NULL = today's user-driven path; set =
+   * task is part of an Agent's tree (root, schedule fire, channel thread, etc.).
+   * Note: this is the Grackle Agent entity id, NOT the ACP runtime "agent id"
+   * used inside session metadata — those are unrelated despite the name collision.
+   */
+  agentId: text("agent_id").references(() => agents.id),
+  /**
+   * Discriminator for agent-owned tasks (#1418). Default `task` matches today's
+   * user-driven tasks. Reserved values: `root | schedule_rule | schedule_fire |
+   * channel_config | channel_thread` — only `task` and `root` are populated in
+   * #1418; the others are reserved for #1439 / #1421.
+   */
+  kind: text("kind").notNull().default("task"),
 });
 
 /** Row shape returned by a SELECT on the tasks table. */
@@ -255,6 +269,14 @@ export const agents = sqliteTable("agents", {
   name: text("name").notNull().unique(),
   avatar: text("avatar").notNull().default(""),
   primaryPersonaId: text("primary_persona_id").notNull().default(""),
+  /**
+   * The Agent's home environment (#1418, epic #1412). Required at the handler
+   * layer (`agent-handlers.createAgent` validates non-empty + existence).
+   * Defaults to '' at the column level so the v21 ALTER succeeds on
+   * pre-existing rows; the only such rows in the wild are dev-only #1417
+   * test fixtures.
+   */
+  environmentId: text("environment_id").notNull().default(""),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(datetime('now'))`),

--- a/packages/database/src/task-store.test.ts
+++ b/packages/database/src/task-store.test.ts
@@ -52,7 +52,9 @@ function applySchema(): void {
       workpad       TEXT NOT NULL DEFAULT '',
       schedule_id   TEXT NOT NULL DEFAULT '',
       token_budget  INTEGER NOT NULL DEFAULT 0,
-      cost_budget_millicents INTEGER NOT NULL DEFAULT 0
+      cost_budget_millicents INTEGER NOT NULL DEFAULT 0,
+      agent_id      TEXT,
+      kind          TEXT NOT NULL DEFAULT 'task'
     );
   `);
 }

--- a/packages/database/src/task-store.ts
+++ b/packages/database/src/task-store.ts
@@ -24,6 +24,16 @@ export interface InsertTaskFields {
   defaultPersonaId: string;
   tokenBudget: number;
   costBudgetMillicents: number;
+  /**
+   * Owning Agent id (#1418). NULL/undefined = user-driven task (today's path).
+   * Set = the task is part of an Agent's tree.
+   */
+  agentId?: string;
+  /**
+   * Discriminator for agent-spawned tasks (#1418). Defaults to `task`.
+   * Reserved values: `root | schedule_rule | schedule_fire | channel_config | channel_thread`.
+   */
+  kind?: string;
 }
 
 /**
@@ -59,6 +69,8 @@ export function insertTask(fields: InsertTaskFields): void {
       defaultPersonaId: fields.defaultPersonaId,
       tokenBudget: fields.tokenBudget,
       costBudgetMillicents: fields.costBudgetMillicents,
+      agentId: fields.agentId ?? null,
+      kind: fields.kind ?? "task",
     })
     .run();
 }
@@ -81,6 +93,8 @@ export function createTask(
   tokenBudget: number = 0,
   costBudgetMillicents: number = 0,
   injectKnowledge: boolean = true,
+  agentId?: string,
+  kind?: string,
 ): void {
   let depth = 0;
   let branch: string;
@@ -122,6 +136,8 @@ export function createTask(
     defaultPersonaId,
     tokenBudget,
     costBudgetMillicents,
+    agentId,
+    kind,
   });
 }
 
@@ -477,4 +493,22 @@ export function reparentTask(taskId: string, newParentTaskId: string): void {
  */
 export function getOrphanedTasks(parentTaskId: string): TaskRow[] {
   return getChildren(parentTaskId).filter((child) => !TERMINAL_TASK_STATUSES.has(child.status));
+}
+
+/**
+ * Return the root task for a given Agent — the singleton task with
+ * `agent_id = agentId AND kind = 'root'`. Returns `undefined` when the
+ * Agent has no root yet (the auto-create subscriber runs on `agent.created`).
+ */
+export function getRootTaskForAgent(agentId: string): TaskRow | undefined {
+  return db
+    .select()
+    .from(tasks)
+    .where(and(eq(tasks.agentId, agentId), eq(tasks.kind, "root")))
+    .get();
+}
+
+/** Return all tasks owned by an Agent (root + descendants). Used for cascade-delete. */
+export function getTasksForAgent(agentId: string): TaskRow[] {
+  return db.select().from(tasks).where(eq(tasks.agentId, agentId)).all();
 }

--- a/packages/plugin-core/src/agent-handlers.test.ts
+++ b/packages/plugin-core/src/agent-handlers.test.ts
@@ -3,8 +3,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // Mock the database layer used by the agent handlers.
 const mockDb: {
   agents: Map<string, Record<string, unknown>>;
+  environments: Map<string, Record<string, unknown>>;
+  /** Tasks owned by an agent, keyed by agentId. */
+  agentTasks: Map<string, Array<Record<string, unknown>>>;
+  /** Sessions belonging to a task, keyed by taskId. */
+  taskSessions: Map<string, Array<Record<string, unknown>>>;
+  /** Tasks that have been deleted via deleteTask, for assertions. */
+  deletedTaskIds: string[];
 } = {
   agents: new Map(),
+  environments: new Map([["local", { id: "local", displayName: "Local" }]]),
+  agentTasks: new Map(),
+  taskSessions: new Map(),
+  deletedTaskIds: [],
 };
 
 vi.mock("@grackle-ai/database", () => ({
@@ -16,12 +27,19 @@ vi.mock("@grackle-ai/database", () => ({
     getAgent: (id: string): Record<string, unknown> | undefined => mockDb.agents.get(id),
     getAgentByName: (name: string): Record<string, unknown> | undefined =>
       [...mockDb.agents.values()].find((a) => (a as { name: string }).name === name),
-    createAgent: (id: string, name: string, avatar: string, primaryPersonaId: string): void => {
+    createAgent: (
+      id: string,
+      name: string,
+      avatar: string,
+      primaryPersonaId: string,
+      environmentId: string,
+    ): void => {
       mockDb.agents.set(id, {
         id,
         name,
         avatar,
         primaryPersonaId,
+        environmentId,
         createdAt: "2024-01-01",
         updatedAt: "2024-01-01",
       });
@@ -45,7 +63,29 @@ vi.mock("@grackle-ai/database", () => ({
       mockDb.agents.delete(id);
     },
   },
+  envRegistry: {
+    getEnvironment: (id: string): Record<string, unknown> | undefined =>
+      mockDb.environments.get(id),
+  },
+  sessionStore: {
+    listSessionsForTask: (taskId: string): Array<Record<string, unknown>> =>
+      mockDb.taskSessions.get(taskId) ?? [],
+  },
+  taskStore: {
+    getTasksForAgent: (agentId: string): Array<Record<string, unknown>> =>
+      mockDb.agentTasks.get(agentId) ?? [],
+    deleteTask: (id: string): void => {
+      mockDb.deletedTaskIds.push(id);
+    },
+  },
   slugify: (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+}));
+
+// killSessionAndCleanup is imported from grpc-shared. Mock the module to
+// record calls without pulling in the real streamHub / lifecycle plumbing.
+const killSessionMock = vi.fn();
+vi.mock("./grpc-shared.js", () => ({
+  killSessionAndCleanup: (session: Record<string, unknown>): void => killSessionMock(session),
 }));
 
 const emitMock = vi.fn();
@@ -60,12 +100,17 @@ import * as agentHandlers from "./agent-handlers.js";
 describe("agent-handlers", () => {
   beforeEach(() => {
     mockDb.agents.clear();
+    mockDb.agentTasks.clear();
+    mockDb.taskSessions.clear();
+    mockDb.deletedTaskIds = [];
     emitMock.mockClear();
+    killSessionMock.mockClear();
   });
 
   it("createAgent + listAgents round-trip and emits agent.created", async () => {
     const created = await agentHandlers.createAgent(
       create(grackle.CreateAgentRequestSchema, {
+        environmentId: "local",
         name: "Refactor Bot",
         avatar: "🐦",
         primaryPersonaId: "p1",
@@ -82,15 +127,19 @@ describe("agent-handlers", () => {
   });
 
   it("lists agents ordered by name", async () => {
-    await agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "Zeta" }));
-    await agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "Alpha" }));
+    await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Zeta" }),
+    );
+    await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Alpha" }),
+    );
     const list = await agentHandlers.listAgents();
     expect(list.agents.map((a) => a.name)).toEqual(["Alpha", "Zeta"]);
   });
 
   it("getAgent returns a created agent", async () => {
     const created = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "Findable" }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Findable" }),
     );
     const got = await agentHandlers.getAgent(create(grackle.AgentIdSchema, { id: created.id }));
     expect(got.name).toBe("Findable");
@@ -103,15 +152,20 @@ describe("agent-handlers", () => {
   });
 
   it("createAgent rejects a duplicate name", async () => {
-    await agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "Dupe" }));
+    await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Dupe" }),
+    );
     await expect(
-      agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "Dupe" })),
+      agentHandlers.createAgent(
+        create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Dupe" }),
+      ),
     ).rejects.toThrow(/already exists/i);
   });
 
   it("updateAgent changes only provided fields and emits agent.updated", async () => {
     const created = await agentHandlers.createAgent(
       create(grackle.CreateAgentRequestSchema, {
+        environmentId: "local",
         name: "Before",
         avatar: "x",
         primaryPersonaId: "p1",
@@ -128,7 +182,7 @@ describe("agent-handlers", () => {
 
   it("deleteAgent removes the agent and emits agent.deleted", async () => {
     const created = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "Doomed" }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Doomed" }),
     );
     await agentHandlers.deleteAgent(create(grackle.AgentIdSchema, { id: created.id }));
     expect(mockDb.agents.has(created.id)).toBe(false);
@@ -137,20 +191,22 @@ describe("agent-handlers", () => {
 
   it("createAgent trims whitespace from the name and stores the trimmed value", async () => {
     const created = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "  Trimmed  " }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "  Trimmed  " }),
     );
     expect(created.name).toBe("Trimmed");
   });
 
   it("createAgent rejects a whitespace-only name", async () => {
     await expect(
-      agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "   " })),
+      agentHandlers.createAgent(
+        create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "   " }),
+      ),
     ).rejects.toThrow(/name is required/i);
   });
 
   it("updateAgent rejects an explicitly-empty name (presence-tracked)", async () => {
     const created = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "Keep" }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Keep" }),
     );
     await expect(
       agentHandlers.updateAgent(
@@ -166,7 +222,7 @@ describe("agent-handlers", () => {
 
   it("updateAgent rejects a request with no updatable fields", async () => {
     const created = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "NoOp" }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "NoOp" }),
     );
     await expect(
       agentHandlers.updateAgent(create(grackle.UpdateAgentRequestSchema, { id: created.id })),
@@ -176,6 +232,7 @@ describe("agent-handlers", () => {
   it("createAgent trims avatar and primaryPersonaId before storing", async () => {
     const created = await agentHandlers.createAgent(
       create(grackle.CreateAgentRequestSchema, {
+        environmentId: "local",
         name: "Trimmer",
         avatar: "   ",
         primaryPersonaId: "  claude-code  ",
@@ -189,6 +246,7 @@ describe("agent-handlers", () => {
   it("updateAgent trims avatar / primaryPersonaId; empty string clears, undefined preserves", async () => {
     const created = await agentHandlers.createAgent(
       create(grackle.CreateAgentRequestSchema, {
+        environmentId: "local",
         name: "Clearer",
         avatar: "X",
         primaryPersonaId: "p1",
@@ -214,9 +272,11 @@ describe("agent-handlers", () => {
   });
 
   it("updateAgent trims the name and rejects a name colliding with another agent", async () => {
-    await agentHandlers.createAgent(create(grackle.CreateAgentRequestSchema, { name: "Taken" }));
+    await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Taken" }),
+    );
     const other = await agentHandlers.createAgent(
-      create(grackle.CreateAgentRequestSchema, { name: "Other" }),
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Other" }),
     );
     // Trimming applies before the duplicate check.
     await expect(
@@ -224,5 +284,94 @@ describe("agent-handlers", () => {
         create(grackle.UpdateAgentRequestSchema, { id: other.id, name: "  Taken  " }),
       ),
     ).rejects.toThrow(/already exists/i);
+  });
+
+  // ── #1418 — environment validation + cascade delete ─────────────────
+
+  it("createAgent rejects an empty environment_id", async () => {
+    await expect(
+      agentHandlers.createAgent(
+        create(grackle.CreateAgentRequestSchema, { name: "NoEnv", environmentId: "" }),
+      ),
+    ).rejects.toThrow(/environment_id is required/i);
+  });
+
+  it("createAgent rejects a whitespace-only environment_id", async () => {
+    await expect(
+      agentHandlers.createAgent(
+        create(grackle.CreateAgentRequestSchema, { name: "BlankEnv", environmentId: "   " }),
+      ),
+    ).rejects.toThrow(/environment_id is required/i);
+  });
+
+  it("createAgent rejects an unknown environment id with NotFound", async () => {
+    await expect(
+      agentHandlers.createAgent(
+        create(grackle.CreateAgentRequestSchema, {
+          name: "Ghosted",
+          environmentId: "does-not-exist",
+        }),
+      ),
+    ).rejects.toThrow(/environment not found/i);
+  });
+
+  it("createAgent emits agent.created with environmentId in the payload", async () => {
+    await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { name: "WithEnv", environmentId: "local" }),
+    );
+    expect(emitMock).toHaveBeenCalledWith(
+      "agent.created",
+      expect.objectContaining({ environmentId: "local" }),
+    );
+  });
+
+  it("createAgent exposes environment_id on the returned proto", async () => {
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { name: "WithEnv2", environmentId: "local" }),
+    );
+    expect(created.environmentId).toBe("local");
+  });
+
+  it("deleteAgent kills non-terminal sessions, deletes descendant tasks, then the agent", async () => {
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { name: "Cascade", environmentId: "local" }),
+    );
+    // Seed the mock with a root task + one child task; the root has a live session.
+    const rootTaskId = `${created.id}-root`;
+    const childTaskId = `${created.id}-child`;
+    mockDb.agentTasks.set(created.id, [
+      { id: rootTaskId, kind: "root", agentId: created.id },
+      { id: childTaskId, kind: "task", agentId: created.id, parentTaskId: rootTaskId },
+    ]);
+    mockDb.taskSessions.set(rootTaskId, [
+      { id: "s-root-1", taskId: rootTaskId, status: "running" },
+    ]);
+    mockDb.taskSessions.set(childTaskId, []);
+
+    await agentHandlers.deleteAgent(create(grackle.AgentIdSchema, { id: created.id }));
+
+    // Live session got killed.
+    expect(killSessionMock).toHaveBeenCalledTimes(1);
+    expect(killSessionMock).toHaveBeenCalledWith(expect.objectContaining({ id: "s-root-1" }));
+    // Both tasks deleted (in some order).
+    expect(mockDb.deletedTaskIds.sort()).toEqual([childTaskId, rootTaskId].sort());
+    // Agent row removed.
+    expect(mockDb.agents.has(created.id)).toBe(false);
+    // agent.deleted event fired.
+    expect(emitMock).toHaveBeenCalledWith(
+      "agent.deleted",
+      expect.objectContaining({ agentId: created.id }),
+    );
+  });
+
+  it("deleteAgent on an agent with no tasks is a no-op cascade", async () => {
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { name: "Lonely", environmentId: "local" }),
+    );
+    // No agentTasks entry → getTasksForAgent returns [].
+    await agentHandlers.deleteAgent(create(grackle.AgentIdSchema, { id: created.id }));
+    expect(killSessionMock).not.toHaveBeenCalled();
+    expect(mockDb.deletedTaskIds).toEqual([]);
+    expect(mockDb.agents.has(created.id)).toBe(false);
   });
 });

--- a/packages/plugin-core/src/agent-handlers.ts
+++ b/packages/plugin-core/src/agent-handlers.ts
@@ -12,11 +12,12 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import { agentStore } from "@grackle-ai/database";
+import { agentStore, envRegistry, sessionStore, taskStore } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { slugify } from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
 import { agentRowToProto } from "./grpc-proto-converters.js";
+import { killSessionAndCleanup } from "./grpc-shared.js";
 
 /** List all agents. */
 export async function listAgents(): Promise<grackle.AgentList> {
@@ -36,6 +37,17 @@ export async function createAgent(req: grackle.CreateAgentRequest): Promise<grac
     throw new ConnectError(`Agent with name "${name}" already exists`, Code.AlreadyExists);
   }
 
+  // The Agent's home environment is required (#1418): an Agent without an
+  // environment can't be the principal for autonomous work since the runtime
+  // needs a place to live. Validation: non-empty + environment exists.
+  const environmentId = req.environmentId.trim();
+  if (!environmentId) {
+    throw new ConnectError("Agent environment_id is required", Code.InvalidArgument);
+  }
+  if (!envRegistry.getEnvironment(environmentId)) {
+    throw new ConnectError(`Environment not found: ${environmentId}`, Code.NotFound);
+  }
+
   // Enforce a unique ID derived from the name (mirrors persona handling).
   let id = slugify(name) || uuid().slice(0, 8);
   if (agentStore.getAgent(id)) {
@@ -47,8 +59,8 @@ export async function createAgent(req: grackle.CreateAgentRequest): Promise<grac
   // (otherwise a string of spaces is truthy and skips the monogram fallback)
   // and prevents " https://..." style values from breaking the isImageAvatar
   // prefix check downstream.
-  agentStore.createAgent(id, name, req.avatar.trim(), req.primaryPersonaId.trim());
-  emit("agent.created", { agentId: id });
+  agentStore.createAgent(id, name, req.avatar.trim(), req.primaryPersonaId.trim(), environmentId);
+  emit("agent.created", { agentId: id, environmentId });
   const row = agentStore.getAgent(id);
   return agentRowToProto(row!);
 }
@@ -99,8 +111,30 @@ export async function updateAgent(req: grackle.UpdateAgentRequest): Promise<grac
   return agentRowToProto(row!);
 }
 
-/** Delete an agent by ID. */
+/**
+ * Delete an agent. Cascades through the Agent's task subtree (#1418):
+ *
+ * 1. Resolve the Agent's tasks (root + descendants — every task with this
+ *    `agent_id`).
+ * 2. Kill any non-terminal sessions attached to those tasks via
+ *    {@link killSessionAndCleanup} so live runs don't keep ticking after
+ *    the Agent disappears.
+ * 3. Delete every task that belongs to the Agent.
+ * 4. Delete the Agent row and emit `agent.deleted`.
+ *
+ * This is application-level cascade — the schema declares the FK but no
+ * `ON DELETE CASCADE` (project convention; see `db.ts` migration comments).
+ */
 export async function deleteAgent(req: grackle.AgentId): Promise<grackle.Empty> {
+  const agentTasks = taskStore.getTasksForAgent(req.id);
+  for (const task of agentTasks) {
+    for (const session of sessionStore.listSessionsForTask(task.id)) {
+      killSessionAndCleanup(session);
+    }
+  }
+  for (const task of agentTasks) {
+    taskStore.deleteTask(task.id);
+  }
   agentStore.deleteAgent(req.id);
   emit("agent.deleted", { agentId: req.id });
   return create(grackle.EmptySchema, {});

--- a/packages/plugin-core/src/agent-root-task-boot.test.ts
+++ b/packages/plugin-core/src/agent-root-task-boot.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { AgentRow, TaskRow } from "@grackle-ai/database";
+import type { GrackleEvent, PluginContext } from "@grackle-ai/core";
+import {
+  handleAgentCreated,
+  createAgentRootTaskSubscriber,
+  type AgentRootTaskBootDeps,
+} from "./agent-root-task-boot.js";
+
+interface InsertedTask {
+  id: string;
+  title: string;
+  agentId?: string;
+  kind?: string;
+  parentTaskId: string;
+  depth: number;
+  canDecompose: boolean;
+  defaultPersonaId: string;
+}
+
+interface MockState {
+  agents: Map<string, AgentRow>;
+  rootByAgent: Map<string, TaskRow>;
+  inserted: InsertedTask[];
+  idCounter: number;
+}
+
+function buildDeps(state: MockState): AgentRootTaskBootDeps {
+  return {
+    getAgent: (id) => state.agents.get(id),
+    getRootTaskForAgent: (agentId) => state.rootByAgent.get(agentId),
+    insertTask: (fields) => {
+      state.inserted.push({
+        id: fields.id,
+        title: fields.title,
+        agentId: fields.agentId,
+        kind: fields.kind,
+        parentTaskId: fields.parentTaskId,
+        depth: fields.depth,
+        canDecompose: fields.canDecompose,
+        defaultPersonaId: fields.defaultPersonaId,
+      });
+      // After insert, the next getRootTaskForAgent should return this row.
+      // Build a minimal TaskRow shape — the subscriber only ever reads it
+      // back via `getRootTaskForAgent` in the idempotency check, which
+      // doesn't inspect any column. A typed cast keeps the test honest.
+      state.rootByAgent.set(fields.agentId!, {
+        id: fields.id,
+        title: fields.title,
+        agentId: fields.agentId ?? null,
+        kind: fields.kind ?? "task",
+      } as unknown as TaskRow);
+    },
+    newId: () => {
+      state.idCounter += 1;
+      return `root-task-${state.idCounter}`;
+    },
+  };
+}
+
+function makeAgent(id: string, name: string, personaId = "claude-code"): AgentRow {
+  return {
+    id,
+    name,
+    avatar: "",
+    primaryPersonaId: personaId,
+    environmentId: "local",
+    createdAt: "2026-05-31T00:00:00.000Z",
+    updatedAt: "2026-05-31T00:00:00.000Z",
+  };
+}
+
+describe("handleAgentCreated", () => {
+  let state: MockState;
+  let deps: AgentRootTaskBootDeps;
+
+  beforeEach(() => {
+    state = {
+      agents: new Map(),
+      rootByAgent: new Map(),
+      inserted: [],
+      idCounter: 0,
+    };
+    deps = buildDeps(state);
+  });
+
+  it("creates a root task for a newly-created agent", () => {
+    state.agents.set("a1", makeAgent("a1", "Refactor Bot", "claude-code"));
+
+    handleAgentCreated(deps, { agentId: "a1" });
+
+    expect(state.inserted).toHaveLength(1);
+    const t = state.inserted[0];
+    expect(t.title).toBe("Refactor Bot");
+    expect(t.kind).toBe("root");
+    expect(t.agentId).toBe("a1");
+    expect(t.parentTaskId).toBe("");
+    expect(t.depth).toBe(0);
+    expect(t.canDecompose).toBe(true);
+    expect(t.defaultPersonaId).toBe("claude-code");
+  });
+
+  it("is idempotent — running the handler twice creates only one root task", () => {
+    state.agents.set("a1", makeAgent("a1", "Refactor Bot"));
+
+    handleAgentCreated(deps, { agentId: "a1" });
+    handleAgentCreated(deps, { agentId: "a1" });
+
+    expect(state.inserted).toHaveLength(1);
+  });
+
+  it("is a no-op when the agent has already been deleted", () => {
+    // No agent stored — simulates the race where agent.created fires then
+    // agent.deleted lands before this handler runs.
+    handleAgentCreated(deps, { agentId: "ghost" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("preserves each agent's own root in a multi-agent scenario", () => {
+    state.agents.set("a1", makeAgent("a1", "Bot One"));
+    state.agents.set("a2", makeAgent("a2", "Bot Two", "codex"));
+
+    handleAgentCreated(deps, { agentId: "a1" });
+    handleAgentCreated(deps, { agentId: "a2" });
+
+    expect(state.inserted).toHaveLength(2);
+    expect(state.inserted[0].agentId).toBe("a1");
+    expect(state.inserted[0].defaultPersonaId).toBe("claude-code");
+    expect(state.inserted[1].agentId).toBe("a2");
+    expect(state.inserted[1].defaultPersonaId).toBe("codex");
+  });
+
+  it("propagates the agent's primary persona id to the root task default", () => {
+    state.agents.set("a1", makeAgent("a1", "X", "my-persona"));
+    handleAgentCreated(deps, { agentId: "a1" });
+    expect(state.inserted[0].defaultPersonaId).toBe("my-persona");
+  });
+});
+
+describe("createAgentRootTaskSubscriber", () => {
+  it("fires handleAgentCreated when an agent.created event arrives", () => {
+    const state: MockState = {
+      agents: new Map([["a1", makeAgent("a1", "Subbed Bot")]]),
+      rootByAgent: new Map(),
+      inserted: [],
+      idCounter: 0,
+    };
+    const deps = buildDeps(state);
+
+    // Capture the subscriber callback by spying on ctx.subscribe.
+    let captured: ((event: GrackleEvent) => void) | undefined;
+    const ctx: PluginContext = {
+      subscribe: vi.fn((cb) => {
+        captured = cb;
+        return () => {};
+      }),
+      emit: vi.fn(),
+    };
+
+    const disposable = createAgentRootTaskSubscriber(ctx, deps);
+    expect(ctx.subscribe).toHaveBeenCalledTimes(1);
+    expect(captured).toBeDefined();
+
+    captured!({
+      type: "agent.created",
+      payload: { agentId: "a1" },
+      timestamp: "2026-05-31T00:00:00.000Z",
+    } as GrackleEvent);
+
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0].agentId).toBe("a1");
+
+    disposable.dispose();
+  });
+
+  it("ignores events of other types", () => {
+    const state: MockState = {
+      agents: new Map([["a1", makeAgent("a1", "Ignore Me")]]),
+      rootByAgent: new Map(),
+      inserted: [],
+      idCounter: 0,
+    };
+    const deps = buildDeps(state);
+
+    let captured: ((event: GrackleEvent) => void) | undefined;
+    const ctx: PluginContext = {
+      subscribe: vi.fn((cb) => {
+        captured = cb;
+        return () => {};
+      }),
+      emit: vi.fn(),
+    };
+
+    createAgentRootTaskSubscriber(ctx, deps);
+
+    captured!({
+      type: "agent.updated",
+      payload: { agentId: "a1" },
+      timestamp: "2026-05-31T00:00:00.000Z",
+    } as GrackleEvent);
+
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("ignores agent.created events with no agentId in payload", () => {
+    const state: MockState = {
+      agents: new Map(),
+      rootByAgent: new Map(),
+      inserted: [],
+      idCounter: 0,
+    };
+    const deps = buildDeps(state);
+
+    let captured: ((event: GrackleEvent) => void) | undefined;
+    const ctx: PluginContext = {
+      subscribe: vi.fn((cb) => {
+        captured = cb;
+        return () => {};
+      }),
+      emit: vi.fn(),
+    };
+
+    createAgentRootTaskSubscriber(ctx, deps);
+
+    captured!({
+      type: "agent.created",
+      payload: {},
+      timestamp: "2026-05-31T00:00:00.000Z",
+    } as GrackleEvent);
+
+    expect(state.inserted).toHaveLength(0);
+  });
+});

--- a/packages/plugin-core/src/agent-root-task-boot.ts
+++ b/packages/plugin-core/src/agent-root-task-boot.ts
@@ -1,0 +1,129 @@
+/**
+ * Auto-create the root task for a new Agent (#1418).
+ *
+ * Listens for `agent.created` and inserts a `kind=root` task tied to the
+ * Agent. Idempotent: re-emitting the event (or seeing it twice via
+ * domain-events replay) is a no-op when the root already exists.
+ *
+ * This module is deliberately thin — no reanimation, no backoff. The Agent's
+ * root task is an inert anchor that future tickets (heartbeat #1438,
+ * schedule reroute #1439, channels #1421) attach sessions/children under.
+ *
+ * @module
+ */
+
+import type { AgentRow, TaskRow } from "@grackle-ai/database";
+import type { Disposable, GrackleEvent, PluginContext } from "@grackle-ai/core";
+import { logger } from "@grackle-ai/core";
+
+/** Dependencies injected for testability. */
+export interface AgentRootTaskBootDeps {
+  /** Look up an Agent by id. Returns `undefined` if the agent was deleted before the subscriber ran. */
+  getAgent: (id: string) => AgentRow | undefined;
+  /** Look up the existing root task for an Agent (`kind=root`). Returns `undefined` if none. */
+  getRootTaskForAgent: (agentId: string) => TaskRow | undefined;
+  /** Insert a task row. Mirrors `taskStore.insertTask`'s shape. */
+  insertTask: (fields: {
+    id: string;
+    title: string;
+    description: string;
+    branch: string;
+    dependsOn: string[];
+    parentTaskId: string;
+    depth: number;
+    canDecompose: boolean;
+    injectKnowledge: boolean;
+    defaultPersonaId: string;
+    tokenBudget: number;
+    costBudgetMillicents: number;
+    agentId?: string;
+    kind?: string;
+  }) => void;
+  /** Mint a fresh task id. UUID factory injected so tests can be deterministic. */
+  newId: () => string;
+}
+
+/**
+ * Idempotent root-task creation for an `agent.created` event.
+ *
+ * Exported separately from the subscriber factory so unit tests can drive
+ * the handler synchronously without going through the event bus.
+ */
+export function handleAgentCreated(
+  deps: AgentRootTaskBootDeps,
+  payload: { agentId: string },
+): void {
+  const agent = deps.getAgent(payload.agentId);
+  if (!agent) {
+    // Agent was deleted between emit and handler-fire. Safe no-op.
+    logger.debug(
+      { agentId: payload.agentId },
+      "agent-root-task-boot: agent no longer exists, skipping root task creation",
+    );
+    return;
+  }
+  if (deps.getRootTaskForAgent(agent.id)) {
+    // Already created (subscriber re-fire, server restart with persisted events, etc.).
+    return;
+  }
+  deps.insertTask({
+    id: deps.newId(),
+    title: agent.name,
+    description: "",
+    branch: "",
+    dependsOn: [],
+    parentTaskId: "",
+    depth: 0,
+    canDecompose: true,
+    // Root tasks for agents don't need KG injection — they're inert anchors
+    // until a wake-up surface (#1438/#1439/#1421) attaches real work.
+    injectKnowledge: false,
+    defaultPersonaId: agent.primaryPersonaId,
+    tokenBudget: 0,
+    costBudgetMillicents: 0,
+    agentId: agent.id,
+    kind: "root",
+  });
+  logger.debug(
+    { agentId: agent.id, agentName: agent.name },
+    "agent-root-task-boot: created root task",
+  );
+}
+
+/**
+ * Create the agent-root-task subscriber.
+ *
+ * Subscribes to `agent.created` and (re)dispatches `handleAgentCreated` for
+ * each event. Returns a `Disposable` that unsubscribes on dispose.
+ *
+ * @param ctx - Plugin context providing event-bus access.
+ * @param deps - Injected dependencies for testability.
+ */
+export function createAgentRootTaskSubscriber(
+  ctx: PluginContext,
+  deps: AgentRootTaskBootDeps,
+): Disposable {
+  const unsubscribe = ctx.subscribe((event: GrackleEvent) => {
+    if (event.type !== "agent.created") {
+      return;
+    }
+    const payload = event.payload as { agentId?: string };
+    if (!payload.agentId) {
+      return;
+    }
+    try {
+      handleAgentCreated(deps, { agentId: payload.agentId });
+    } catch (err: unknown) {
+      logger.warn(
+        { err, agentId: payload.agentId },
+        "agent-root-task-boot: failed to create root task",
+      );
+    }
+  });
+
+  return {
+    dispose(): void {
+      unsubscribe();
+    },
+  };
+}

--- a/packages/plugin-core/src/environment-handlers.ts
+++ b/packages/plugin-core/src/environment-handlers.ts
@@ -115,8 +115,11 @@ export async function removeEnvironment(req: grackle.EnvironmentId): Promise<gra
       .map((a) => a.name)
       .join(", ");
     const tail = homedAgents.length > 3 ? `, +${homedAgents.length - 3} more` : "";
+    // Note: only "delete" is currently actionable — agent.environment_id is
+    // immutable in the Phase-0 update RPC, so we don't tell the user they
+    // can reassign (the option doesn't exist yet).
     throw new ConnectError(
-      `Cannot remove environment: ${homedAgents.length} standing agent(s) still call it home (${names}${tail}). Delete or reassign those agents first.`,
+      `Cannot remove environment: ${homedAgents.length} standing agent(s) still call it home (${names}${tail}). Delete those agents first.`,
       Code.FailedPrecondition,
     );
   }

--- a/packages/plugin-core/src/environment-handlers.ts
+++ b/packages/plugin-core/src/environment-handlers.ts
@@ -7,6 +7,7 @@ import {
   workspaceEnvironmentLinkStore,
   sessionStore,
   sqlite,
+  agentStore,
 } from "@grackle-ai/database";
 import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import { adapterManager } from "@grackle-ai/core";
@@ -100,6 +101,22 @@ export async function removeEnvironment(req: grackle.EnvironmentId): Promise<gra
   if (wsCount > 0) {
     throw new ConnectError(
       `Cannot remove environment: ${wsCount} active workspace(s) still reference it. Archive or reparent them first.`,
+      Code.FailedPrecondition,
+    );
+  }
+  // Block deletion if standing Agents still call this their home (#1418).
+  // The agents.environment_id column is application-validated (no FK on the
+  // table because the column was added with a default of '' for migration
+  // compatibility), so the guard lives here next to the workspace check.
+  const homedAgents = agentStore.getAgentsByEnvironment(req.id);
+  if (homedAgents.length > 0) {
+    const names = homedAgents
+      .slice(0, 3)
+      .map((a) => a.name)
+      .join(", ");
+    const tail = homedAgents.length > 3 ? `, +${homedAgents.length - 3} more` : "";
+    throw new ConnectError(
+      `Cannot remove environment: ${homedAgents.length} standing agent(s) still call it home (${names}${tail}). Delete or reassign those agents first.`,
       Code.FailedPrecondition,
     );
   }

--- a/packages/plugin-core/src/grpc-agent.test.ts
+++ b/packages/plugin-core/src/grpc-agent.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration tests for the agent task-ownership pipeline (#1418):
+ *
+ *   createAgent  →  agent.created event  →  auto-create root task
+ *   deleteAgent  →  walk task subtree   →  kill non-terminal sessions
+ *                                       →  delete tasks (incl. children)
+ *                                       →  delete agent row
+ *
+ * Uses a real in-memory SQLite database (no store mocks) and wires the
+ * agent-root-task subscriber against the real event bus so the
+ * `createAgent → root-task` path runs end-to-end. Mocks the side-effect
+ * modules (stream-hub, lifecycle, etc.) the same way `grpc-environment.test.ts`
+ * does so `killSessionAndCleanup` can run without a live runtime.
+ *
+ * The high-value scenario this catches that `agent-handlers.test.ts`
+ * doesn't: cascade-delete against a real `tasks` table with a child
+ * task and a real `sessions` row referencing it via the sessions.task_id
+ * FK. The mocked agent-handlers test just calls `taskStore.deleteTask`
+ * as a spy; only this file exercises the actual SQLite FK behavior.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+
+// ── Mock side-effect modules (resolved via __mocks__/) ──
+vi.mock("./logger.js");
+vi.mock("./log-writer.js");
+vi.mock("./stream-hub.js");
+vi.mock("./token-push.js");
+vi.mock("./adapter-manager.js");
+vi.mock("./event-processor.js");
+vi.mock("./processor-registry.js");
+vi.mock("./session-recovery.js");
+vi.mock("./auto-reconnect.js");
+vi.mock("./lifecycle.js");
+vi.mock("./knowledge-init.js");
+vi.mock("./reanimate-agent.js");
+vi.mock("./github-import.js");
+vi.mock("./stream-registry.js");
+vi.mock("./pipe-delivery.js");
+vi.mock("./utils/exec.js");
+vi.mock("./utils/network.js");
+vi.mock("./utils/format-gh-error.js");
+
+// NOTE: event-bus is deliberately NOT mocked here — we want emit() →
+// subscribers to fire so the agent-root-task-boot subscriber actually
+// inserts the root task when createAgent fires `agent.created`.
+
+vi.mock("@grackle-ai/adapter-sdk", () => ({
+  reconnectOrProvision: vi.fn(async function* () {
+    /* empty */
+  }),
+}));
+vi.mock("@grackle-ai/prompt", () => ({
+  resolvePersona: vi.fn(),
+  buildOrchestratorContext: vi.fn(() => ""),
+  SystemPromptBuilder: vi.fn().mockImplementation(() => ({ build: () => "" })),
+  buildTaskPrompt: vi.fn((t: string) => t),
+}));
+vi.mock("@grackle-ai/auth", () => ({
+  createScopedToken: vi.fn(() => "mock-token"),
+  loadOrCreateApiKey: vi.fn(() => "mock-api-key"),
+  generatePairingCode: vi.fn(() => ({ code: "mock-code", token: "mock-token" })),
+}));
+vi.mock("@grackle-ai/knowledge", () => ({
+  knowledgeSearch: vi.fn(),
+  getNode: vi.fn(),
+  expandNode: vi.fn(),
+  createNativeNode: vi.fn(),
+  ingest: vi.fn(),
+  createPassThroughChunker: vi.fn(),
+  listRecentNodes: vi.fn(),
+}));
+
+import { agentStore, taskStore, sessionStore } from "@grackle-ai/database";
+import { subscribe } from "@grackle-ai/core";
+import { initTestDatabase, getHandlers } from "./test-utils/integration-setup.js";
+import { createAgentRootTaskSubscriber } from "./agent-root-task-boot.js";
+import { randomUUID } from "node:crypto";
+
+interface EnvironmentInfo {
+  id: string;
+  displayName: string;
+}
+
+interface AgentInfo {
+  id: string;
+  name: string;
+  environmentId: string;
+}
+
+let handlers: ReturnType<typeof getHandlers>;
+let unsubAgentRoot: (() => void) | undefined;
+
+beforeAll(() => {
+  initTestDatabase();
+  handlers = getHandlers();
+
+  // Wire the agent-root-task subscriber against the real event bus.
+  // In production this is wired in server/src/event-subscribers.ts; the
+  // plugin-core integration harness doesn't include that wiring, so we
+  // do it here to exercise the full createAgent → root-task path.
+  const disposable = createAgentRootTaskSubscriber(
+    { subscribe, emit: () => {} },
+    {
+      getAgent: agentStore.getAgent,
+      getRootTaskForAgent: taskStore.getRootTaskForAgent,
+      insertTask: taskStore.insertTask,
+      newId: () => randomUUID(),
+    },
+  );
+  unsubAgentRoot = (): void => disposable.dispose();
+});
+
+beforeEach(() => {
+  // No global reset — agent rows are uniquely named per test to avoid collisions.
+});
+
+afterAll(() => {
+  unsubAgentRoot?.();
+});
+
+async function createEnv(displayName: string): Promise<string> {
+  const response = (await handlers.addEnvironment({
+    displayName,
+    adapterType: "local",
+    adapterConfig: "{}",
+  })) as EnvironmentInfo;
+  return response.id;
+}
+
+async function createAgent(name: string, environmentId: string): Promise<AgentInfo> {
+  return (await handlers.createAgent({
+    name,
+    avatar: "",
+    primaryPersonaId: "",
+    environmentId,
+  })) as AgentInfo;
+}
+
+describe("Agent task ownership (#1418) — real-DB integration", () => {
+  it("createAgent auto-creates a kind=root task via the subscriber", async () => {
+    const envId = await createEnv("auto-root-env");
+    const agent = await createAgent("AutoRootBot", envId);
+
+    // Wait a microtask cycle for the queued-microtask subscriber dispatch.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const root = taskStore.getRootTaskForAgent(agent.id);
+    expect(root).toBeDefined();
+    expect(root!.kind).toBe("root");
+    expect(root!.agentId).toBe(agent.id);
+    expect(root!.parentTaskId).toBe("");
+    expect(root!.depth).toBe(0);
+    expect(root!.canDecompose).toBe(true);
+    expect(root!.title).toBe("AutoRootBot");
+  });
+
+  it("deleteAgent cascades through a non-empty subtree with real FK constraints", async () => {
+    const envId = await createEnv("cascade-env");
+    const agent = await createAgent("CascadeBot", envId);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const root = taskStore.getRootTaskForAgent(agent.id)!;
+
+    // Manually add a child task under the agent root (#1438/#1439 will do
+    // this via wake-up surfaces; for now we're just proving the cascade
+    // shape works against real SQLite).
+    const childId = randomUUID();
+    taskStore.insertTask({
+      id: childId,
+      workspaceId: undefined,
+      title: "child of cascade",
+      description: "",
+      branch: "",
+      dependsOn: [],
+      parentTaskId: root.id,
+      depth: 1,
+      canDecompose: false,
+      injectKnowledge: false,
+      defaultPersonaId: "",
+      tokenBudget: 0,
+      costBudgetMillicents: 0,
+      agentId: agent.id,
+      kind: "schedule_fire",
+    });
+
+    // Real session row referencing the child task — this is what gets the
+    // sessions.task_id FK involved. If the cascade doesn't handle this
+    // correctly the deleteTask call below will throw a FK error.
+    const sessionId = `cascade-sess-${randomUUID().slice(0, 8)}`;
+    sessionStore.createSession(
+      sessionId,
+      envId,
+      "claude-code",
+      "test prompt",
+      "sonnet",
+      "/tmp/log",
+      childId,
+      "",
+      "",
+    );
+
+    // Sanity: the rows exist before delete.
+    expect(taskStore.getTask(root.id)).toBeDefined();
+    expect(taskStore.getTask(childId)).toBeDefined();
+    expect(sessionStore.getSession(sessionId)).toBeDefined();
+    expect(agentStore.getAgent(agent.id)).toBeDefined();
+
+    // The real test: deleteAgent shouldn't throw FK errors and should
+    // leave the DB consistent.
+    await handlers.deleteAgent({ id: agent.id });
+
+    // Agent gone.
+    expect(agentStore.getAgent(agent.id)).toBeUndefined();
+    // Root + child tasks gone.
+    expect(taskStore.getTask(root.id)).toBeUndefined();
+    expect(taskStore.getTask(childId)).toBeUndefined();
+    // No tasks left attributed to this agent.
+    expect(taskStore.getTasksForAgent(agent.id)).toEqual([]);
+    // Session was force-stopped by killSessionAndCleanup (status =
+    // SESSION_STATUS.STOPPED). Note: sessionStore.deleteByEnvironment isn't
+    // called by deleteAgent — we only force-stop the session, not delete
+    // its row, so the session row may still exist with a terminal status.
+    // (Stopping is enough — the runtime is no longer ticking.)
+    const sessionAfter = sessionStore.getSession(sessionId);
+    if (sessionAfter) {
+      expect(sessionAfter.status).toBe("stopped");
+    }
+  });
+
+  it("deleteAgent on agent with only a root task (no child work) is a clean cascade", async () => {
+    const envId = await createEnv("lonely-env");
+    const agent = await createAgent("LonelyBot", envId);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const root = taskStore.getRootTaskForAgent(agent.id)!;
+    expect(taskStore.getTasksForAgent(agent.id)).toHaveLength(1);
+
+    await handlers.deleteAgent({ id: agent.id });
+
+    expect(agentStore.getAgent(agent.id)).toBeUndefined();
+    expect(taskStore.getTask(root.id)).toBeUndefined();
+  });
+
+  it("multiple agents on the same env are independent — deleting one leaves the other intact", async () => {
+    const envId = await createEnv("multi-env");
+    const a1 = await createAgent("MultiBot1", envId);
+    const a2 = await createAgent("MultiBot2", envId);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const root1 = taskStore.getRootTaskForAgent(a1.id)!;
+    const root2 = taskStore.getRootTaskForAgent(a2.id)!;
+
+    await handlers.deleteAgent({ id: a1.id });
+
+    expect(agentStore.getAgent(a1.id)).toBeUndefined();
+    expect(taskStore.getTask(root1.id)).toBeUndefined();
+
+    expect(agentStore.getAgent(a2.id)).toBeDefined();
+    expect(taskStore.getTask(root2.id)).toBeDefined();
+    expect(taskStore.getRootTaskForAgent(a2.id)).toBeDefined();
+  });
+});

--- a/packages/plugin-core/src/grpc-environment.test.ts
+++ b/packages/plugin-core/src/grpc-environment.test.ts
@@ -202,3 +202,39 @@ describe("gRPC updateEnvironment handlers", () => {
     expect(err.message).toContain("Environment not found");
   });
 });
+
+describe("gRPC removeEnvironment — agent home guard (#1418)", () => {
+  /** Helper to create an environment and return its ID. */
+  async function createEnv(displayName: string): Promise<string> {
+    const response = (await handlers.addEnvironment({
+      displayName,
+      adapterType: "local",
+      adapterConfig: "{}",
+    })) as EnvironmentInfo;
+    return response.id;
+  }
+
+  it("rejects removeEnvironment when standing agents still call it home", async () => {
+    // Create an env, then an agent on it.
+    const envId = await createEnv("guard-env");
+    const created = (await handlers.createAgent({
+      name: "Homed Bot",
+      avatar: "",
+      primaryPersonaId: "",
+      environmentId: envId,
+    })) as { id: string };
+
+    // Attempt to remove the env — should be blocked.
+    const err = (await handlers.removeEnvironment({ id: envId }).catch((e: unknown) => e)) as
+      | ConnectError
+      | Error;
+    expect(err).toBeInstanceOf(ConnectError);
+    expect((err as ConnectError).code).toBe(Code.FailedPrecondition);
+    expect((err as ConnectError).message).toContain("standing agent");
+    expect((err as ConnectError).message).toContain("Homed Bot");
+
+    // Delete the agent → removeEnvironment now succeeds.
+    await handlers.deleteAgent({ id: created.id });
+    await handlers.removeEnvironment({ id: envId });
+  });
+});

--- a/packages/plugin-core/src/grpc-proto-converters.ts
+++ b/packages/plugin-core/src/grpc-proto-converters.ts
@@ -115,6 +115,8 @@ export function taskRowToProto(
     scheduleId: row.scheduleId,
     tokenBudget: row.tokenBudget,
     costBudgetMillicents: row.costBudgetMillicents,
+    agentId: row.agentId ?? "",
+    kind: row.kind,
   });
 }
 
@@ -153,13 +155,14 @@ export function safeParseJson<T>(value: string | undefined, fallback: T): T {
   }
 }
 
-/** Convert an agent database row to an Agent proto message (#1417). */
+/** Convert an agent database row to an Agent proto message (#1417, #1418). */
 export function agentRowToProto(row: agentStore.AgentRow): grackle.Agent {
   return create(grackle.AgentSchema, {
     id: row.id,
     name: row.name,
     avatar: row.avatar,
     primaryPersonaId: row.primaryPersonaId,
+    environmentId: row.environmentId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   });

--- a/packages/plugin-core/src/grpc-task-test-helpers.ts
+++ b/packages/plugin-core/src/grpc-task-test-helpers.ts
@@ -57,7 +57,9 @@ export function resetSchema(): void {
       workpad   TEXT NOT NULL DEFAULT '',
       schedule_id TEXT NOT NULL DEFAULT '',
       token_budget  INTEGER NOT NULL DEFAULT 0,
-      cost_budget_millicents INTEGER NOT NULL DEFAULT 0
+      cost_budget_millicents INTEGER NOT NULL DEFAULT 0,
+      agent_id      TEXT,
+      kind          TEXT NOT NULL DEFAULT 'task'
     );
   `);
 }

--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -16,6 +16,8 @@ export {
 } from "./signals/orphan-reparent.js";
 export { createRootTaskBootSubscriber } from "./root-task-boot.js";
 export type { RootTaskBootDeps } from "./root-task-boot.js";
+export { createAgentRootTaskSubscriber, handleAgentCreated } from "./agent-root-task-boot.js";
+export type { AgentRootTaskBootDeps } from "./agent-root-task-boot.js";
 
 // ─── Reconciliation Phases ──────────────────────────────────
 export { createDispatchPhase } from "./dispatch-phase.js";

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -209,12 +209,19 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
   // Resolve workspace scope for the token: prefer explicit workspaceId, then inherit from the
   // parent session's task (for piped child sessions spawned from a task-based session).
   let resolvedWorkspaceId = cfg?.workspaceId || "";
-  // #1418: agent_id is inherited from the parent task (the only "task" in
-  // scope here is the parent session's, since spawnAgent doesn't take a
-  // taskId of its own). Subagents of an agent-owned task carry the same
-  // agent principal.
+  // #1418: agent_id can come from two places — the spawn request's own
+  // `cfg.taskId` (when spawning a session against a known agent-owned task)
+  // or the parent session's task (when piping a child session under a
+  // task-based parent). Both paths produce the same agent attribution.
   let resolvedAgentId: string | undefined;
-  if (parentSessionId) {
+  if (cfg?.taskId) {
+    const reqTask = taskStore.getTask(cfg.taskId);
+    if (!resolvedWorkspaceId) {
+      resolvedWorkspaceId = reqTask?.workspaceId || "";
+    }
+    resolvedAgentId = reqTask?.agentId || undefined;
+  }
+  if (!resolvedAgentId && parentSessionId) {
     const parentSession = sessionStore.getSession(parentSessionId);
     if (parentSession?.taskId) {
       const parentTask = taskStore.getTask(parentSession.taskId);

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -209,15 +209,29 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
   // Resolve workspace scope for the token: prefer explicit workspaceId, then inherit from the
   // parent session's task (for piped child sessions spawned from a task-based session).
   let resolvedWorkspaceId = cfg?.workspaceId || "";
-  if (!resolvedWorkspaceId && parentSessionId) {
+  // #1418: agent_id is inherited from the parent task (the only "task" in
+  // scope here is the parent session's, since spawnAgent doesn't take a
+  // taskId of its own). Subagents of an agent-owned task carry the same
+  // agent principal.
+  let resolvedAgentId: string | undefined;
+  if (parentSessionId) {
     const parentSession = sessionStore.getSession(parentSessionId);
     if (parentSession?.taskId) {
       const parentTask = taskStore.getTask(parentSession.taskId);
-      resolvedWorkspaceId = parentTask?.workspaceId || "";
+      if (!resolvedWorkspaceId) {
+        resolvedWorkspaceId = parentTask?.workspaceId || "";
+      }
+      resolvedAgentId = parentTask?.agentId || undefined;
     }
   }
   const mcpToken = createScopedToken(
-    { sub: sessionId, pid: resolvedWorkspaceId, per: resolved.personaId, sid: sessionId },
+    {
+      sub: sessionId,
+      pid: resolvedWorkspaceId,
+      per: resolved.personaId,
+      sid: sessionId,
+      agt: resolvedAgentId,
+    },
     loadOrCreateApiKey(grackleHome),
   );
 

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -511,7 +511,15 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
   const taskMcpDialHost = toDialableHost(process.env.GRACKLE_HOST || "127.0.0.1");
   const taskMcpUrl = `http://${taskMcpDialHost}:${taskMcpPort}/mcp`;
   const taskMcpToken = createScopedToken(
-    { sub: task.id, pid: task.workspaceId || "", per: resolved.personaId, sid: sessionId },
+    {
+      sub: task.id,
+      pid: task.workspaceId || "",
+      per: resolved.personaId,
+      sid: sessionId,
+      // #1418: tasks owned by an Agent carry the agent_id through to the
+      // scoped token so MCP requests can be attributed to the principal.
+      agt: task.agentId || undefined,
+    },
     loadOrCreateApiKey(grackleHome),
   );
 

--- a/packages/plugin-core/src/test-utils/mock-database.ts
+++ b/packages/plugin-core/src/test-utils/mock-database.ts
@@ -87,6 +87,16 @@ export function createDatabaseMock() {
       countWorkspacesByEnvironment: vi.fn(() => 0),
     },
 
+    agentStore: {
+      listAgents: vi.fn(() => []),
+      getAgent: vi.fn(() => undefined),
+      getAgentByName: vi.fn(() => undefined),
+      createAgent: vi.fn(),
+      updateAgent: vi.fn(),
+      deleteAgent: vi.fn(),
+      getAgentsByEnvironment: vi.fn(() => []),
+    },
+
     personaStore: {
       createPersona: vi.fn(),
       getPersona: vi.fn(() => undefined),

--- a/packages/server/src/core-plugin.test.ts
+++ b/packages/server/src/core-plugin.test.ts
@@ -31,6 +31,7 @@ vi.mock("@grackle-ai/plugin-core", () => ({
   })),
   createLifecycleSubscriber: vi.fn(() => ({ dispose: vi.fn() })),
   createRootTaskBootSubscriber: vi.fn(() => ({ dispose: vi.fn() })),
+  createAgentRootTaskSubscriber: vi.fn(() => ({ dispose: vi.fn() })),
   createDispatchPhase: vi.fn(() => ({ name: "dispatch", execute: vi.fn() })),
   lifecycleCleanupPhase: { name: "lifecycle-cleanup", execute: vi.fn() },
   createEnvironmentReconciliationPhase: vi.fn(() => ({
@@ -50,6 +51,7 @@ vi.mock("@grackle-ai/common", () => ({
 }));
 
 vi.mock("@grackle-ai/database", () => ({
+  agentStore: { getAgent: vi.fn() },
   taskStore: {
     createTask: vi.fn(),
     setTaskScheduleId: vi.fn(),
@@ -57,6 +59,8 @@ vi.mock("@grackle-ai/database", () => ({
     listTasks: vi.fn(),
     reparentTask: vi.fn(),
     areDependenciesMet: vi.fn(),
+    getRootTaskForAgent: vi.fn(),
+    insertTask: vi.fn(),
   },
   workspaceStore: { listWorkspaces: vi.fn(() => []) },
   personaStore: { getPersona: vi.fn() },
@@ -139,20 +143,23 @@ describe("createCorePlugin", () => {
     expect(names).not.toContain("orphan-reparent");
   });
 
-  it("eventSubscribers returns only lifecycle when skipRootAutostart is true", () => {
+  it("eventSubscribers returns lifecycle + agent-root when skipRootAutostart is true", () => {
+    // #1418: the agent-root-task subscriber runs regardless of the system
+    // root-task autostart flag — 2 disposables: lifecycle + agent-root.
     const plugin = createCorePlugin();
     const ctx = createMockContext({ skipRootAutostart: true });
     const disposables = plugin.eventSubscribers!(ctx);
 
-    expect(disposables.length).toBe(1);
+    expect(disposables.length).toBe(2);
     expect(disposables[0]).toHaveProperty("dispose");
   });
 
   it("eventSubscribers includes root boot when skipRootAutostart is false", () => {
+    // 3 disposables: lifecycle + system-root-boot + agent-root.
     const plugin = createCorePlugin();
     const ctx = createMockContext({ skipRootAutostart: false });
     const disposables = plugin.eventSubscribers!(ctx);
 
-    expect(disposables.length).toBe(2);
+    expect(disposables.length).toBe(3);
   });
 });

--- a/packages/server/src/event-subscribers.test.ts
+++ b/packages/server/src/event-subscribers.test.ts
@@ -16,10 +16,16 @@ vi.mock("@grackle-ai/core", () => ({
 vi.mock("@grackle-ai/plugin-core", () => ({
   createLifecycleSubscriber: vi.fn(() => ({ dispose: vi.fn() })),
   createRootTaskBootSubscriber: vi.fn(() => mockDisposable),
+  createAgentRootTaskSubscriber: vi.fn(() => ({ dispose: vi.fn() })),
 }));
 
 vi.mock("@grackle-ai/database", () => ({
-  taskStore: { getTask: vi.fn() },
+  agentStore: { getAgent: vi.fn() },
+  taskStore: {
+    getTask: vi.fn(),
+    getRootTaskForAgent: vi.fn(),
+    insertTask: vi.fn(),
+  },
   sessionStore: { listSessionsForTask: vi.fn(), getLatestSessionForTask: vi.fn() },
   settingsStore: { getSetting: vi.fn() },
 }));
@@ -41,14 +47,18 @@ describe("wireEventSubscribers (core-only)", () => {
     );
   });
 
-  it("returns only lifecycle disposable when skipRootAutostart is true", () => {
+  it("returns lifecycle + agent-root subscribers when skipRootAutostart is true", () => {
+    // #1418: the agent-root-task subscriber runs regardless of the system
+    // root-task autostart flag (those are independent concerns), so we get
+    // 2 disposables here: lifecycle + agent-root.
     const disposables = wireEventSubscribers({ skipRootAutostart: true });
-    expect(disposables).toHaveLength(1);
+    expect(disposables).toHaveLength(2);
     expect(disposables[0]).toHaveProperty("dispose");
   });
 
   it("includes root task boot when skipRootAutostart is false", () => {
+    // 3 disposables: lifecycle + system-root-boot + agent-root.
     const disposables = wireEventSubscribers({ skipRootAutostart: false });
-    expect(disposables).toHaveLength(2);
+    expect(disposables).toHaveLength(3);
   });
 });

--- a/packages/server/src/event-subscribers.ts
+++ b/packages/server/src/event-subscribers.ts
@@ -7,8 +7,13 @@ import {
   reanimateAgent,
 } from "@grackle-ai/core";
 import type { Disposable, PluginContext, SubscriberFactory } from "@grackle-ai/core";
-import { createLifecycleSubscriber, createRootTaskBootSubscriber } from "@grackle-ai/plugin-core";
-import { taskStore, sessionStore, settingsStore } from "@grackle-ai/database";
+import {
+  createLifecycleSubscriber,
+  createRootTaskBootSubscriber,
+  createAgentRootTaskSubscriber,
+} from "@grackle-ai/plugin-core";
+import { agentStore, taskStore, sessionStore, settingsStore } from "@grackle-ai/database";
+import { randomUUID } from "node:crypto";
 
 /**
  * Context accepted by createEventSubscribers.
@@ -47,6 +52,17 @@ export function createEventSubscribers(ctx: SubscriberContext): Disposable[] {
       }),
     );
   }
+
+  // Auto-create the root task for each new Agent (#1418). Independent of the
+  // root-task autostart flag above (which gates the *system* root task).
+  factories.push((pluginCtx) =>
+    createAgentRootTaskSubscriber(pluginCtx, {
+      getAgent: agentStore.getAgent,
+      getRootTaskForAgent: taskStore.getRootTaskForAgent,
+      insertTask: taskStore.insertTask,
+      newId: () => randomUUID(),
+    }),
+  );
 
   return factories.map((factory) => factory(ctx));
 }

--- a/packages/web-components/src/components/agents/AgentManager.test.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.test.tsx
@@ -390,4 +390,73 @@ describe("AgentManager", () => {
     );
     expect(screen.getByTestId("agent-environment").textContent).toBe("local");
   });
+
+  it("create form syncs environment selection when environments load async (Copilot review)", () => {
+    // Mount with no environments (simulating mid-fetch state).
+    const { rerender } = render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={[]}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("agent-name-input"), { target: { value: "RaceBot" } });
+    // Submit disabled because environmentId is still "".
+    expect((screen.getByTestId("agent-submit") as HTMLButtonElement).disabled).toBe(true);
+
+    // Environments arrive (the useGrackleSocket fetch lands).
+    rerender(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+
+    // The useEffect should now populate environmentId with the first env.
+    const select = screen.getByTestId("agent-environment-select") as HTMLSelectElement;
+    expect(select.value).toBe("local");
+    expect((screen.getByTestId("agent-submit") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("create form keeps user's env selection when the environments list updates", () => {
+    const { rerender } = render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    // User picks sandbox.
+    fireEvent.change(screen.getByTestId("agent-environment-select"), {
+      target: { value: "sandbox" },
+    });
+
+    // Environments list re-renders (e.g. an env was added/changed elsewhere).
+    rerender(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+
+    // Selection still sandbox — the user's choice survives because it's
+    // still present in the new list.
+    expect((screen.getByTestId("agent-environment-select") as HTMLSelectElement).value).toBe(
+      "sandbox",
+    );
+  });
 });

--- a/packages/web-components/src/components/agents/AgentManager.test.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.test.tsx
@@ -425,6 +425,39 @@ describe("AgentManager", () => {
     expect((screen.getByTestId("agent-submit") as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("create form clears env selection and disables submit if environments transition to empty (Copilot review)", () => {
+    const onCreate = vi.fn();
+    const { rerender } = render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={onCreate}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("agent-name-input"), { target: { value: "Stale" } });
+    // Now both name and env are present → submit enabled.
+    expect((screen.getByTestId("agent-submit") as HTMLButtonElement).disabled).toBe(false);
+
+    // Environments list goes empty (e.g. all environments removed).
+    rerender(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={[]}
+        onCreate={onCreate}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+
+    // Submit should now be disabled — environmentId got cleared to "" by
+    // the effect, so canSubmit is false and a stale id can't be submitted.
+    expect((screen.getByTestId("agent-submit") as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("create form keeps user's env selection when the environments list updates", () => {
     const { rerender } = render(
       <AgentManager

--- a/packages/web-components/src/components/agents/AgentManager.test.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.test.tsx
@@ -2,11 +2,23 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 import { AgentManager, isImageAvatar } from "./AgentManager.js";
-import type { AgentData, PersonaData } from "../../hooks/types.js";
+import type { AgentData, Environment, PersonaData } from "../../hooks/types.js";
 
 const AGENTS: AgentData[] = [
-  { id: "refactor-bot", name: "Refactor Bot", avatar: "B", primaryPersonaId: "claude-code" },
-  { id: "doc-writer", name: "Doc Writer", avatar: "D", primaryPersonaId: "" },
+  {
+    id: "refactor-bot",
+    name: "Refactor Bot",
+    avatar: "B",
+    primaryPersonaId: "claude-code",
+    environmentId: "local",
+  },
+  {
+    id: "doc-writer",
+    name: "Doc Writer",
+    avatar: "D",
+    primaryPersonaId: "",
+    environmentId: "sandbox",
+  },
 ];
 
 const PERSONAS: PersonaData[] = [
@@ -28,8 +40,29 @@ const PERSONAS: PersonaData[] = [
   },
 ];
 
+const ENVIRONMENTS: Environment[] = [
+  {
+    id: "local",
+    displayName: "Local",
+    adapterType: "local",
+    adapterConfig: "{}",
+    status: "connected",
+    bootstrapped: true,
+    githubAccountId: "",
+  },
+  {
+    id: "sandbox",
+    displayName: "Sandbox",
+    adapterType: "docker",
+    adapterConfig: "{}",
+    status: "connected",
+    bootstrapped: true,
+    githubAccountId: "",
+  },
+];
+
 const NOOP = (): void => {};
-const NOOP_CREATE = (_n: string, _a: string, _p: string): void => {};
+const NOOP_CREATE = (_n: string, _a: string, _p: string, _e: string): void => {};
 const NOOP_DELETE = (_id: string): void => {};
 
 describe("isImageAvatar", () => {
@@ -74,6 +107,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         agentId="refactor-bot"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -91,6 +125,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={[]}
+        environments={ENVIRONMENTS}
         agentId="refactor-bot"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -105,6 +140,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         agentId="doc-writer"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -119,6 +155,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
         onNavigateBack={NOOP}
@@ -139,6 +176,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={[]}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         onCreate={onCreate}
         onDelete={NOOP_DELETE}
         onNavigateBack={NOOP}
@@ -151,7 +189,9 @@ describe("AgentManager", () => {
     const submit = screen.getByTestId("agent-submit") as HTMLButtonElement;
     expect(submit.disabled).toBe(false);
     fireEvent.click(submit);
-    expect(onCreate).toHaveBeenCalledWith("New Bot", "X", "");
+    // Form defaults environment to the first option ("local") so submit
+    // carries 4 args including environmentId.
+    expect(onCreate).toHaveBeenCalledWith("New Bot", "X", "", "local");
   });
 
   it("renders the not-found view when agentId is set but missing from agents", () => {
@@ -159,6 +199,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         agentId="ghost"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -175,6 +216,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={[]}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         agentId="loading-bot"
         agentsLoading
         onCreate={NOOP_CREATE}
@@ -191,8 +233,11 @@ describe("AgentManager", () => {
   it("renders an inline glyph for emoji avatars and an <img> for URL avatars", () => {
     const { rerender } = render(
       <AgentManager
-        agents={[{ id: "a", name: "Emoji", avatar: "🐦", primaryPersonaId: "" }]}
+        agents={[
+          { id: "a", name: "Emoji", avatar: "🐦", primaryPersonaId: "", environmentId: "local" },
+        ]}
         personas={[]}
+        environments={ENVIRONMENTS}
         agentId="a"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -203,8 +248,17 @@ describe("AgentManager", () => {
 
     rerender(
       <AgentManager
-        agents={[{ id: "a", name: "Url", avatar: "https://x.test/a.png", primaryPersonaId: "" }]}
+        agents={[
+          {
+            id: "a",
+            name: "Url",
+            avatar: "https://x.test/a.png",
+            primaryPersonaId: "",
+            environmentId: "local",
+          },
+        ]}
         personas={[]}
+        environments={ENVIRONMENTS}
         agentId="a"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -220,8 +274,11 @@ describe("AgentManager", () => {
   it("falls back to a monogram derived from the name when avatar is empty", () => {
     render(
       <AgentManager
-        agents={[{ id: "a", name: "monica", avatar: "", primaryPersonaId: "" }]}
+        agents={[
+          { id: "a", name: "monica", avatar: "", primaryPersonaId: "", environmentId: "local" },
+        ]}
         personas={[]}
+        environments={ENVIRONMENTS}
         agentId="a"
         onCreate={NOOP_CREATE}
         onDelete={NOOP_DELETE}
@@ -237,6 +294,7 @@ describe("AgentManager", () => {
       <AgentManager
         agents={AGENTS}
         personas={PERSONAS}
+        environments={ENVIRONMENTS}
         agentId="refactor-bot"
         onCreate={NOOP_CREATE}
         onDelete={onDelete}
@@ -245,5 +303,91 @@ describe("AgentManager", () => {
     );
     fireEvent.click(screen.getByTestId("agent-delete"));
     expect(onDelete).toHaveBeenCalledWith("refactor-bot");
+  });
+
+  // ── #1418: environment selector + view chip ──────────────────────────
+
+  it("create form renders an environment selector with all options", () => {
+    render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    const select = screen.getByTestId("agent-environment-select") as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    expect(select.value).toBe("local"); // defaults to the first environment
+    const optionLabels = Array.from(select.options).map((o) => o.textContent);
+    expect(optionLabels).toEqual(["Local", "Sandbox"]);
+  });
+
+  it("create form changing the environment updates onCreate's 4th arg", () => {
+    const onCreate = vi.fn();
+    render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        onCreate={onCreate}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("agent-name-input"), { target: { value: "Pickier" } });
+    fireEvent.change(screen.getByTestId("agent-environment-select"), {
+      target: { value: "sandbox" },
+    });
+    fireEvent.click(screen.getByTestId("agent-submit"));
+    expect(onCreate).toHaveBeenCalledWith("Pickier", "", "", "sandbox");
+  });
+
+  it("create form disables submit when no environments are available", () => {
+    render(
+      <AgentManager
+        agents={[]}
+        personas={PERSONAS}
+        environments={[]}
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("agent-name-input"), { target: { value: "WantsEnv" } });
+    const submit = screen.getByTestId("agent-submit") as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("read-only view shows the environment display name", () => {
+    render(
+      <AgentManager
+        agents={AGENTS}
+        personas={PERSONAS}
+        environments={ENVIRONMENTS}
+        agentId="refactor-bot"
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    expect(screen.getByTestId("agent-environment").textContent).toBe("Local");
+  });
+
+  it("read-only view falls back to the raw environment id when the env is unknown", () => {
+    render(
+      <AgentManager
+        agents={AGENTS}
+        personas={PERSONAS}
+        environments={[]}
+        agentId="refactor-bot"
+        onCreate={NOOP_CREATE}
+        onDelete={NOOP_DELETE}
+        onNavigateBack={NOOP}
+      />,
+    );
+    expect(screen.getByTestId("agent-environment").textContent).toBe("local");
   });
 });

--- a/packages/web-components/src/components/agents/AgentManager.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.tsx
@@ -216,8 +216,13 @@ function AgentCreateForm({
   // gets a permanently disabled submit unless they manually change the
   // select. Sync the selection to the first environment when one arrives
   // (and only if the user hasn't picked one already that's still valid).
+  // If the list goes empty (last env was removed), clear the selection so
+  // the disabled-submit guard fires instead of carrying a stale id forward.
   useEffect(() => {
     if (environments.length === 0) {
+      if (environmentId !== "") {
+        setEnvironmentId("");
+      }
       return;
     }
     const stillValid = environmentId && environments.some((e) => e.id === environmentId);

--- a/packages/web-components/src/components/agents/AgentManager.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.tsx
@@ -6,7 +6,7 @@
  * @module
  */
 
-import { useState, type FormEvent, type JSX } from "react";
+import { useEffect, useState, type FormEvent, type JSX } from "react";
 import type { AgentData, Environment, PersonaData } from "../../hooks/types.js";
 import { Button } from "../display/Button.js";
 import styles from "./AgentManager.module.scss";
@@ -210,6 +210,21 @@ function AgentCreateForm({
   // glance; user can change it. If there are no environments the form's
   // submit button stays disabled (we can't create an agent without a home).
   const [environmentId, setEnvironmentId] = useState(environments[0]?.id ?? "");
+
+  // Environments are loaded async via useGrackleSocket — if the form mounts
+  // before the fetch lands, useState above captures `""` once and the user
+  // gets a permanently disabled submit unless they manually change the
+  // select. Sync the selection to the first environment when one arrives
+  // (and only if the user hasn't picked one already that's still valid).
+  useEffect(() => {
+    if (environments.length === 0) {
+      return;
+    }
+    const stillValid = environmentId && environments.some((e) => e.id === environmentId);
+    if (!stillValid) {
+      setEnvironmentId(environments[0].id);
+    }
+  }, [environments, environmentId]);
 
   const canSubmit = name.trim().length > 0 && environmentId.length > 0;
 

--- a/packages/web-components/src/components/agents/AgentManager.tsx
+++ b/packages/web-components/src/components/agents/AgentManager.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, type FormEvent, type JSX } from "react";
-import type { AgentData, PersonaData } from "../../hooks/types.js";
+import type { AgentData, Environment, PersonaData } from "../../hooks/types.js";
 import { Button } from "../display/Button.js";
 import styles from "./AgentManager.module.scss";
 
@@ -17,6 +17,11 @@ export interface AgentManagerProps {
   agents: AgentData[];
   /** Personas available to be chosen as the primary persona. */
   personas: PersonaData[];
+  /**
+   * Environments available as the Agent's home (#1418). Required in the
+   * create form; rendered as a chip in the read-only view.
+   */
+  environments: Environment[];
   /** When set and found in `agents`, render the read-only view; else create form. */
   agentId?: string;
   /**
@@ -26,7 +31,7 @@ export interface AgentManagerProps {
    */
   agentsLoading?: boolean;
   /** Create a new agent. Called only in create mode. */
-  onCreate: (name: string, avatar: string, primaryPersonaId: string) => void;
+  onCreate: (name: string, avatar: string, primaryPersonaId: string, environmentId: string) => void;
   /** Delete the viewed agent. Called only in view mode. */
   onDelete: (id: string) => void;
   /** Navigate away (after create/delete, or via the back affordance). */
@@ -93,6 +98,7 @@ function AvatarPreview({ name, avatar }: { name: string; avatar: string }): JSX.
 export function AgentManager({
   agents,
   personas,
+  environments,
   agentId,
   agentsLoading = false,
   onCreate,
@@ -136,6 +142,7 @@ export function AgentManager({
   // ── Read-only view ───────────────────────────────────────────────────────
   if (agentId && agent) {
     const persona = personas.find((p) => p.id === agent.primaryPersonaId);
+    const env = environments.find((e) => e.id === agent.environmentId);
     return (
       <div className={styles.container} data-testid="agent-view">
         <div className={styles.header}>
@@ -149,6 +156,8 @@ export function AgentManager({
           <dd data-testid="agent-persona">
             {persona ? persona.name : agent.primaryPersonaId || "(none)"}
           </dd>
+          <dt>Environment</dt>
+          <dd data-testid="agent-environment">{env ? env.displayName : agent.environmentId}</dd>
         </dl>
         <section className={styles.history} data-testid="agent-history">
           <h2 className={styles.sectionTitle}>History</h2>
@@ -169,30 +178,47 @@ export function AgentManager({
   }
 
   // ── Create form ──────────────────────────────────────────────────────────
-  return <AgentCreateForm personas={personas} onCreate={onCreate} onCancel={onNavigateBack} />;
+  return (
+    <AgentCreateForm
+      personas={personas}
+      environments={environments}
+      onCreate={onCreate}
+      onCancel={onNavigateBack}
+    />
+  );
 }
 
 /** Props for the internal create form. */
 interface AgentCreateFormProps {
   personas: PersonaData[];
-  onCreate: (name: string, avatar: string, primaryPersonaId: string) => void;
+  environments: Environment[];
+  onCreate: (name: string, avatar: string, primaryPersonaId: string, environmentId: string) => void;
   onCancel: () => void;
 }
 
 /** Controlled create form for a new agent. */
-function AgentCreateForm({ personas, onCreate, onCancel }: AgentCreateFormProps): JSX.Element {
+function AgentCreateForm({
+  personas,
+  environments,
+  onCreate,
+  onCancel,
+}: AgentCreateFormProps): JSX.Element {
   const [name, setName] = useState("");
   const [avatar, setAvatar] = useState("");
   const [primaryPersonaId, setPrimaryPersonaId] = useState("");
+  // Default to the first environment so the form is submittable on first
+  // glance; user can change it. If there are no environments the form's
+  // submit button stays disabled (we can't create an agent without a home).
+  const [environmentId, setEnvironmentId] = useState(environments[0]?.id ?? "");
 
-  const canSubmit = name.trim().length > 0;
+  const canSubmit = name.trim().length > 0 && environmentId.length > 0;
 
   const handleSubmit = (e: FormEvent): void => {
     e.preventDefault();
     if (!canSubmit) {
       return;
     }
-    onCreate(name.trim(), avatar.trim(), primaryPersonaId);
+    onCreate(name.trim(), avatar.trim(), primaryPersonaId, environmentId);
   };
 
   return (
@@ -241,6 +267,27 @@ function AgentCreateForm({ personas, onCreate, onCancel }: AgentCreateFormProps)
         {personas.map((p) => (
           <option key={p.id} value={p.id}>
             {p.name}
+          </option>
+        ))}
+      </select>
+
+      <label className={styles.label} htmlFor="agent-environment-select">
+        Environment <span className={styles.hint}>(where the agent lives)</span>
+      </label>
+      <select
+        id="agent-environment-select"
+        className={styles.input}
+        value={environmentId}
+        onChange={(e) => setEnvironmentId(e.target.value)}
+        data-testid="agent-environment-select"
+        required
+      >
+        {environments.length === 0 && (
+          <option value="">(no environments — create one first)</option>
+        )}
+        {environments.map((env) => (
+          <option key={env.id} value={env.id}>
+            {env.displayName}
           </option>
         ))}
       </select>

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -212,8 +212,9 @@ export interface PersonaData {
 }
 
 /**
- * A standing agent as the web UI consumes it (#1417). Phase 0: a minimal
- * context-axis entity with no lifecycle — identity plus a primary persona.
+ * A standing agent as the web UI consumes it (#1417, #1418). Phase 0
+ * shipped identity + a primary persona; #1418 adds the home environment
+ * (required) so the Agent can spawn sessions when wake-up surfaces fire.
  */
 export interface AgentData {
   id: string;
@@ -221,6 +222,8 @@ export interface AgentData {
   /** Emoji, image URL, or base64 data URI. Empty string renders a monogram. */
   avatar: string;
   primaryPersonaId: string;
+  /** The Agent's home environment id (#1418). Required at creation time. */
+  environmentId: string;
 }
 
 /** Fields accepted when updating an agent. Omitted fields are left unchanged. */
@@ -582,8 +585,13 @@ export interface UseAgentsResult {
   agentsLoading: boolean;
   /** Request the current agent list from the server. */
   loadAgents: () => Promise<void>;
-  /** Create a new agent. */
-  createAgent: (name: string, avatar?: string, primaryPersonaId?: string) => Promise<AgentData>;
+  /** Create a new agent. Requires `environmentId` (the agent's home environment, #1418). */
+  createAgent: (
+    name: string,
+    avatar: string,
+    primaryPersonaId: string,
+    environmentId: string,
+  ) => Promise<AgentData>;
   /** Update an existing agent; omitted fields are preserved. */
   updateAgent: (id: string, updates: UpdateAgentFields) => Promise<AgentData>;
   /** Delete an agent by ID. */

--- a/packages/web-components/src/mocks/MockGrackleProvider.tsx
+++ b/packages/web-components/src/mocks/MockGrackleProvider.tsx
@@ -1108,13 +1108,19 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
         agents,
         agentsLoading: false,
         loadAgents: async () => {},
-        createAgent: async (name: string, avatar?: string, primaryPersonaId?: string) => {
-          console.log("[MockGrackle] createAgent", { name });
+        createAgent: async (
+          name: string,
+          avatar: string,
+          primaryPersonaId: string,
+          environmentId: string,
+        ) => {
+          console.log("[MockGrackle] createAgent", { name, environmentId });
           const created: AgentData = {
             id: `mock-agent-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
             name,
-            avatar: avatar ?? "",
-            primaryPersonaId: primaryPersonaId ?? "",
+            avatar,
+            primaryPersonaId,
+            environmentId,
           };
           setAgents((prev) => [...prev, created]);
           return created;

--- a/packages/web-components/src/mocks/mockData.ts
+++ b/packages/web-components/src/mocks/mockData.ts
@@ -1635,12 +1635,14 @@ export const MOCK_AGENTS: AgentData[] = [
     name: "Refactor Bot",
     avatar: "",
     primaryPersonaId: "persona-fe",
+    environmentId: "local",
   },
   {
     id: "security-auditor",
     name: "Security Auditor",
     avatar: "",
     primaryPersonaId: "persona-arch",
+    environmentId: "local",
   },
 ];
 

--- a/packages/web/src/hooks/proto-converters.ts
+++ b/packages/web/src/hooks/proto-converters.ts
@@ -213,6 +213,7 @@ export function protoToAgent(p: grackle.Agent): AgentData {
     name: p.name,
     avatar: p.avatar,
     primaryPersonaId: p.primaryPersonaId,
+    environmentId: p.environmentId,
   };
 }
 

--- a/packages/web/src/hooks/useAgents.ts
+++ b/packages/web/src/hooks/useAgents.ts
@@ -56,11 +56,17 @@ export function useAgents(): UseAgentsResult {
   );
 
   const createAgent = useCallback(
-    async (name: string, avatar?: string, primaryPersonaId?: string): Promise<AgentData> => {
+    async (
+      name: string,
+      avatar: string,
+      primaryPersonaId: string,
+      environmentId: string,
+    ): Promise<AgentData> => {
       const resp = await grackleClient.createAgent({
         name,
-        avatar: avatar ?? "",
-        primaryPersonaId: primaryPersonaId ?? "",
+        avatar,
+        primaryPersonaId,
+        environmentId,
       });
       const created = protoToAgent(resp);
       setAgents((prev) => [...prev.filter((a) => a.id !== created.id), created]);

--- a/packages/web/src/pages/AgentDetailPage.tsx
+++ b/packages/web/src/pages/AgentDetailPage.tsx
@@ -18,10 +18,16 @@ export function AgentDetailPage(): JSX.Element {
   const {
     agents: { agents, agentsLoading, createAgent, deleteAgent },
     personas: { personas },
+    environments: { environments },
   } = useGrackle();
 
-  const handleCreate = (name: string, avatar: string, primaryPersonaId: string): void => {
-    createAgent(name, avatar, primaryPersonaId).then(
+  const handleCreate = (
+    name: string,
+    avatar: string,
+    primaryPersonaId: string,
+    environmentId: string,
+  ): void => {
+    createAgent(name, avatar, primaryPersonaId, environmentId).then(
       (created) => {
         navigate(agentUrl(created.id));
       },
@@ -50,6 +56,7 @@ export function AgentDetailPage(): JSX.Element {
     <AgentManager
       agents={agents}
       personas={personas}
+      environments={environments}
       agentId={agentId}
       agentsLoading={agentsLoading}
       onCreate={handleCreate}


### PR DESCRIPTION
## Summary

Phase 1 foundation of the Code/Claw split (epic #1412, post-#1417). Agent becomes the *principal that owns tasks* — every task can be attributed to an Agent, and Agent gets a root task on creation that future tickets (#1438 heartbeat, #1439 schedule reroute, #1421 channels) attach work under.

**Pure additive plumbing.** No end-user behavior change for non-Agent flows — agents can already be created and now also auto-spawn a `kind=root` task, but the system root task and existing user-driven tasks behave identically. The spawn-config cascade resolver originally folded into #1418 has been left in **#1427** per the slimmed scope.

Closes #1418.

## Changes

- **proto** (`@grackle-ai/common`): `Task.agent_id`, `Task.kind`, `Agent.environment_id`, `CreateAgentRequest.environment_id`.
- **database** (`@grackle-ai/database`): migration **v21** adds `tasks.agent_id` (nullable FK → agents), `tasks.kind` (TEXT default `'task'`, reserved values `root | schedule_rule | schedule_fire | channel_config | channel_thread`), `agents.environment_id` (TEXT, validated non-empty at the handler layer), and three indices. Stamps the system root task with `kind='root'`; fresh installs match via `db-seed.ts`. New `agent-store.getAgentsByEnvironment`, `task-store.getRootTaskForAgent`, `task-store.getTasksForAgent`. `agent-store.createAgent` now requires `environmentId` positional arg.
- **plugin-core**: `agent-handlers.createAgent` validates env_id (empty/whitespace → `InvalidArgument`, unknown env → `NotFound`) and emits `agent.created` with `environmentId` in payload. `deleteAgent` cascades — kills non-terminal sessions in the agent's task subtree via `killSessionAndCleanup`, deletes every task with the agent id, then deletes the agent row. New `agent-root-task-boot.ts` subscriber listens on `agent.created` and idempotently inserts the root task (`kind=root`, `parent_task_id=''`, `depth=0`, `canDecompose=true`, persona-id from the agent).
- **server**: new factory entry in `event-subscribers.ts` wires the agent-root-task subscriber against `agentStore.getAgent` / `taskStore.getRootTaskForAgent` / `taskStore.insertTask` / `crypto.randomUUID`.
- **auth**: scoped-token gains optional `agt` claim (round-trips through verify, type-checked); `AuthContext` scoped variant gains optional `agentId`; `auth-middleware` passes `claims.agt` through. Three `createScopedToken` call sites (`session-handlers.spawnAgent`, `task-handlers.startTask`, `core/task-session.startTaskSession`) now thread `agt: task?.agentId || undefined`.
- **CLI**: `grackle agent create <name> --environment <id>` (required), `grackle agent show` displays the new `Env:` field.
- **web**: `AgentData` gains `environmentId`; `AgentManager` create form adds a required environment selector (defaults to first env; submit disabled when no environments exist); read-only detail view adds an Environment row (displayName, falls back to raw id). `useAgents.createAgent` signature gains `environmentId`. `MockGrackleProvider` + `MOCK_AGENTS` updated.

## Tests

| Package | Tests | New |
|---|---|---|
| `@grackle-ai/database` | 292 ✅ | +1 (v21 migration test) |
| `@grackle-ai/plugin-core` | 433 ✅ | +8 (agent-root-task subscriber) + 7 (env validation + cascade) |
| `@grackle-ai/auth` | 121 ✅ | +4 (agt claim round-trip + non-string rejection + middleware) |
| `@grackle-ai/web-components` | 262 ✅ | +5 (env selector + chip + disabled-on-empty + fallback) |
| `@grackle-ai/web` | 280 ✅ | hook signature updated |

Local `rush build` clean (no warnings — warnings-as-errors).

## Manual verification

Live verified via `/launch-grackle` (isolated server on ports 18540-18543):

- **CLI**: `agent list` (empty) → `env list` (local) → `agent create "Refactor Bot" --avatar B --persona claude-code --environment local` → `agent show refactor-bot` shows `Env: local` → DB query `tasks WHERE agent_id = 'refactor-bot'` returns one `kind=root` row (auto-created by the subscriber) → `agent delete refactor-bot` → DB query confirms both the agent and root task are gone (cascade).
- **CLI negative cases**: `agent create "Missing Env"` (no `--environment`) → commander error "required option `--environment <id>` not specified". `agent create "Bad Env" --environment "no-such-env"` → `gRPC error [NotFound]: Environment not found: no-such-env`.
- **Migration paths**: v21 fresh install → `user_version=21` immediately, `system` task has `kind='root'`. (v20→v21 upgrade path covered by the new v21 migration test in `db.test.ts`.)
- **Web** (Playwright on the same isolated server): walked setup wizard → **+ Create Agent** → form shows env selector defaulted to "Local" → filled `Web Bot / W` → submit → landed on `/agents/web-bot` with the read-only detail view showing Environment: Local → DB query shows the root task → clicked Delete → landed back at `/` → DB query shows agent + root task both gone.

## Screenshots

**Create form** (env selector defaults to "Local"):
![create form](https://gist.githubusercontent.com/nick-pape/7fd9f0ad8f630ff3b5ac021ca3b2b287/raw/84d8c80a8fa93bd20531d59ce26c0fdbac35047c/pr-1418-create-form.svg)

**Detail view** (Environment chip rendered as `Local`):
![detail view](https://gist.githubusercontent.com/nick-pape/7fd9f0ad8f630ff3b5ac021ca3b2b287/raw/9cf0fc50b44704e8a59c4622ced40f16f826b1f0/pr-1418-detail.svg)

## Open decisions (resolved)

| | Question | Answer |
|---|---|---|
| D1 | Root task `status` value | Used existing `not_started` (zero schema churn; derived effective status via `computeTaskStatus`) |
| D2 | Agent delete behavior | Cascade-delete root + descendants (kills non-terminal sessions first) |
| D3 | `resolveSpawnConfig` location | Out of scope — stays in #1427 |
| D4 | Spawn-site refactor scope | Out of scope — stays in #1427 |
| D5 | Auto-root-task hook | Event subscriber in new `agent-root-task-boot.ts`, wired in `event-subscribers.ts` |

## Out of scope (sibling tickets queued under #1412)

- **#1427** — `resolveSpawnConfig` cascade resolver + workspace `defaultRuntime`/`defaultModel` columns.
- **#1438** — Agent heartbeat: cadence + reanimation loop + rules prompt.
- **#1439** — Schedule reroute: existing schedules attach to Agents, fires under Agent identity.
- **#1421** — Inbound channel triggers bound to an Agent.
- **#1419** — Live agent view (depends on #1438).
- **#1420** — Per-agent credentials.
- **"Code is an Agent" unification** — architecturally compatible with this design (Agent with no cadence, delegated identity, `kind=builtin-code`) but deliberately *not* shipped here. No required-fields-Code-couldn't-fill were introduced.
