### PR TITLE
Support GRACKLE_API_KEY env var on the server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,9 @@
 # GRACKLE_URL=http://127.0.0.1:7434
 
 # API key for authenticating with the server (used by both server and CLI).
-# If set, the server uses this instead of reading/generating ~/.grackle/api-key.
-# Useful for injecting a stable key from a secrets manager (e.g., Vault/bao).
+# If set to a non-empty value, the server uses this instead of
+# reading/generating ~/.grackle/api-key. Empty or whitespace-only values
+# are ignored. Useful for injecting a stable key from a secrets manager.
 # GRACKLE_API_KEY=
 
 # ── Server Behavior ───────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -104,8 +104,9 @@
 # gRPC server URL used by the CLI and MCP clients.
 # GRACKLE_URL=http://127.0.0.1:7434
 
-# API key for authenticating with the server.
-# Generated automatically on first run; override for scripted setups.
+# API key for authenticating with the server (used by both server and CLI).
+# If set, the server uses this instead of reading/generating ~/.grackle/api-key.
+# Useful for injecting a stable key from a secrets manager (e.g., Vault/bao).
 # GRACKLE_API_KEY=
 
 # ── Server Behavior ───────────────────────────────────────────────

--- a/apps/docs-site/docs/features/credentials.md
+++ b/apps/docs-site/docs/features/credentials.md
@@ -130,6 +130,18 @@ export GRACKLE_API_KEY=<your-key>
 grackle env list
 ```
 
+#### Injecting the key from a secrets manager
+
+Both the **server** and the **CLI** respect the `GRACKLE_API_KEY` environment variable. When the server sees it, it skips the on-disk read/generate entirely and uses the env value as the API key. This lets you source a stable key from a secrets manager (Vault, bao, AWS Secrets Manager, etc.) instead of relying on the auto-generated file:
+
+```bash
+# Docker / systemd example — inject from your secrets backend
+export GRACKLE_API_KEY="$(vault kv get -field=api_key secret/grackle)"
+grackle serve
+```
+
+If `GRACKLE_API_KEY` is unset, the server falls back to the original behavior: read `~/.grackle/api-key`, or generate one on first run.
+
 ### Pairing code → session cookie (web)
 
 The browser never sees the API key. It earns a session by pairing.

--- a/apps/docs-site/docs/features/credentials.md
+++ b/apps/docs-site/docs/features/credentials.md
@@ -132,7 +132,7 @@ grackle env list
 
 #### Injecting the key from a secrets manager
 
-Both the **server** and the **CLI** respect the `GRACKLE_API_KEY` environment variable. When the server sees it, it skips the on-disk read/generate entirely and uses the env value as the API key. This lets you source a stable key from a secrets manager (Vault, bao, AWS Secrets Manager, etc.) instead of relying on the auto-generated file:
+Both the **server** and the **CLI** respect the `GRACKLE_API_KEY` environment variable. When set to a non-empty value, the server skips the on-disk read/generate entirely and uses the env value as the API key (leading/trailing whitespace is trimmed). This lets you source a stable key from a secrets manager (Vault, bao, AWS Secrets Manager, etc.) instead of relying on the auto-generated file:
 
 ```bash
 # Docker / systemd example — inject from your secrets backend
@@ -140,7 +140,7 @@ export GRACKLE_API_KEY="$(vault kv get -field=api_key secret/grackle)"
 grackle serve
 ```
 
-If `GRACKLE_API_KEY` is unset, the server falls back to the original behavior: read `~/.grackle/api-key`, or generate one on first run.
+If `GRACKLE_API_KEY` is unset or empty, the server falls back to the original behavior: read `~/.grackle/api-key`, or generate one on first run.
 
 ### Pairing code → session cookie (web)
 

--- a/common/changes/@grackle-ai/cli/nick-pape-grackle-api-key-env_2026-06-03-02-23.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-grackle-api-key-env_2026-06-03-02-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Support GRACKLE_API_KEY env var on the server for injecting API keys from a secrets manager",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/auth/src/api-key.test.ts
+++ b/packages/auth/src/api-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { loadOrCreateApiKey, verifyApiKey, _resetCachedKeyForTesting } from "./api-key.js";
@@ -18,6 +18,7 @@ describe("api-key", () => {
 
   afterEach(() => {
     _resetCachedKeyForTesting();
+    rmSync(tempDir, { recursive: true, force: true });
     if (savedEnv !== undefined) {
       process.env.GRACKLE_API_KEY = savedEnv;
     } else {

--- a/packages/auth/src/api-key.test.ts
+++ b/packages/auth/src/api-key.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadOrCreateApiKey, verifyApiKey, _resetCachedKeyForTesting } from "./api-key.js";
+import { API_KEY_FILENAME } from "@grackle-ai/common";
+
+describe("api-key", () => {
+  let tempDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    _resetCachedKeyForTesting();
+    tempDir = mkdtempSync(join(tmpdir(), "grackle-api-key-test-"));
+    savedEnv = process.env.GRACKLE_API_KEY;
+    delete process.env.GRACKLE_API_KEY;
+  });
+
+  afterEach(() => {
+    _resetCachedKeyForTesting();
+    if (savedEnv !== undefined) {
+      process.env.GRACKLE_API_KEY = savedEnv;
+    } else {
+      delete process.env.GRACKLE_API_KEY;
+    }
+  });
+
+  describe("loadOrCreateApiKey", () => {
+    it("generates a key on disk when no file or env var exists", () => {
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toHaveLength(64);
+      const onDisk = readFileSync(join(tempDir, API_KEY_FILENAME), "utf8").trim();
+      expect(onDisk).toBe(key);
+    });
+
+    it("reads an existing key from disk", () => {
+      const existingKey = "b".repeat(64);
+      writeFileSync(join(tempDir, API_KEY_FILENAME), existingKey + "\n");
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toBe(existingKey);
+    });
+
+    it("uses GRACKLE_API_KEY env var when set", () => {
+      const envKey = "c".repeat(64);
+      process.env.GRACKLE_API_KEY = envKey;
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toBe(envKey);
+      expect(existsSync(join(tempDir, API_KEY_FILENAME))).toBe(false);
+    });
+
+    it("env var takes precedence over file on disk", () => {
+      const diskKey = "d".repeat(64);
+      const envKey = "e".repeat(64);
+      writeFileSync(join(tempDir, API_KEY_FILENAME), diskKey + "\n");
+      process.env.GRACKLE_API_KEY = envKey;
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toBe(envKey);
+    });
+
+    it("ignores empty or whitespace-only GRACKLE_API_KEY", () => {
+      process.env.GRACKLE_API_KEY = "   ";
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toHaveLength(64);
+      expect(existsSync(join(tempDir, API_KEY_FILENAME))).toBe(true);
+    });
+
+    it("trims whitespace from GRACKLE_API_KEY", () => {
+      const envKey = "f".repeat(64);
+      process.env.GRACKLE_API_KEY = `  ${envKey}  `;
+      const key = loadOrCreateApiKey(tempDir);
+      expect(key).toBe(envKey);
+    });
+
+    it("returns cached key on subsequent calls", () => {
+      const key1 = loadOrCreateApiKey(tempDir);
+      const key2 = loadOrCreateApiKey(tempDir);
+      expect(key1).toBe(key2);
+    });
+  });
+
+  describe("verifyApiKey", () => {
+    it("returns true for a matching token", () => {
+      const key = loadOrCreateApiKey(tempDir);
+      expect(verifyApiKey(key)).toBe(true);
+    });
+
+    it("returns false for a non-matching token", () => {
+      loadOrCreateApiKey(tempDir);
+      expect(verifyApiKey("wrong-key")).toBe(false);
+    });
+
+    it("verifies against env-var-supplied key", () => {
+      const envKey = "g".repeat(64);
+      process.env.GRACKLE_API_KEY = envKey;
+      loadOrCreateApiKey(tempDir);
+      expect(verifyApiKey(envKey)).toBe(true);
+      expect(verifyApiKey("wrong")).toBe(false);
+    });
+  });
+});

--- a/packages/auth/src/api-key.ts
+++ b/packages/auth/src/api-key.ts
@@ -38,13 +38,22 @@ function createApiKey(homePath: string, keyPath: string): string {
 }
 
 /**
- * Load or create the API key. On first run, a random 256-bit key is
- * generated and written to `<homePath>/api-key` with 0600 permissions.
+ * Load or create the API key. If `GRACKLE_API_KEY` is set in the environment,
+ * it takes precedence over the on-disk key. Otherwise, on first run a random
+ * 256-bit key is generated and written to `<homePath>/api-key` with 0600
+ * permissions.
  *
  * @param homePath - The Grackle home directory (e.g., `~/.grackle`).
  */
 export function loadOrCreateApiKey(homePath: string): string {
   if (cachedKey) {
+    return cachedKey;
+  }
+
+  const envKey = process.env.GRACKLE_API_KEY?.trim();
+  if (envKey && envKey.length > 0) {
+    cachedKey = envKey;
+    getAuthLogger().info({}, "Using API key from GRACKLE_API_KEY environment variable");
     return cachedKey;
   }
 


### PR DESCRIPTION
## Summary
- `loadOrCreateApiKey()` in `@grackle-ai/auth` now checks `GRACKLE_API_KEY` env var before falling back to disk read/generate
- Lets deployments inject a stable API key from a secrets manager (e.g., Vault/bao) instead of relying on auto-generated keys in `~/.grackle/api-key`
- The CLI already supported this env var; the server now does too

## Test plan
- [x] New unit tests in `packages/auth/src/api-key.test.ts` (10 tests covering env var precedence, trimming, empty values, verification)
- [x] All 131 existing auth tests pass
- [x] `rush build -t @grackle-ai/auth` succeeds
- [ ] Manual: set `GRACKLE_API_KEY=<key>`, start server, verify log message and Bearer auth works