### PR TITLE
Add rawPrompt option to startTaskSession (prereq #1438)

### DIFF
--- a/common/api/prompt.public.api.md
+++ b/common/api/prompt.public.api.md
@@ -98,6 +98,16 @@ export interface ResolvedPersona {
 export function resolvePersona(requestPersonaId: string, taskDefaultPersonaId: string | undefined, workspaceDefaultPersonaId: string | undefined, appDefaultPersonaId: string | undefined, lookupPersona: (id: string) => PersonaResolveInput | undefined): ResolvedPersona;
 
 // @public
+export function selectTaskPrompt(task: {
+    id: string;
+    title: string;
+    description: string;
+}, options: {
+    notes?: string;
+    rawPrompt?: string;
+}): string;
+
+// @public
 export class SystemPromptBuilder {
     constructor(options: SystemPromptOptions);
     build(): string;

--- a/common/changes/@grackle-ai/cli/nick-pape-1442-rawprompt-option_2026-06-01.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1442-rawprompt-option_2026-06-01.json
@@ -1,0 +1,21 @@
+{
+  "changes": [
+    {
+      "packageName": "@grackle-ai/cli",
+      "comment": "Lockstep version bump for the `rawPrompt` option on `startTaskSession` (#1442, prereq for #1438).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/prompt",
+      "comment": "Add `selectTaskPrompt(task, options)` — picks the first user message bytes for a task spawn, with precedence `rawPrompt` > ROOT_TASK_ID notes > `buildTaskPrompt` wrapping (#1442).",
+      "type": "patch"
+    },
+    {
+      "packageName": "@grackle-ai/core",
+      "comment": "`startTaskSession` accepts a new optional `rawPrompt` argument that bypasses title/description wrapping; existing callers unchanged. Used by the heartbeat fresh-spawn fallback (#1438) and inbound channels (#1421) to match `publishToStdin` bytes (#1442).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -895,6 +895,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.0.1)(sass@1.98.0)(terser@5.46.1)
 
   ../../packages/prompt:
+    dependencies:
+      '@grackle-ai/common':
+        specifier: workspace:*
+        version: link:../common
     devDependencies:
       '@grackle-ai/heft-rig':
         specifier: workspace:*

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -28,7 +28,7 @@ import {
   resolvePersona,
   buildOrchestratorContext,
   SystemPromptBuilder,
-  buildTaskPrompt,
+  selectTaskPrompt,
 } from "@grackle-ai/prompt";
 import { logger } from "./logger.js";
 import { processEventStream } from "./event-processor.js";
@@ -46,11 +46,16 @@ import { hasSpawnContextProviders, runSpawnContextProviders } from "./spawn-cont
  * the runtime on the environment's PowerLine connection. The environment must
  * already be connected — this function does not auto-provision.
  *
+ * Pass `options.rawPrompt` to bypass the default title/description wrapping and
+ * use the given bytes as the first user message verbatim. This matches the
+ * shape that `publishToStdin` would deliver to a reanimated session, used by
+ * the heartbeat fresh-spawn fallback (#1438) and inbound channels (#1421).
+ *
  * @returns An error message string on failure, `undefined` on success.
  */
 export async function startTaskSession(
   task: taskStore.TaskRow,
-  options?: { personaId?: string; environmentId?: string; notes?: string },
+  options?: { personaId?: string; environmentId?: string; notes?: string; rawPrompt?: string },
 ): Promise<string | undefined> {
   const workspace = task.workspaceId ? workspaceStore.getWorkspace(task.workspaceId) : undefined;
   if (task.workspaceId && !workspace) {
@@ -96,13 +101,7 @@ export async function startTaskSession(
   const logPath = join(grackleHome, LOGS_DIR, sessionId);
 
   const freshTask = taskStore.getTask(task.id) || task;
-  // For the root/System task, use the user's chat message (passed as notes)
-  // as the initial prompt instead of the task title "System".
-  // For regular tasks, build the prompt from title + description.
-  const taskPrompt =
-    freshTask.id === ROOT_TASK_ID
-      ? options.notes || ""
-      : buildTaskPrompt(freshTask.title, freshTask.description, options.notes);
+  const taskPrompt = selectTaskPrompt(freshTask, options);
 
   const isOrchestrator = freshTask.canDecompose && freshTask.depth <= 1 && !!freshTask.workspaceId;
   const orchestratorCtx = isOrchestrator

--- a/packages/prompt/package.json
+++ b/packages/prompt/package.json
@@ -35,7 +35,9 @@
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "vitest run --coverage"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@grackle-ai/common": "workspace:*"
+  },
   "devDependencies": {
     "@grackle-ai/heft-rig": "workspace:*",
     "@rushstack/heft": "1.2.7",

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -1,5 +1,5 @@
 // ─── System Prompt Builder ──────────────────────────────────
-export { SystemPromptBuilder, buildTaskPrompt } from "./system-prompt-builder.js";
+export { SystemPromptBuilder, buildTaskPrompt, selectTaskPrompt } from "./system-prompt-builder.js";
 export type {
   SystemPromptOptions,
   TaskTreeNode,

--- a/packages/prompt/src/system-prompt-builder.test.ts
+++ b/packages/prompt/src/system-prompt-builder.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { ROOT_TASK_ID } from "@grackle-ai/common";
 import {
   SystemPromptBuilder,
   buildTaskPrompt,
+  selectTaskPrompt,
   type SystemPromptOptions,
   type TaskTreeNode,
 } from "./system-prompt-builder.js";
@@ -175,6 +177,42 @@ describe("buildTaskPrompt", () => {
 
   it("omits notes when notes are empty", () => {
     expect(buildTaskPrompt("My Task", "Do the thing", "")).toBe("My Task\n\nDo the thing");
+  });
+});
+
+describe("selectTaskPrompt", () => {
+  const leafTask = { id: "task-1", title: "Refactor X", description: "Background notes" };
+  const rootTask = { id: ROOT_TASK_ID, title: "System", description: "" };
+
+  it("returns rawPrompt verbatim, ignoring title/description/notes", () => {
+    expect(
+      selectTaskPrompt(leafTask, { rawPrompt: "exact bytes", notes: "should be ignored" }),
+    ).toBe("exact bytes");
+  });
+
+  it("treats empty rawPrompt as a defined value (not a fallback to wrapping)", () => {
+    expect(selectTaskPrompt(leafTask, { rawPrompt: "", notes: "should be ignored" })).toBe("");
+  });
+
+  it("returns notes raw for ROOT_TASK_ID when rawPrompt is unset", () => {
+    expect(selectTaskPrompt(rootTask, { notes: "hello" })).toBe("hello");
+  });
+
+  it("returns empty string for ROOT_TASK_ID when neither rawPrompt nor notes are set", () => {
+    expect(selectTaskPrompt(rootTask, {})).toBe("");
+  });
+
+  it("wraps via buildTaskPrompt for non-root tasks when rawPrompt is unset", () => {
+    expect(selectTaskPrompt(leafTask, {})).toBe("Refactor X\n\nBackground notes");
+    expect(selectTaskPrompt(leafTask, { notes: "extra context" })).toBe(
+      "Refactor X\n\nBackground notes\n\n## Notes\nextra context",
+    );
+  });
+
+  it("rawPrompt precedence wins over the ROOT_TASK_ID special-case", () => {
+    expect(selectTaskPrompt(rootTask, { rawPrompt: "verbatim", notes: "ignored" })).toBe(
+      "verbatim",
+    );
   });
 });
 

--- a/packages/prompt/src/system-prompt-builder.ts
+++ b/packages/prompt/src/system-prompt-builder.ts
@@ -9,6 +9,8 @@
  * belong in the user prompt (see {@link buildTaskPrompt}).
  */
 
+import { ROOT_TASK_ID } from "@grackle-ai/common";
+
 /** Build the user-facing prompt from task title, description, and optional notes. */
 export function buildTaskPrompt(title: string, description: string, notes?: string): string {
   const parts = [title];
@@ -19,6 +21,35 @@ export function buildTaskPrompt(title: string, description: string, notes?: stri
     parts.push(`## Notes\n${notes}`);
   }
   return parts.join("\n\n");
+}
+
+/**
+ * Select the first user message bytes for a task spawn.
+ *
+ * Precedence:
+ *   1. explicit `rawPrompt` — verbatim, ignoring title/description/notes
+ *   2. ROOT_TASK_ID special-case — `notes` used raw (chat-as-prompt)
+ *   3. default — {@link buildTaskPrompt} wrapping with title + description
+ *
+ * Heartbeat fires (#1438) and inbound channels (#1421) pass `rawPrompt` so the
+ * fresh-spawn path produces the same bytes that `publishToStdin` would deliver
+ * to a reanimated session. Without that escape hatch, the title/description
+ * wrapping would silently diverge across the reanimate vs. fresh-spawn paths.
+ *
+ * Empty string for `rawPrompt` is a defined value (send empty prompt) — checked
+ * with `!== undefined`, not truthiness.
+ */
+export function selectTaskPrompt(
+  task: { id: string; title: string; description: string },
+  options: { notes?: string; rawPrompt?: string },
+): string {
+  if (options.rawPrompt !== undefined) {
+    return options.rawPrompt;
+  }
+  if (task.id === ROOT_TASK_ID) {
+    return options.notes || "";
+  }
+  return buildTaskPrompt(task.title, task.description, options.notes);
 }
 
 // ─── Orchestrator Data Types ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds opt-in `rawPrompt?: string` to `startTaskSession` that bypasses title/description wrapping and uses the bytes verbatim as the first user message. Existing callers untouched.
- Extracts the prompt-selection logic into `selectTaskPrompt` in `@grackle-ai/prompt` (next to `buildTaskPrompt`) — pure helper, exhaustively unit-tested without mocking the dozen stores `startTaskSession` touches.
- Precedence: `rawPrompt` > `ROOT_TASK_ID` notes > `buildTaskPrompt` wrapping. Empty-string `rawPrompt` is a defined value (send empty prompt), not a fallback.

Prereq for #1438 (Agent heartbeat) where the fresh-spawn fallback must produce the same bytes that `publishToStdin` delivers to a reanimated session; also needed by #1421 (inbound channels) where the channel message body IS the prompt.

## Test plan
- [x] Six unit cases in `packages/prompt/src/system-prompt-builder.test.ts` covering rawPrompt precedence, empty-string semantics, ROOT_TASK_ID branch, default wrapping branch, and the precedence override case
- [x] Full `rush build` clean (no `SUCCESS WITH WARNINGS`)
- [x] `rush test -t @grackle-ai/plugin-core -t @grackle-ai/core` passes — existing callers (root-task-boot, dispatch-phase) behavior unchanged
- [x] `rush change --verify` accepts the lockstep change file
- [ ] Live verification deferred to #1438 (this PR has no observable behavior change until a caller sets `rawPrompt`)

Closes #1442