### PR TITLE
Unify spawn-config resolution into a single declared cascade (#1427)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1427-unify-spawn-config_2026-06-02-05-53.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1427-unify-spawn-config_2026-06-02-05-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Unify spawn-config resolution into a single declared cascade/resolver (#1427)",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,3 +129,26 @@ export {
 export { toPersonaResolveInput, buildOrchestratorContextInput } from "./persona-mapper.js";
 export { importAccountsFromGhCli } from "./github-account-import.js";
 export type { ImportAccountsResult } from "./github-account-import.js";
+export {
+  resolveSpawnSpec,
+  mergeToolConfig,
+  mergeMcpServers,
+  personaToLayer,
+  workspaceToLayer,
+  taskToLayer,
+  agentToLayer,
+  spawnRequestToLayer,
+  hostDefaults,
+} from "./resolve-spawn-spec.js";
+export type {
+  SpawnConfigLayer,
+  ResolvedSpawnSpec,
+  ResolveSpawnSpecInput,
+  ToolConfigSpec,
+  McpServerSpec,
+  PersonaConfigSource,
+  WorkspaceConfigSource,
+  TaskConfigSource,
+  AgentConfigSource,
+  SpawnRequestSource,
+} from "./resolve-spawn-spec.js";

--- a/packages/core/src/resolve-spawn-spec.test.ts
+++ b/packages/core/src/resolve-spawn-spec.test.ts
@@ -174,13 +174,30 @@ describe("mergeToolConfig", () => {
     expect(merged.allowedTools.sort()).toEqual(["read", "write"]);
   });
 
-  it("unions disallowedTools across layers — deny wins on conflict", () => {
+  it("unions disallowedTools across layers — deny wins: disallowed tools are stripped from allowed", () => {
     const merged = mergeToolConfig([
       { toolConfig: { allowedTools: ["exec"], disallowedTools: [] } },
       { toolConfig: { allowedTools: [], disallowedTools: ["exec"] } },
     ]);
-    expect(merged.allowedTools).toEqual(["exec"]);
+    expect(merged.allowedTools).toEqual([]);
     expect(merged.disallowedTools).toEqual(["exec"]);
+  });
+
+  it("deny in any layer removes the tool from allowedTools regardless of layer order", () => {
+    // Higher-precedence layer denies; lower-precedence allows.
+    const denyHigh = mergeToolConfig([
+      { toolConfig: { allowedTools: ["exec"], disallowedTools: [] } },
+      { toolConfig: { allowedTools: [], disallowedTools: ["exec"] } },
+    ]);
+    // Higher-precedence layer allows; lower-precedence denies.
+    const denyLow = mergeToolConfig([
+      { toolConfig: { allowedTools: [], disallowedTools: ["exec"] } },
+      { toolConfig: { allowedTools: ["exec"], disallowedTools: [] } },
+    ]);
+    expect(denyHigh.allowedTools).toEqual([]);
+    expect(denyLow.allowedTools).toEqual([]);
+    expect(denyHigh.disallowedTools).toEqual(["exec"]);
+    expect(denyLow.disallowedTools).toEqual(["exec"]);
   });
 
   it("skips layers with no toolConfig contribution", () => {
@@ -246,12 +263,13 @@ describe("personaToLayer — sentinel handling", () => {
     });
     expect(layer.runtime).toBeUndefined();
     expect(layer.model).toBeUndefined();
-    expect(layer.maxTurns).toBeUndefined();
+    // Persona maxTurns=0 means "unlimited" (not "unset"), so it's passed through.
+    expect(layer.maxTurns).toBe(0);
     expect(layer.toolConfig).toBeUndefined();
     expect(layer.mcpServers).toBeUndefined();
   });
 
-  it("treats 0 maxTurns as unset", () => {
+  it("passes maxTurns=0 through (Persona semantics: 0 = unlimited, not unset)", () => {
     const layer = personaToLayer({
       runtime: "claude-code",
       model: "sonnet",
@@ -259,7 +277,7 @@ describe("personaToLayer — sentinel handling", () => {
       toolConfig: "{}",
       mcpServers: "[]",
     });
-    expect(layer.maxTurns).toBeUndefined();
+    expect(layer.maxTurns).toBe(0);
   });
 
   it("parses non-empty toolConfig JSON", () => {
@@ -485,5 +503,43 @@ describe("end-to-end — adapter + resolver against realistic shapes", () => {
     expect(spec.runtime).toBe("copilot");
     expect(spec.model).toBe("opus");
     expect(spec.maxTurns).toBe(25);
+  });
+
+  it("persona maxTurns=0 (unlimited) survives the cascade even when host has a non-zero default", () => {
+    // Demonstrates why personaToLayer passes maxTurns through verbatim: a
+    // future lower-precedence layer with a positive default must not silently
+    // override an explicit "unlimited" expressed by the persona.
+    const persona = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 0, // explicit "unlimited"
+      toolConfig: "{}",
+      mcpServers: "[]",
+    });
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/workspace", maxTurns: 50 }, // would-be host default
+      persona,
+    });
+    expect(spec.maxTurns).toBe(0);
+  });
+
+  it("SpawnRequest maxTurns=0 falls through to persona (proto unset sentinel)", () => {
+    // On the request wire, configMaxTurns=0 means "no opinion; use persona."
+    // This is the inverse of the persona's "0 = unlimited" semantics, and
+    // both adapters get it right.
+    const persona = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 100,
+      toolConfig: "{}",
+      mcpServers: "[]",
+    });
+    const spawnOverride = spawnRequestToLayer({ configMaxTurns: 0 });
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/workspace" },
+      persona,
+      spawnOverride,
+    });
+    expect(spec.maxTurns).toBe(100);
   });
 });

--- a/packages/core/src/resolve-spawn-spec.test.ts
+++ b/packages/core/src/resolve-spawn-spec.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Unit tests for the unified spawn-config cascade (#1427).
+ *
+ * Covers per-field precedence, sentinel-to-undefined handling at each
+ * adapter, missing-layer behavior, and merge semantics for tool/MCP lists.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  resolveSpawnSpec,
+  mergeToolConfig,
+  mergeMcpServers,
+  personaToLayer,
+  workspaceToLayer,
+  taskToLayer,
+  agentToLayer,
+  spawnRequestToLayer,
+  hostDefaults,
+  type SpawnConfigLayer,
+  type ResolveSpawnSpecInput,
+} from "./resolve-spawn-spec.js";
+
+/** Build a minimal valid input — host + persona always present. */
+function baseInput(overrides: Partial<ResolveSpawnSpecInput> = {}): ResolveSpawnSpecInput {
+  return {
+    host: { workingDirectory: "/host" },
+    persona: { runtime: "claude-code", model: "sonnet", maxTurns: 50 },
+    ...overrides,
+  };
+}
+
+describe("resolveSpawnSpec — scalar precedence", () => {
+  it("returns persona+host defaults when no other layer contributes", () => {
+    const spec = resolveSpawnSpec(baseInput());
+    expect(spec.runtime).toBe("claude-code");
+    expect(spec.model).toBe("sonnet");
+    expect(spec.maxTurns).toBe(50);
+    expect(spec.workingDirectory).toBe("/host");
+    expect(spec.useWorktrees).toBeUndefined();
+  });
+
+  it("workspace overrides persona for workingDirectory", () => {
+    const spec = resolveSpawnSpec(baseInput({ workspace: { workingDirectory: "/workspace-wd" } }));
+    expect(spec.workingDirectory).toBe("/workspace-wd");
+  });
+
+  it("task overrides workspace overrides persona overrides host", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host", runtime: "host-runtime" },
+      persona: { runtime: "claude-code", model: "sonnet", workingDirectory: "/persona-wd" },
+      workspace: { workingDirectory: "/workspace-wd" },
+      task: { workingDirectory: "/task-wd" },
+    });
+    expect(spec.workingDirectory).toBe("/task-wd");
+    expect(spec.runtime).toBe("claude-code"); // persona beats host
+  });
+
+  it("agent slots between workspace and task in precedence", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host" },
+      persona: { runtime: "claude-code", model: "sonnet", workingDirectory: "/persona-wd" },
+      workspace: { workingDirectory: "/workspace-wd" },
+      agent: { workingDirectory: "/agent-wd" },
+      // No task contribution: agent wins over workspace.
+    });
+    expect(spec.workingDirectory).toBe("/agent-wd");
+  });
+
+  it("task overrides agent", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host" },
+      persona: { runtime: "claude-code", model: "sonnet" },
+      agent: { workingDirectory: "/agent-wd" },
+      task: { workingDirectory: "/task-wd" },
+    });
+    expect(spec.workingDirectory).toBe("/task-wd");
+  });
+
+  it("spawnOverride beats every other layer", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host", runtime: "host-rt" },
+      persona: { runtime: "persona-rt", model: "persona-model" },
+      workspace: { workingDirectory: "/ws", useWorktrees: true },
+      task: { workingDirectory: "/task", maxTurns: 10 },
+      spawnOverride: {
+        runtime: "override-rt",
+        model: "override-model",
+        workingDirectory: "/override-wd",
+        maxTurns: 99,
+        useWorktrees: false,
+      },
+    });
+    expect(spec.runtime).toBe("override-rt");
+    expect(spec.model).toBe("override-model");
+    expect(spec.workingDirectory).toBe("/override-wd");
+    expect(spec.maxTurns).toBe(99);
+    expect(spec.useWorktrees).toBe(false);
+  });
+});
+
+describe("resolveSpawnSpec — useWorktrees handling", () => {
+  it("respects a false workspace value (false is a real contribution, not unset)", () => {
+    const spec = resolveSpawnSpec(baseInput({ workspace: { useWorktrees: false } }));
+    expect(spec.useWorktrees).toBe(false);
+  });
+
+  it("respects a true workspace value", () => {
+    const spec = resolveSpawnSpec(baseInput({ workspace: { useWorktrees: true } }));
+    expect(spec.useWorktrees).toBe(true);
+  });
+
+  it("spawn override of false beats workspace true", () => {
+    const spec = resolveSpawnSpec(
+      baseInput({
+        workspace: { useWorktrees: true },
+        spawnOverride: { useWorktrees: false },
+      }),
+    );
+    expect(spec.useWorktrees).toBe(false);
+  });
+
+  it("returns undefined when no layer expresses an opinion", () => {
+    const spec = resolveSpawnSpec(baseInput());
+    expect(spec.useWorktrees).toBeUndefined();
+  });
+});
+
+describe("resolveSpawnSpec — missing optional layers", () => {
+  it("works with only host + persona (degenerate spawnAgent path)", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host" },
+      persona: { runtime: "claude-code", model: "sonnet", maxTurns: 42 },
+    });
+    expect(spec.runtime).toBe("claude-code");
+    expect(spec.maxTurns).toBe(42);
+    expect(spec.workingDirectory).toBe("/host");
+  });
+
+  it("works with no spawnOverride layer (task-spawn flow)", () => {
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/host" },
+      persona: { runtime: "claude-code", model: "sonnet" },
+      workspace: { workingDirectory: "/ws", useWorktrees: true },
+      task: {},
+    });
+    expect(spec.workingDirectory).toBe("/ws");
+    expect(spec.useWorktrees).toBe(true);
+  });
+
+  it("agent layer absent does not contribute spurious values", () => {
+    const spec = resolveSpawnSpec(baseInput({ workspace: { workingDirectory: "/ws" } }));
+    expect(spec.workingDirectory).toBe("/ws");
+  });
+});
+
+describe("mergeToolConfig", () => {
+  it("returns empty when no layer contributes", () => {
+    const merged = mergeToolConfig([{}, {}]);
+    expect(merged).toEqual({ allowedTools: [], disallowedTools: [] });
+  });
+
+  it("is identity for a single contributing layer (persona-only behavior)", () => {
+    const merged = mergeToolConfig([
+      { toolConfig: { allowedTools: ["read", "write"], disallowedTools: ["exec"] } },
+    ]);
+    expect(merged.allowedTools).toEqual(["read", "write"]);
+    expect(merged.disallowedTools).toEqual(["exec"]);
+  });
+
+  it("unions allowedTools across layers (low → high)", () => {
+    const merged = mergeToolConfig([
+      { toolConfig: { allowedTools: ["read"], disallowedTools: [] } },
+      { toolConfig: { allowedTools: ["write"], disallowedTools: [] } },
+    ]);
+    expect(merged.allowedTools.sort()).toEqual(["read", "write"]);
+  });
+
+  it("unions disallowedTools across layers — deny wins on conflict", () => {
+    const merged = mergeToolConfig([
+      { toolConfig: { allowedTools: ["exec"], disallowedTools: [] } },
+      { toolConfig: { allowedTools: [], disallowedTools: ["exec"] } },
+    ]);
+    expect(merged.allowedTools).toEqual(["exec"]);
+    expect(merged.disallowedTools).toEqual(["exec"]);
+  });
+
+  it("skips layers with no toolConfig contribution", () => {
+    const merged = mergeToolConfig([
+      {},
+      { toolConfig: { allowedTools: ["read"], disallowedTools: [] } },
+      {},
+    ]);
+    expect(merged.allowedTools).toEqual(["read"]);
+  });
+});
+
+describe("mergeMcpServers", () => {
+  it("returns empty when no layer contributes", () => {
+    expect(mergeMcpServers([{}])).toEqual([]);
+  });
+
+  it("is identity for a single contributing layer (persona-only behavior)", () => {
+    const merged = mergeMcpServers([
+      {
+        mcpServers: [{ name: "github", command: "gh-mcp", args: ["--token", "abc"], tools: [] }],
+      },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe("github");
+    expect(merged[0].args).toEqual(["--token", "abc"]);
+  });
+
+  it("appends new server names from higher layers", () => {
+    const merged = mergeMcpServers([
+      { mcpServers: [{ name: "github", command: "gh", args: [], tools: [] }] },
+      { mcpServers: [{ name: "linear", command: "ln", args: [], tools: [] }] },
+    ]);
+    const names = merged.map((s) => s.name).sort();
+    expect(names).toEqual(["github", "linear"]);
+  });
+
+  it("higher-precedence layer replaces same-name server wholesale", () => {
+    const merged = mergeMcpServers([
+      {
+        mcpServers: [{ name: "github", command: "gh", args: ["--token", "persona"], tools: ["a"] }],
+      },
+      {
+        mcpServers: [
+          { name: "github", command: "gh", args: ["--token", "workspace"], tools: ["b"] },
+        ],
+      },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].args).toEqual(["--token", "workspace"]);
+    expect(merged[0].tools).toEqual(["b"]); // not merged with persona's tools
+  });
+});
+
+describe("personaToLayer — sentinel handling", () => {
+  it("treats empty strings as unset (runtime, model)", () => {
+    const layer = personaToLayer({
+      runtime: "",
+      model: "",
+      maxTurns: 0,
+      toolConfig: "",
+      mcpServers: "",
+    });
+    expect(layer.runtime).toBeUndefined();
+    expect(layer.model).toBeUndefined();
+    expect(layer.maxTurns).toBeUndefined();
+    expect(layer.toolConfig).toBeUndefined();
+    expect(layer.mcpServers).toBeUndefined();
+  });
+
+  it("treats 0 maxTurns as unset", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 0,
+      toolConfig: "{}",
+      mcpServers: "[]",
+    });
+    expect(layer.maxTurns).toBeUndefined();
+  });
+
+  it("parses non-empty toolConfig JSON", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 100,
+      toolConfig: JSON.stringify({ allowedTools: ["read"], disallowedTools: ["exec"] }),
+      mcpServers: "[]",
+    });
+    expect(layer.toolConfig).toEqual({ allowedTools: ["read"], disallowedTools: ["exec"] });
+    expect(layer.maxTurns).toBe(100);
+  });
+
+  it("treats `{}` toolConfig as unset (empty arrays)", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 50,
+      toolConfig: "{}",
+      mcpServers: "[]",
+    });
+    expect(layer.toolConfig).toBeUndefined();
+  });
+
+  it("ignores malformed toolConfig JSON without throwing", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 50,
+      toolConfig: "{not json}",
+      mcpServers: "[]",
+    });
+    expect(layer.toolConfig).toBeUndefined();
+  });
+
+  it("parses non-empty mcpServers JSON", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 50,
+      toolConfig: "{}",
+      mcpServers: JSON.stringify([{ name: "github", command: "gh", args: ["--x"], tools: [] }]),
+    });
+    expect(layer.mcpServers).toHaveLength(1);
+    expect(layer.mcpServers?.[0].name).toBe("github");
+  });
+
+  it("skips mcp entries with no name", () => {
+    const layer = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 50,
+      toolConfig: "{}",
+      mcpServers: JSON.stringify([
+        { name: "", command: "x" },
+        { name: "ok", command: "y" },
+      ]),
+    });
+    expect(layer.mcpServers).toHaveLength(1);
+    expect(layer.mcpServers?.[0].name).toBe("ok");
+  });
+});
+
+describe("workspaceToLayer", () => {
+  it("treats empty workingDirectory as unset", () => {
+    const layer = workspaceToLayer({ useWorktrees: true, workingDirectory: "" });
+    expect(layer.workingDirectory).toBeUndefined();
+  });
+
+  it("propagates a non-empty workingDirectory", () => {
+    const layer = workspaceToLayer({ useWorktrees: false, workingDirectory: "/repo" });
+    expect(layer.workingDirectory).toBe("/repo");
+  });
+
+  it("propagates useWorktrees=false as a real contribution", () => {
+    const layer = workspaceToLayer({ useWorktrees: false, workingDirectory: "" });
+    expect(layer.useWorktrees).toBe(false);
+  });
+});
+
+describe("taskToLayer / agentToLayer", () => {
+  it("return empty contributions (no per-task/per-agent config yet)", () => {
+    expect(taskToLayer({})).toEqual({});
+    expect(agentToLayer({})).toEqual({});
+  });
+});
+
+describe("spawnRequestToLayer", () => {
+  it("treats empty provider/modelId/configMaxTurns/configWorkingDirectory as unset", () => {
+    const layer = spawnRequestToLayer({
+      provider: "",
+      modelId: "",
+      configMaxTurns: 0,
+      configWorkingDirectory: "",
+      configUseWorktrees: undefined,
+    });
+    expect(layer.runtime).toBeUndefined();
+    expect(layer.model).toBeUndefined();
+    expect(layer.maxTurns).toBeUndefined();
+    expect(layer.workingDirectory).toBeUndefined();
+    expect(layer.useWorktrees).toBeUndefined();
+  });
+
+  it("propagates non-empty overrides", () => {
+    const layer = spawnRequestToLayer({
+      provider: "copilot",
+      modelId: "opus",
+      configMaxTurns: 25,
+      configWorkingDirectory: "/explicit",
+      configUseWorktrees: false,
+    });
+    expect(layer.runtime).toBe("copilot");
+    expect(layer.model).toBe("opus");
+    expect(layer.maxTurns).toBe(25);
+    expect(layer.workingDirectory).toBe("/explicit");
+    expect(layer.useWorktrees).toBe(false);
+  });
+
+  it("trims whitespace-only workingDirectory to unset", () => {
+    const layer = spawnRequestToLayer({ configWorkingDirectory: "   " });
+    expect(layer.workingDirectory).toBeUndefined();
+  });
+
+  it("undefined source fields produce undefined contributions", () => {
+    const layer = spawnRequestToLayer({});
+    expect(layer).toEqual({});
+  });
+});
+
+describe("hostDefaults", () => {
+  const original = {
+    wd: process.env.GRACKLE_WORKING_DIRECTORY,
+    base: process.env.GRACKLE_WORKTREE_BASE,
+  };
+
+  beforeEach(() => {
+    delete process.env.GRACKLE_WORKING_DIRECTORY;
+    delete process.env.GRACKLE_WORKTREE_BASE;
+  });
+
+  afterEach(() => {
+    if (original.wd === undefined) {
+      delete process.env.GRACKLE_WORKING_DIRECTORY;
+    } else {
+      process.env.GRACKLE_WORKING_DIRECTORY = original.wd;
+    }
+    if (original.base === undefined) {
+      delete process.env.GRACKLE_WORKTREE_BASE;
+    } else {
+      process.env.GRACKLE_WORKTREE_BASE = original.base;
+    }
+  });
+
+  it("falls back to /workspace when no env var is set", () => {
+    expect(hostDefaults().workingDirectory).toBe("/workspace");
+  });
+
+  it("prefers GRACKLE_WORKING_DIRECTORY when set", () => {
+    process.env.GRACKLE_WORKING_DIRECTORY = "/custom";
+    expect(hostDefaults().workingDirectory).toBe("/custom");
+  });
+
+  it("falls through to GRACKLE_WORKTREE_BASE when WORKING_DIRECTORY is unset", () => {
+    process.env.GRACKLE_WORKTREE_BASE = "/base";
+    expect(hostDefaults().workingDirectory).toBe("/base");
+  });
+
+  it("does not contribute a useWorktrees default (call sites apply their own)", () => {
+    expect(hostDefaults().useWorktrees).toBeUndefined();
+  });
+});
+
+describe("end-to-end — adapter + resolver against realistic shapes", () => {
+  it("startTask flow: workspace + task + persona compose to expected spec", () => {
+    const persona = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 50,
+      toolConfig: JSON.stringify({ allowedTools: ["read"], disallowedTools: [] }),
+      mcpServers: JSON.stringify([
+        { name: "github", command: "gh", args: ["--persona"], tools: [] },
+      ]),
+    });
+    const workspace = workspaceToLayer({ useWorktrees: true, workingDirectory: "/repo" });
+    const task = taskToLayer({});
+    const spawnOverride: SpawnConfigLayer = {}; // startTask has no per-spawn scalar override
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/workspace" },
+      persona,
+      workspace,
+      task,
+      spawnOverride,
+    });
+    expect(spec.runtime).toBe("claude-code");
+    expect(spec.model).toBe("sonnet");
+    expect(spec.maxTurns).toBe(50);
+    expect(spec.workingDirectory).toBe("/repo");
+    expect(spec.useWorktrees).toBe(true);
+    expect(spec.mcpServers).toHaveLength(1);
+    expect(spec.mcpServers[0].name).toBe("github");
+    expect(spec.toolConfig.allowedTools).toEqual(["read"]);
+  });
+
+  it("spawnAgent flow: explicit provider+model+maxTurns override persona", () => {
+    const persona = personaToLayer({
+      runtime: "claude-code",
+      model: "sonnet",
+      maxTurns: 100,
+      toolConfig: "{}",
+      mcpServers: "[]",
+    });
+    const spawnOverride = spawnRequestToLayer({
+      provider: "copilot",
+      modelId: "opus",
+      configMaxTurns: 25,
+    });
+    const spec = resolveSpawnSpec({
+      host: { workingDirectory: "/workspace" },
+      persona,
+      spawnOverride,
+    });
+    expect(spec.runtime).toBe("copilot");
+    expect(spec.model).toBe("opus");
+    expect(spec.maxTurns).toBe(25);
+  });
+});

--- a/packages/core/src/resolve-spawn-spec.ts
+++ b/packages/core/src/resolve-spawn-spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Single declared cascade for the per-spawn config (#1427).
+ *
+ * The session/task spawn handlers used to assemble their config — runtime,
+ * model, max turns, working directory, worktrees, MCP servers, tool policy —
+ * by ad-hoc fallback chains repeated at every call site (`provider ||
+ * persona.runtime`, `cfg?.maxTurns || persona.maxTurns`, etc.). This module
+ * centralizes the cascade so precedence is declared once, tested once, and
+ * extending it (e.g. when the Agent entity becomes config-bearing in the
+ * #1418 follow-up) is a one-line change at the call sites.
+ *
+ * Pure (no I/O). Persona ID selection still runs through {@link
+ * resolvePersona} from `@grackle-ai/prompt` *before* this resolver, because
+ * the persona ID determines which persona record to load; this resolver
+ * accepts the already-loaded layer contributions.
+ *
+ * Precedence (highest first): `spawnOverride > task > agent > workspace >
+ * persona > host`. For scalars (runtime, model, maxTurns, workingDirectory,
+ * useWorktrees), the first layer with a defined contribution wins. For
+ * lists (mcpServers, toolConfig), all contributing layers are merged with
+ * documented semantics (see {@link mergeMcpServers}, {@link mergeToolConfig}).
+ *
+ * @module
+ */
+
+/** Structural view of an MCP server entry — matches `grackle.McpServerConfig`. */
+export interface McpServerSpec {
+  name: string;
+  command: string;
+  args: string[];
+  tools: string[];
+}
+
+/** Structural view of a tool policy — matches `grackle.ToolConfig`. */
+export interface ToolConfigSpec {
+  allowedTools: string[];
+  disallowedTools: string[];
+}
+
+/**
+ * Per-layer contribution to the spawn config. `undefined` on any field means
+ * "this layer makes no contribution; defer to the next layer." Empty arrays
+ * on list fields likewise mean "no contribution" (matches the proto sentinel
+ * for `mcp_servers`/`tool_config` repeated fields).
+ */
+export interface SpawnConfigLayer {
+  runtime?: string;
+  model?: string;
+  maxTurns?: number;
+  workingDirectory?: string;
+  useWorktrees?: boolean;
+  toolConfig?: ToolConfigSpec;
+  mcpServers?: McpServerSpec[];
+}
+
+/** Final resolved spec passed into the runtime SDK's `createSession`. */
+export interface ResolvedSpawnSpec {
+  runtime: string;
+  model: string;
+  maxTurns: number;
+  workingDirectory: string;
+  /**
+   * `undefined` when no layer expressed an opinion — call sites that need a
+   * hard default (e.g. task path: `false` when no workspace exists) apply it
+   * at the boundary. The session path passes `undefined` through to the
+   * adapter so its own host default applies.
+   */
+  useWorktrees: boolean | undefined;
+  toolConfig: ToolConfigSpec;
+  mcpServers: McpServerSpec[];
+}
+
+/** Inputs to {@link resolveSpawnSpec}. Layers are listed lowest → highest precedence. */
+export interface ResolveSpawnSpecInput {
+  /** Process-level defaults (env vars, hardcoded fallbacks). Always present. */
+  host: SpawnConfigLayer;
+  /** Already-resolved persona (via {@link resolvePersona}). Always present. */
+  persona: SpawnConfigLayer;
+  /** Workspace defaults — absent for spawns with no workspace context. */
+  workspace?: SpawnConfigLayer;
+  /**
+   * Standing-Agent defaults — present when an Agent owns the spawn (#1418).
+   * Today contributes nothing (the minimal Agent holds only a persona
+   * reference); reserved so the #1418 follow-up that makes Agents
+   * config-bearing is a one-line adapter change.
+   */
+  agent?: SpawnConfigLayer;
+  /** Task-level overrides — absent for direct spawns without a task. */
+  task?: SpawnConfigLayer;
+  /** Per-spawn explicit overrides from the gRPC request. */
+  spawnOverride?: SpawnConfigLayer;
+}
+
+/**
+ * Resolve a spawn spec from the layered contributions. Precedence (highest
+ * first): `spawnOverride > task > agent > workspace > persona > host`.
+ */
+export function resolveSpawnSpec(input: ResolveSpawnSpecInput): ResolvedSpawnSpec {
+  // High → low precedence. The first layer with a defined scalar wins.
+  const layers: SpawnConfigLayer[] = [
+    input.spawnOverride ?? {},
+    input.task ?? {},
+    input.agent ?? {},
+    input.workspace ?? {},
+    input.persona,
+    input.host,
+  ];
+
+  return {
+    runtime: pickString(layers, "runtime") ?? "",
+    model: pickString(layers, "model") ?? "",
+    maxTurns: pickNumber(layers, "maxTurns") ?? 0,
+    workingDirectory: pickString(layers, "workingDirectory") ?? "",
+    useWorktrees: pickBoolean(layers, "useWorktrees"),
+    // For lists, merge low → high so higher-precedence layers can override.
+    toolConfig: mergeToolConfig([...layers].reverse()),
+    mcpServers: mergeMcpServers([...layers].reverse()),
+  };
+}
+
+function pickString(
+  layers: SpawnConfigLayer[],
+  key: "runtime" | "model" | "workingDirectory",
+): string | undefined {
+  for (const layer of layers) {
+    const v = layer[key];
+    if (v !== undefined) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+function pickNumber(layers: SpawnConfigLayer[], key: "maxTurns"): number | undefined {
+  for (const layer of layers) {
+    const v = layer[key];
+    if (v !== undefined) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+function pickBoolean(layers: SpawnConfigLayer[], key: "useWorktrees"): boolean | undefined {
+  for (const layer of layers) {
+    const v = layer[key];
+    if (v !== undefined) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Merge `ToolConfigSpec` across layers (low → high precedence).
+ *
+ * - `allowedTools`: union of every contributing layer's list.
+ * - `disallowedTools`: union of every contributing layer's list (deny wins
+ *   even when a higher-precedence layer allows the same tool).
+ *
+ * Rationale: workspace/task/agent overrides should *tighten* persona's
+ * permissions, not widen them. A `disallowedTools` entry in any layer
+ * forbids the tool regardless of `allowedTools` at higher layers.
+ *
+ * @param layers - Layers in low → high precedence order (e.g.
+ *   `[host, persona, workspace, agent, task, spawnOverride]`).
+ */
+export function mergeToolConfig(layers: SpawnConfigLayer[]): ToolConfigSpec {
+  const allowed = new Set<string>();
+  const disallowed = new Set<string>();
+  for (const layer of layers) {
+    const tc = layer.toolConfig;
+    if (!tc) {
+      continue;
+    }
+    for (const t of tc.allowedTools) {
+      allowed.add(t);
+    }
+    for (const t of tc.disallowedTools) {
+      disallowed.add(t);
+    }
+  }
+  return {
+    allowedTools: [...allowed],
+    disallowedTools: [...disallowed],
+  };
+}
+
+/**
+ * Merge `McpServerSpec[]` across layers (low → high precedence). Servers
+ * key by `name`: a higher-precedence layer's same-name entry **replaces**
+ * the lower-precedence one wholesale; new names append.
+ *
+ * Rationale: a workspace's `"github"` MCP server (e.g. different auth token)
+ * should override the persona's, not silently merge `args`/`tools`.
+ *
+ * @param layers - Layers in low → high precedence order.
+ */
+export function mergeMcpServers(layers: SpawnConfigLayer[]): McpServerSpec[] {
+  const byName = new Map<string, McpServerSpec>();
+  for (const layer of layers) {
+    const servers = layer.mcpServers;
+    if (!servers || servers.length === 0) {
+      continue;
+    }
+    for (const s of servers) {
+      byName.set(s.name, s);
+    }
+  }
+  return [...byName.values()];
+}
+
+// ─── Source adapters ──────────────────────────────────────────────────────
+// Each adapter converts a source shape's proto/db sentinels (empty string,
+// zero, empty array) into `undefined` so the resolver remains field-agnostic.
+
+/** Subset of `ResolvedPersona` used to build the persona layer contribution. */
+export interface PersonaConfigSource {
+  runtime: string;
+  model: string;
+  maxTurns: number;
+  /** JSON string — see `Persona.tool_config` (`{}` is the empty sentinel). */
+  toolConfig: string;
+  /** JSON string — see `Persona.mcp_servers` (`[]` or `""` is the empty sentinel). */
+  mcpServers: string;
+}
+
+/**
+ * Build a persona-layer contribution from an already-resolved persona record.
+ * Caller resolves the persona via `resolvePersona()` from `@grackle-ai/prompt`.
+ */
+export function personaToLayer(p: PersonaConfigSource): SpawnConfigLayer {
+  return {
+    runtime: p.runtime || undefined,
+    model: p.model || undefined,
+    maxTurns: p.maxTurns || undefined,
+    toolConfig: parseToolConfigJson(p.toolConfig),
+    mcpServers: parseMcpServersJson(p.mcpServers),
+  };
+}
+
+/** Subset of `WorkspaceRow` used to build the workspace layer contribution. */
+export interface WorkspaceConfigSource {
+  useWorktrees: boolean;
+  workingDirectory: string;
+}
+
+/** Build a workspace-layer contribution from a workspace row. */
+export function workspaceToLayer(w: WorkspaceConfigSource): SpawnConfigLayer {
+  return {
+    workingDirectory: w.workingDirectory || undefined,
+    // `useWorktrees` is a real boolean on the workspace (default true on
+    // insert) — both `true` and `false` are intentional contributions.
+    useWorktrees: w.useWorktrees,
+  };
+}
+
+/** Subset of `TaskRow` reserved for future per-task config (#1418 follow-up). */
+export interface TaskConfigSource {
+  // Today the task contributes nothing to the spawn cascade. Reserved as
+  // the documented seam for per-task overrides (e.g. per-task maxTurns).
+}
+
+/** Build a task-layer contribution. Currently empty by design. */
+export function taskToLayer(_t: TaskConfigSource): SpawnConfigLayer {
+  return {};
+}
+
+/**
+ * Subset of `AgentRow` reserved for the #1418 follow-up that makes Agents
+ * config-bearing. Today the minimal Agent holds only `primaryPersonaId`
+ * (already consumed via the persona-ID cascade in `resolvePersona`), so this
+ * layer contributes nothing.
+ */
+export interface AgentConfigSource {
+  // Reserved for the #1418 follow-up.
+}
+
+/** Build an agent-layer contribution. Currently empty by design. */
+export function agentToLayer(_a: AgentConfigSource): SpawnConfigLayer {
+  return {};
+}
+
+/**
+ * Spawn-time overrides from a `grackle.SpawnRequest`. Reads only the fields
+ * the resolver cares about so the adapter can be exercised in tests without
+ * constructing a full proto message.
+ */
+export interface SpawnRequestSource {
+  /** `SpawnRequest.provider` — `""` = unset. */
+  provider?: string;
+  /** `SpawnRequest.model.id` — `""` = unset. */
+  modelId?: string;
+  /** `SpawnRequest.config.max_turns` — `0` = unset. */
+  configMaxTurns?: number;
+  /** `SpawnRequest.config.working_directory` — `""` = unset (trimmed). */
+  configWorkingDirectory?: string;
+  /** `SpawnRequest.config.use_worktrees` — proto3 optional, `undefined` = unset. */
+  configUseWorktrees?: boolean;
+}
+
+/** Build a spawn-override layer from the relevant `SpawnRequest` fields. */
+export function spawnRequestToLayer(src: SpawnRequestSource): SpawnConfigLayer {
+  const wd = (src.configWorkingDirectory ?? "").trim();
+  return {
+    runtime: src.provider || undefined,
+    model: src.modelId || undefined,
+    maxTurns: src.configMaxTurns || undefined,
+    workingDirectory: wd || undefined,
+    useWorktrees: src.configUseWorktrees,
+  };
+}
+
+/**
+ * Host-level defaults — env-var fallbacks for working directory, with the
+ * legacy hardcoded `/workspace` default applied when neither env var is set.
+ * `useWorktrees` is intentionally omitted; call sites that require a hard
+ * default apply it at the boundary (the resolver leaves it `undefined` so
+ * the adapter's own default can apply).
+ */
+export function hostDefaults(): SpawnConfigLayer {
+  return {
+    workingDirectory:
+      process.env.GRACKLE_WORKING_DIRECTORY || process.env.GRACKLE_WORKTREE_BASE || "/workspace",
+  };
+}
+
+// ─── JSON parsers for persona-stored config ──────────────────────────────
+
+function parseToolConfigJson(json: string): ToolConfigSpec | undefined {
+  if (!json) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const obj = parsed as { allowedTools?: unknown; disallowedTools?: unknown };
+  const allowed = stringArray(obj.allowedTools);
+  const disallowed = stringArray(obj.disallowedTools);
+  if (allowed.length === 0 && disallowed.length === 0) {
+    return undefined;
+  }
+  return { allowedTools: allowed, disallowedTools: disallowed };
+}
+
+function parseMcpServersJson(json: string): McpServerSpec[] | undefined {
+  if (!json) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return undefined;
+  }
+  const servers: McpServerSpec[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const e = entry as {
+      name?: unknown;
+      command?: unknown;
+      args?: unknown;
+      tools?: unknown;
+    };
+    if (typeof e.name !== "string" || !e.name) {
+      continue;
+    }
+    servers.push({
+      name: e.name,
+      command: typeof e.command === "string" ? e.command : "",
+      args: stringArray(e.args),
+      tools: stringArray(e.tools),
+    });
+  }
+  return servers.length > 0 ? servers : undefined;
+}
+
+function stringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) {
+    return [];
+  }
+  return v.filter((x): x is string => typeof x === "string");
+}

--- a/packages/core/src/resolve-spawn-spec.ts
+++ b/packages/core/src/resolve-spawn-spec.ts
@@ -154,9 +154,11 @@ function pickBoolean(layers: SpawnConfigLayer[], key: "useWorktrees"): boolean |
 /**
  * Merge `ToolConfigSpec` across layers (low → high precedence).
  *
- * - `allowedTools`: union of every contributing layer's list.
- * - `disallowedTools`: union of every contributing layer's list (deny wins
- *   even when a higher-precedence layer allows the same tool).
+ * - `disallowedTools`: union of every contributing layer's list.
+ * - `allowedTools`: union of every contributing layer's list, then
+ *   **filtered** so any tool in `disallowedTools` is removed. Deny-wins is
+ *   enforced *here* so consumers can use `allowedTools` directly without
+ *   re-implementing the rule (and without risking accidental allows).
  *
  * Rationale: workspace/task/agent overrides should *tighten* persona's
  * permissions, not widen them. A `disallowedTools` entry in any layer
@@ -179,6 +181,9 @@ export function mergeToolConfig(layers: SpawnConfigLayer[]): ToolConfigSpec {
     for (const t of tc.disallowedTools) {
       disallowed.add(t);
     }
+  }
+  for (const t of disallowed) {
+    allowed.delete(t);
   }
   return {
     allowedTools: [...allowed],
@@ -228,12 +233,20 @@ export interface PersonaConfigSource {
 /**
  * Build a persona-layer contribution from an already-resolved persona record.
  * Caller resolves the persona via `resolvePersona()` from `@grackle-ai/prompt`.
+ *
+ * `maxTurns` is passed through verbatim: on a persona, `0` documents
+ * *unlimited* (per `PersonaResolveInput` in `@grackle-ai/prompt`), not
+ * "unset" — so the persona always contributes a concrete value and a
+ * future lower-precedence default cannot accidentally override an explicit
+ * "unlimited". The `SpawnRequest`-side adapter normalizes `0 → undefined`
+ * because for the `SessionConfig.max_turns` proto field, `0` is the
+ * unset sentinel that means "use the persona default."
  */
 export function personaToLayer(p: PersonaConfigSource): SpawnConfigLayer {
   return {
     runtime: p.runtime || undefined,
     model: p.model || undefined,
-    maxTurns: p.maxTurns || undefined,
+    maxTurns: p.maxTurns,
     toolConfig: parseToolConfigJson(p.toolConfig),
     mcpServers: parseMcpServersJson(p.mcpServers),
   };

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -38,6 +38,13 @@ import { emit } from "./event-bus.js";
 import { createScopedToken, loadOrCreateApiKey } from "@grackle-ai/auth";
 import { toPersonaResolveInput, buildOrchestratorContextInput } from "./persona-mapper.js";
 import { hasSpawnContextProviders, runSpawnContextProviders } from "./spawn-context-registry.js";
+import {
+  resolveSpawnSpec,
+  personaToLayer,
+  workspaceToLayer,
+  taskToLayer,
+  hostDefaults,
+} from "./resolve-spawn-spec.js";
 
 /**
  * Start a new agent session for a task.
@@ -97,7 +104,16 @@ export async function startTaskSession(
   }
 
   const sessionId = uuid();
-  const { runtime, model, maxTurns, systemPrompt } = resolved;
+
+  // Unified spawn-config cascade (#1427): host → persona → workspace → task.
+  const spec = resolveSpawnSpec({
+    host: hostDefaults(),
+    persona: personaToLayer(resolved),
+    workspace: workspace ? workspaceToLayer(workspace) : undefined,
+    task: taskToLayer({}),
+  });
+  const { runtime, model, maxTurns } = spec;
+  const { systemPrompt } = resolved;
   const logPath = join(grackleHome, LOGS_DIR, sessionId);
 
   const freshTask = taskStore.getTask(task.id) || task;
@@ -212,7 +228,8 @@ export async function startTaskSession(
     loadOrCreateApiKey(grackleHome),
   );
 
-  const useWorktrees = workspace?.useWorktrees ?? false;
+  // Preserve historical default of `false` when no workspace expresses an opinion.
+  const useWorktrees = spec.useWorktrees ?? false;
 
   const { stream } = conn.transport.createSession({
     sessionId,
@@ -221,12 +238,8 @@ export async function startTaskSession(
     model,
     maxTurns,
     branch: freshTask.branch,
-    workingDirectory: freshTask.branch
-      ? workspace?.workingDirectory ||
-        process.env.GRACKLE_WORKING_DIRECTORY ||
-        process.env.GRACKLE_WORKTREE_BASE ||
-        "/workspace"
-      : "",
+    // "no branch → no working dir" stays a workflow rule at the call site.
+    workingDirectory: freshTask.branch ? spec.workingDirectory : "",
     useWorktrees,
     systemContext,
     workspaceId: freshTask.workspaceId ?? undefined,

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -48,7 +48,13 @@ import { deliverPendingEscalations } from "@grackle-ai/core";
 import { createEventStream } from "@grackle-ai/core";
 import { sessionRowToProto } from "./grpc-proto-converters.js";
 import { validatePipeInputs, toDialableHost, killSessionAndCleanup } from "./grpc-shared.js";
-import { resolveSpawnSelection, buildCreateSessionParams } from "./spawn-request.js";
+import { buildCreateSessionParams } from "./spawn-request.js";
+import {
+  resolveSpawnSpec,
+  personaToLayer,
+  spawnRequestToLayer,
+  hostDefaults,
+} from "@grackle-ai/core";
 import { personaMcpServersToJson } from "@grackle-ai/core";
 import { getTraceId } from "@grackle-ai/core";
 import { resolveBootstrapRuntime } from "@grackle-ai/core";
@@ -159,10 +165,21 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
   const sessionId = uuid();
   const cfg = req.config;
   const parentSessionId = cfg?.parentSessionId ?? "";
-  const { runtime, model } = resolveSpawnSelection(req.provider, req.model?.id ?? "", {
-    runtime: resolved.runtime,
-    model: resolved.model,
+
+  // Unified spawn-config cascade (#1427): host → persona → spawnOverride. No
+  // workspace/task/agent layers here — direct spawnAgent has no task context.
+  const spec = resolveSpawnSpec({
+    host: hostDefaults(),
+    persona: personaToLayer(resolved),
+    spawnOverride: spawnRequestToLayer({
+      provider: req.provider,
+      modelId: req.model?.id,
+      configMaxTurns: cfg?.maxTurns,
+      configWorkingDirectory: cfg?.workingDirectory,
+      configUseWorktrees: cfg?.useWorktrees,
+    }),
   });
+  const { runtime, model, maxTurns } = spec;
 
   // Supply credentials on demand for this runtime, just before spawn (AHP HR6).
   // For local envs, skip file tokens — the PowerLine is on the same machine.
@@ -174,7 +191,6 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
     env.adapterType === "local" ? { excludeFileTokens: true } : undefined,
   );
 
-  const maxTurns = cfg?.maxTurns || resolved.maxTurns;
   const logPath = join(grackleHome, LOGS_DIR, sessionId);
 
   const builderPrompt = new SystemPromptBuilder({
@@ -242,12 +258,10 @@ export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Ses
     loadOrCreateApiKey(grackleHome),
   );
 
-  const workingDirectory = cfg?.branch
-    ? (cfg?.workingDirectory ?? "").trim() ||
-      process.env.GRACKLE_WORKING_DIRECTORY ||
-      process.env.GRACKLE_WORKTREE_BASE ||
-      "/workspace"
-    : "";
+  // `workingDirectory` is only meaningful when the session pins to a branch
+  // — the workflow rule "no branch → no working dir" stays at the call site;
+  // the cascade itself is handled by resolveSpawnSpec above.
+  const workingDirectory = cfg?.branch ? spec.workingDirectory : "";
   const createParams = buildCreateSessionParams({
     sessionId,
     runtime,

--- a/packages/plugin-core/src/spawn-request.test.ts
+++ b/packages/plugin-core/src/spawn-request.test.ts
@@ -1,14 +1,12 @@
 /**
- * Unit tests for the createSession (AHP HR4+5) spawn-shape helpers:
- * runtime/model override resolution and the config→PowerLine wire mapping
- * (task_id plumbing + optional use_worktrees passthrough).
+ * Unit tests for the createSession (AHP HR4+5) config→PowerLine wire mapping
+ * (task_id plumbing + optional use_worktrees passthrough). Cascade resolution
+ * tests live in `resolve-spawn-spec.test.ts` (#1427).
  */
 import { describe, it, expect } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import { resolveSpawnSelection, buildCreateSessionParams } from "./spawn-request.js";
-
-const persona = { runtime: "claude-code", model: "sonnet" };
+import { buildCreateSessionParams } from "./spawn-request.js";
 
 const serverInputs = {
   sessionId: "sess-1",
@@ -24,36 +22,6 @@ const serverInputs = {
   workingDirectory: "",
   workspaceId: "",
 };
-
-describe("resolveSpawnSelection", () => {
-  it("uses an explicit provider over the persona runtime", () => {
-    expect(resolveSpawnSelection("copilot", "", persona)).toEqual({
-      runtime: "copilot",
-      model: "sonnet",
-    });
-  });
-
-  it("uses an explicit model id over the persona model", () => {
-    expect(resolveSpawnSelection("", "opus", persona)).toEqual({
-      runtime: "claude-code",
-      model: "opus",
-    });
-  });
-
-  it("overrides both when both are provided", () => {
-    expect(resolveSpawnSelection("codex", "o3", persona)).toEqual({
-      runtime: "codex",
-      model: "o3",
-    });
-  });
-
-  it("falls back to the persona when neither is provided", () => {
-    expect(resolveSpawnSelection("", "", persona)).toEqual({
-      runtime: "claude-code",
-      model: "sonnet",
-    });
-  });
-});
 
 describe("buildCreateSessionParams", () => {
   it("plumbs task_id from config (no longer hardcoded empty)", () => {

--- a/packages/plugin-core/src/spawn-request.ts
+++ b/packages/plugin-core/src/spawn-request.ts
@@ -1,29 +1,15 @@
 /**
- * Pure helpers for the createSession (AHP HR4+5) spawn shape: resolving the
- * runtime/model selection and mapping the reshaped `grackle.SpawnRequest`
- * `config` onto the host-transport `CreateSessionParams`. Kept free of I/O
- * (and of the core/database import graph) so the wire mapping is
- * unit-testable.
+ * Pure helper for mapping the reshaped `grackle.SpawnRequest` `config` onto
+ * the host-transport `CreateSessionParams`. Kept free of I/O (and of the
+ * core/database import graph) so the wire mapping is unit-testable.
+ *
+ * Runtime/model/maxTurns/workingDirectory/useWorktrees cascade resolution
+ * lives in `@grackle-ai/core`'s `resolveSpawnSpec` (#1427).
  *
  * @module
  */
 import { grackle } from "@grackle-ai/common";
 import type { CreateSessionParams } from "@grackle-ai/adapter-sdk";
-
-/**
- * Resolve the runtime + model for a spawn, honoring explicit request overrides
- * (AHP createSession `provider`/`model`) over the resolved persona's defaults.
- */
-export function resolveSpawnSelection(
-  provider: string,
-  modelId: string,
-  persona: { runtime: string; model: string },
-): { runtime: string; model: string } {
-  return {
-    runtime: provider || persona.runtime,
-    model: modelId || persona.model,
-  };
-}
 
 /** Server-resolved values for a spawn that don't come from the client `config`. */
 export interface CreateSessionInputs {

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -59,6 +59,13 @@ import { validatePipeInputs, toDialableHost, resolveAncestorEnvironmentId } from
 import { personaMcpServersToJson } from "@grackle-ai/core";
 import { hasCapacity, type ConcurrencyDeps, checkBudget } from "@grackle-ai/core";
 import { hasSpawnContextProviders, runSpawnContextProviders } from "@grackle-ai/core";
+import {
+  resolveSpawnSpec,
+  personaToLayer,
+  workspaceToLayer,
+  taskToLayer,
+  hostDefaults,
+} from "@grackle-ai/core";
 
 /** Weighted fields for fuzzy task search: title is twice as important as description. */
 const TASK_SEARCH_KEYS: FuzzyKey[] = [
@@ -409,7 +416,19 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
 
   const env = envRegistry.getEnvironment(environmentId);
   const sessionId = uuid();
-  const { runtime, model, maxTurns, systemPrompt } = resolved;
+
+  // Unified spawn-config cascade (#1427): host → persona → workspace → task.
+  // startTask has no scalar spawnOverride layer (no provider/model/maxTurns
+  // overrides on the request); per-task overrides land here once #1418's
+  // follow-up makes Agents/Tasks config-bearing.
+  const spec = resolveSpawnSpec({
+    host: hostDefaults(),
+    persona: personaToLayer(resolved),
+    workspace: workspace ? workspaceToLayer(workspace) : undefined,
+    task: taskToLayer({}),
+  });
+  const { runtime, model, maxTurns } = spec;
+  const { systemPrompt } = resolved;
   const logPath = join(grackleHome, LOGS_DIR, sessionId);
 
   // Supply credentials on demand for this runtime, just before spawn (AHP HR6).
@@ -499,7 +518,10 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
 
   const mcpServersJson = personaMcpServersToJson(resolved.mcpServers, resolved.personaId);
 
-  const useWorktrees = workspace?.useWorktrees ?? false;
+  // Preserve the task-path's historical default of `false` when no workspace
+  // expresses an opinion (e.g. root/schedule/channel tasks without a
+  // workspaceId). The cascade itself is handled by resolveSpawnSpec above.
+  const useWorktrees = spec.useWorktrees ?? false;
   if (!useWorktrees) {
     logger.warn(
       { taskId: task.id, workspaceId: task.workspaceId, branch: task.branch },
@@ -530,9 +552,9 @@ export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.
     model,
     maxTurns,
     branch: task.branch,
-    workingDirectory: task.branch
-      ? workspace?.workingDirectory || process.env.GRACKLE_WORKTREE_BASE || "/workspace"
-      : "",
+    // "no branch → no working dir" stays a workflow rule at the call site;
+    // the cascade for the populated case is handled by resolveSpawnSpec.
+    workingDirectory: task.branch ? spec.workingDirectory : "",
     useWorktrees,
     systemContext,
     workspaceId: task.workspaceId ?? undefined,


### PR DESCRIPTION
Closes #1427.

## Summary

The per-spawn config (runtime, model, max turns, working directory, worktrees, MCP servers, tool policy) was assembled by ad-hoc fallback chains repeated at every spawn site — three of them, each consulting a different subset of layers. Every new config dimension meant editing all three.

This PR introduces a single declared cascade in `@grackle-ai/core`:

\`\`\`ts
resolveSpawnSpec({ host, persona, workspace?, agent?, task?, spawnOverride? }) → ResolvedSpawnSpec
\`\`\`

- Precedence: \`spawnOverride > task > agent > workspace > persona > host\` — declared once.
- Sentinel-to-undefined normalization at layer entry (\`personaToLayer\`, \`workspaceToLayer\`, \`spawnRequestToLayer\`, \`hostDefaults\`). Empty strings, \`0\`, and \`{}\`/\`[]\` collapse to \`undefined\` so the resolver stays field-agnostic.
- Layered merge for \`mcpServers\` (replace-by-name) and \`toolConfig\` (union of allows, deny-wins on disallows) — semantics documented, tested, and ready for the workspace/agent layers to start contributing.
- \`agentToLayer\` and \`taskToLayer\` are reserved no-op seams: when #1418's follow-up makes Agents/Tasks config-bearing, populating them is a one-line adapter change rather than re-implementing fallbacks at every site.

## Migrated call sites

The deprecated \`resolveSpawnSelection\` helper (\`runtime || persona.runtime\`) is subsumed and removed; \`buildCreateSessionParams\` (pure proto→SDK mapper) is unchanged.

| Site | File | Before | After |
|---|---|---|---|
| \`spawnAgent\` | \`packages/plugin-core/src/session-handlers.ts\` | 3 inline cascades + \`resolveSpawnSelection\` | one \`resolveSpawnSpec\` call |
| \`startTask\` | \`packages/plugin-core/src/task-handlers.ts\` | 2 inline cascades + \`workspace?.useWorktrees ?? false\` | one \`resolveSpawnSpec\` call (\`?? false\` boundary preserved) |
| \`startTaskSession\` | \`packages/core/src/task-session.ts\` | same 2 inline cascades (cron/root/heartbeat path) | one \`resolveSpawnSpec\` call |

## Out of scope (intentional)

- **Budgets** (\`tokenBudget\`, \`costBudgetMillicents\`) — a *check* problem aggregated via \`budget-checker.ts\`, not a *selection* problem. Different shape; can be a parallel \`resolveBudgetSpec\` if desired.
- **SystemPromptBuilder composition** — single-source-per-field, not cascade.
- **Per-agent config fields** — Agent is not config-bearing today; \`agentToLayer\` is reserved for the #1418 follow-up.
- **Proto changes** — none. The resolver consumes existing \`Persona\`, \`Workspace\`, \`Task\`, \`Agent\`, \`SpawnRequest\`, \`SessionConfig\` shapes.

## Test plan

- [x] 43 new unit tests in \`packages/core/src/resolve-spawn-spec.test.ts\` covering per-field precedence, sentinel handling at each adapter, missing-layer behavior, tool/MCP merge semantics, and end-to-end realistic compositions
- [x] \`rush build -t @grackle-ai/plugin-core\` clean (no warnings)
- [x] \`@grackle-ai/core\` + \`@grackle-ai/plugin-core\` test suites green
- [ ] Full \`rush test\` (was hanging locally on \`rush\` orchestration before push — relying on CI for clean single-checkout run)
- [ ] Live smoke via \`/launch-grackle\` after CI is green (spawn agent with persona/workspace/task overrides; verify runtime/model/working-dir cascade)