### PR TITLE
Fix debounce timers not cleared on disconnect/unmount (#1482)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1482-debounce-timer-cleanup_2026-06-03-02-59.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1482-debounce-timer-cleanup_2026-06-03-02-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix debounce/timer leaks on disconnect in useTasks and useEnvironments hooks",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web/src/hooks/useEnvironments.test.ts
+++ b/packages/web/src/hooks/useEnvironments.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { ConnectError, Code } from "@connectrpc/connect";
 import { useEnvironments } from "./useEnvironments.js";
@@ -209,5 +209,51 @@ describe("useEnvironments — operationError", () => {
     });
 
     expect(result.current.operationError).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: onDisconnect clears provision-status timers
+// ---------------------------------------------------------------------------
+
+describe("useEnvironments — onDisconnect clears provision timers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockClient.listEnvironments.mockResolvedValue({ environments: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels pending provision-clear timers so status persists after disconnect", () => {
+    const { result } = renderHook(() => useEnvironments());
+
+    act(() => {
+      result.current.handleEvent({
+        id: "evt-1",
+        timestamp: "2026-01-01T00:00:00Z",
+        type: "environment.provision_progress",
+        payload: {
+          environmentId: "env-1",
+          stage: "ready",
+          message: "done",
+          progress: 100,
+        },
+      });
+    });
+
+    expect(result.current.provisionStatus["env-1"]).toBeDefined();
+
+    act(() => {
+      result.current.domainHook.onDisconnect();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(6_000);
+    });
+
+    expect(result.current.provisionStatus["env-1"]).toBeDefined();
   });
 });

--- a/packages/web/src/hooks/useEnvironments.ts
+++ b/packages/web/src/hooks/useEnvironments.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo } from "react";
 import { ConnectError } from "@connectrpc/connect";
 import { warnBadPayload } from "@grackle-ai/web-components";
 import type {
@@ -41,6 +41,8 @@ export function useEnvironments(): UseEnvironmentsResult {
   const [environments, setEnvironments] = useState<Environment[]>([]);
   const { loading: environmentsLoading, track: trackEnvironments } = useLoadingState();
   const [provisionStatus, setProvisionStatus] = useState<Record<string, ProvisionStatus>>({});
+  /** Per-environment timers that clear provision status after a delay. */
+  const provisionClearTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const [operationError, setOperationError] = useState("");
 
   const clearOperationError = useCallback(() => {
@@ -99,7 +101,9 @@ export function useEnvironments(): UseEnvironmentsResult {
           }));
           if (pp.stage === "ready") {
             const envId = pp.environmentId as string;
-            setTimeout(() => {
+            clearTimeout(provisionClearTimersRef.current[envId]);
+            provisionClearTimersRef.current[envId] = setTimeout(() => {
+              delete provisionClearTimersRef.current[envId];
               setProvisionStatus((prev) => {
                 const next = { ...prev };
                 delete next[envId];
@@ -190,7 +194,9 @@ export function useEnvironments(): UseEnvironmentsResult {
           },
         }));
         if (event.stage === "ready") {
-          setTimeout(() => {
+          clearTimeout(provisionClearTimersRef.current[environmentId]);
+          provisionClearTimersRef.current[environmentId] = setTimeout(() => {
+            delete provisionClearTimersRef.current[environmentId];
             setProvisionStatus((prev) => {
               const next = { ...prev };
               delete next[environmentId];
@@ -230,7 +236,12 @@ export function useEnvironments(): UseEnvironmentsResult {
   const domainHook: DomainHook = useMemo(
     () => ({
       onConnect: () => loadEnvironments(),
-      onDisconnect: () => {},
+      onDisconnect: () => {
+        for (const t of Object.values(provisionClearTimersRef.current)) {
+          clearTimeout(t);
+        }
+        provisionClearTimersRef.current = {};
+      },
       handleEvent,
     }),
     [loadEnvironments, handleEvent],

--- a/packages/web/src/hooks/useEnvironments.ts
+++ b/packages/web/src/hooks/useEnvironments.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { ConnectError } from "@connectrpc/connect";
 import { warnBadPayload } from "@grackle-ai/web-components";
 import type {
@@ -231,6 +231,14 @@ export function useEnvironments(): UseEnvironmentsResult {
     } catch (err) {
       setOperationError(extractErrorMessage(err));
     }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      for (const t of Object.values(provisionClearTimersRef.current)) {
+        clearTimeout(t);
+      }
+    };
   }, []);
 
   const domainHook: DomainHook = useMemo(

--- a/packages/web/src/hooks/useTasks.test.ts
+++ b/packages/web/src/hooks/useTasks.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { ConnectError, Code } from "@connectrpc/connect";
 import { useTasks } from "./useTasks.js";
@@ -135,5 +135,42 @@ describe("useTasks startTask", () => {
 
     expect(result.current.taskStartingId).toBe(undefined);
     expect(caught).toBe(genericErr);
+  });
+});
+
+describe("useTasks onDisconnect clears debounce timers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockClient.listTasks.mockResolvedValue({ tasks: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels pending debounce timers so loadTasks is not called after disconnect", () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.handleEvent({
+        id: "evt-1",
+        timestamp: "2026-01-01T00:00:00Z",
+        type: "task.updated",
+        payload: { workspaceId: "ws-1", taskId: "t-1" },
+      });
+    });
+
+    mockClient.listTasks.mockClear();
+
+    act(() => {
+      result.current.domainHook.onDisconnect();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockClient.listTasks).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/hooks/useTasks.ts
+++ b/packages/web/src/hooks/useTasks.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { ConnectError, Code } from "@connectrpc/connect";
 import type { TaskData, GrackleEvent, WsMessage, UseTasksResult } from "@grackle-ai/web-components";
 import type { DomainHook } from "./domainHook.js";
@@ -134,6 +134,14 @@ export function useTasks(): UseTasksResult {
       clearTimeout(t);
     }
     debounceTimersRef.current = {};
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      for (const t of Object.values(debounceTimersRef.current)) {
+        clearTimeout(t);
+      }
+    };
   }, []);
 
   const handleLegacyMessage = useCallback((msg: WsMessage): boolean => {

--- a/packages/web/src/hooks/useTasks.ts
+++ b/packages/web/src/hooks/useTasks.ts
@@ -130,6 +130,10 @@ export function useTasks(): UseTasksResult {
 
   const onDisconnect = useCallback(() => {
     setTaskStartingId(undefined);
+    for (const t of Object.values(debounceTimersRef.current)) {
+      clearTimeout(t);
+    }
+    debounceTimersRef.current = {};
   }, []);
 
   const handleLegacyMessage = useCallback((msg: WsMessage): boolean => {


### PR DESCRIPTION
## Summary
- **useTasks**: Clear all pending per-workspace debounce timers in `onDisconnect`, preventing stale `loadTasks` calls after the hook unmounts or the WebSocket disconnects.
- **useEnvironments**: Track provision-status clear timers in a new `provisionClearTimersRef` (previously untracked fire-and-forget `setTimeout` calls) and clear them in `onDisconnect`.
- Add unit tests for both hooks verifying timers are cancelled on disconnect using `vi.useFakeTimers()`.

## Test plan
- [x] `rush build -t @grackle-ai/web` — builds with no warnings
- [x] `rushx test` in `packages/web` — all 282 tests pass (including 2 new tests)
- [ ] CI green

Closes #1482