### PR TITLE
Fix: add circular task dependency validation (#1484)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1484-circular-dep-validation_2026-06-03-03-27.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1484-circular-dep-validation_2026-06-03-03-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add circular task dependency validation to prevent deadlocks",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/core/src/test-utils/mock-database.ts
+++ b/packages/core/src/test-utils/mock-database.ts
@@ -69,6 +69,7 @@ export function createDatabaseMock() {
       getUnblockedTasks: vi.fn(() => []),
       checkAndUnblock: vi.fn(() => []),
       areDependenciesMet: vi.fn(() => true),
+      detectDependencyCycle: vi.fn(() => null),
       buildChildIdsMap: vi.fn(() => new Map()),
       getChildren: vi.fn(() => []),
       getDescendants: vi.fn(() => []),

--- a/packages/database/src/task-store.test.ts
+++ b/packages/database/src/task-store.test.ts
@@ -664,4 +664,52 @@ describe("task-store tree operations", () => {
       expect(after >= before).toBe(true);
     });
   });
+
+  describe("detectDependencyCycle", () => {
+    it("detects self-dependency", () => {
+      taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
+      const result = taskStore.detectDependencyCycle("t1", ["t1"]);
+      expect(result).toEqual(["t1"]);
+    });
+
+    it("detects direct cycle (A->B, B->A)", () => {
+      taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
+      taskStore.createTask("t2", "test-proj", "Task B", "desc", ["t1"], "proj");
+      const result = taskStore.detectDependencyCycle("t1", ["t2"]);
+      expect(result).not.toBeNull();
+      expect(result).toContain("t1");
+    });
+
+    it("detects transitive cycle (A->B->C->A)", () => {
+      taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
+      taskStore.createTask("t2", "test-proj", "Task B", "desc", ["t1"], "proj");
+      taskStore.createTask("t3", "test-proj", "Task C", "desc", ["t2"], "proj");
+      const result = taskStore.detectDependencyCycle("t1", ["t3"]);
+      expect(result).not.toBeNull();
+      expect(result).toContain("t1");
+    });
+
+    it("returns null for valid dependencies (no cycle)", () => {
+      taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
+      taskStore.createTask("t2", "test-proj", "Task B", "desc", [], "proj");
+      taskStore.createTask("t3", "test-proj", "Task C", "desc", ["t1"], "proj");
+      const result = taskStore.detectDependencyCycle("t3", ["t2"]);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for diamond dependency (no cycle)", () => {
+      taskStore.createTask("t1", "test-proj", "Task D", "desc", [], "proj");
+      taskStore.createTask("t2", "test-proj", "Task B", "desc", ["t1"], "proj");
+      taskStore.createTask("t3", "test-proj", "Task C", "desc", ["t1"], "proj");
+      taskStore.createTask("t4", "test-proj", "Task A", "desc", ["t2", "t3"], "proj");
+      const result = taskStore.detectDependencyCycle("t4", ["t2", "t3"]);
+      expect(result).toBeNull();
+    });
+
+    it("handles nonexistent dependency gracefully", () => {
+      taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
+      const result = taskStore.detectDependencyCycle("t1", ["nonexistent"]);
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/database/src/task-store.test.ts
+++ b/packages/database/src/task-store.test.ts
@@ -676,8 +676,7 @@ describe("task-store tree operations", () => {
       taskStore.createTask("t1", "test-proj", "Task A", "desc", [], "proj");
       taskStore.createTask("t2", "test-proj", "Task B", "desc", ["t1"], "proj");
       const result = taskStore.detectDependencyCycle("t1", ["t2"]);
-      expect(result).not.toBeNull();
-      expect(result).toContain("t1");
+      expect(result).toEqual(["t2"]);
     });
 
     it("detects transitive cycle (A->B->C->A)", () => {
@@ -685,8 +684,7 @@ describe("task-store tree operations", () => {
       taskStore.createTask("t2", "test-proj", "Task B", "desc", ["t1"], "proj");
       taskStore.createTask("t3", "test-proj", "Task C", "desc", ["t2"], "proj");
       const result = taskStore.detectDependencyCycle("t1", ["t3"]);
-      expect(result).not.toBeNull();
-      expect(result).toContain("t1");
+      expect(result).toEqual(["t3", "t2"]);
     });
 
     it("returns null for valid dependencies (no cycle)", () => {

--- a/packages/database/src/task-store.ts
+++ b/packages/database/src/task-store.ts
@@ -387,8 +387,8 @@ export function detectDependencyCycle(
     const current = queue.shift()!;
     if (current === taskId) {
       const path: string[] = [];
-      let node = current;
-      while (node !== taskId || path.length === 0) {
+      let node = parent.get(current)!;
+      while (node !== taskId) {
         path.unshift(node);
         node = parent.get(node)!;
       }

--- a/packages/database/src/task-store.ts
+++ b/packages/database/src/task-store.ts
@@ -366,6 +366,52 @@ export function areDependenciesMet(taskId: string): boolean {
   });
 }
 
+/**
+ * Detect whether adding the proposed dependencies to a task would create a cycle.
+ * Returns the cycle path (array of task IDs) if a cycle exists, or null if safe.
+ */
+export function detectDependencyCycle(
+  taskId: string,
+  proposedDependsOn: string[],
+): string[] | null {
+  if (proposedDependsOn.includes(taskId)) {
+    return [taskId];
+  }
+  const visited = new Set<string>();
+  const parent = new Map<string, string>();
+  const queue = [...proposedDependsOn];
+  for (const depId of proposedDependsOn) {
+    parent.set(depId, taskId);
+  }
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === taskId) {
+      const path: string[] = [];
+      let node = current;
+      while (node !== taskId || path.length === 0) {
+        path.unshift(node);
+        node = parent.get(node)!;
+      }
+      return path;
+    }
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const task = getTask(current);
+    if (!task) {
+      continue;
+    }
+    for (const depId of safeParseJsonArray(task.dependsOn)) {
+      if (!visited.has(depId)) {
+        parent.set(depId, current);
+        queue.push(depId);
+      }
+    }
+  }
+  return null;
+}
+
 // ─── Tree Queries ────────────────────────────────────
 
 /** Build a map from parentTaskId to child IDs from a pre-fetched list of rows. Avoids N+1 queries. */

--- a/packages/plugin-core/src/task-handlers.test.ts
+++ b/packages/plugin-core/src/task-handlers.test.ts
@@ -235,3 +235,131 @@ describe("scoped-token revocation on task lifecycle (GHSA-f9ff-5x35-7gfw F12)", 
     expect(isRevokedTask("task-1")).toBe(true);
   });
 });
+
+describe("dependency validation", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handlers: Record<string, (...args: any[]) => any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = getHandlers();
+  });
+
+  describe("createTask", () => {
+    it("rejects nonexistent dependency", async () => {
+      vi.mocked(workspaceStore.getWorkspace).mockReturnValue(makeWorkspaceRow() as never);
+      vi.mocked(taskStore.getTask).mockReturnValue(undefined as never);
+
+      const err = (await handlers
+        .createTask({
+          workspaceId: "ws-1",
+          title: "New Task",
+          description: "",
+          dependsOn: ["nonexistent"],
+          parentTaskId: "",
+        })
+        .catch((e: unknown) => e)) as ConnectError;
+
+      expect(err).toBeInstanceOf(ConnectError);
+      expect(err.code).toBe(Code.NotFound);
+      expect(err.message).toContain("Dependency task not found");
+    });
+  });
+
+  describe("updateTask", () => {
+    it("rejects self-dependency", async () => {
+      vi.mocked(taskStore.getTask).mockReturnValue(makeTaskRow() as never);
+
+      const err = (await handlers
+        .updateTask({
+          id: "task-1",
+          title: "",
+          description: "",
+          status: 0,
+          dependsOn: ["task-1"],
+          sessionId: "",
+        })
+        .catch((e: unknown) => e)) as ConnectError;
+
+      expect(err).toBeInstanceOf(ConnectError);
+      expect(err.code).toBe(Code.InvalidArgument);
+      expect(err.message).toContain("cannot depend on itself");
+    });
+
+    it("rejects nonexistent dependency", async () => {
+      vi.mocked(taskStore.getTask).mockImplementation((id: string) => {
+        if (id === "task-1") {
+          return makeTaskRow() as never;
+        }
+        return undefined as never;
+      });
+
+      const err = (await handlers
+        .updateTask({
+          id: "task-1",
+          title: "",
+          description: "",
+          status: 0,
+          dependsOn: ["nonexistent"],
+          sessionId: "",
+        })
+        .catch((e: unknown) => e)) as ConnectError;
+
+      expect(err).toBeInstanceOf(ConnectError);
+      expect(err.code).toBe(Code.NotFound);
+      expect(err.message).toContain("Dependency task not found");
+    });
+
+    it("rejects circular dependency", async () => {
+      vi.mocked(taskStore.getTask).mockReturnValue(makeTaskRow() as never);
+      vi.mocked(taskStore.detectDependencyCycle).mockReturnValue(["task-2", "task-1"]);
+
+      const err = (await handlers
+        .updateTask({
+          id: "task-1",
+          title: "",
+          description: "",
+          status: 0,
+          dependsOn: ["task-2"],
+          sessionId: "",
+        })
+        .catch((e: unknown) => e)) as ConnectError;
+
+      expect(err).toBeInstanceOf(ConnectError);
+      expect(err.code).toBe(Code.InvalidArgument);
+      expect(err.message).toContain("Circular dependency detected");
+    });
+
+    it("allows valid dependency update", async () => {
+      vi.mocked(taskStore.getTask).mockReturnValue(makeTaskRow() as never);
+      vi.mocked(taskStore.detectDependencyCycle).mockReturnValue(null);
+
+      await handlers.updateTask({
+        id: "task-1",
+        title: "",
+        description: "",
+        status: 0,
+        dependsOn: ["task-2"],
+        sessionId: "",
+      });
+
+      expect(taskStore.updateTask).toHaveBeenCalled();
+    });
+
+    it("skips validation when dependsOn is empty", async () => {
+      vi.mocked(taskStore.getTask).mockReturnValue(makeTaskRow() as never);
+
+      await handlers.updateTask({
+        id: "task-1",
+        title: "",
+        description: "",
+        status: 0,
+        dependsOn: [],
+        sessionId: "",
+      });
+
+      expect(taskStore.detectDependencyCycle).not.toHaveBeenCalled();
+      expect(taskStore.updateTask).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -185,6 +185,12 @@ export async function createTask(req: grackle.CreateTaskRequest): Promise<grackl
     throw new ConnectError("Budget values must be >= 0", Code.InvalidArgument);
   }
 
+  for (const depId of req.dependsOn) {
+    if (!taskStore.getTask(depId)) {
+      throw new ConnectError(`Dependency task not found: ${depId}`, Code.NotFound);
+    }
+  }
+
   const id = uuid().slice(0, 8);
   taskStore.createTask(
     id,
@@ -237,6 +243,24 @@ export async function updateTask(req: grackle.UpdateTaskRequest): Promise<grackl
       throw new ConnectError(`Unknown task status enum value: ${req.status}`, Code.InvalidArgument);
     }
     reqStatus = converted;
+  }
+
+  if (req.dependsOn.length > 0) {
+    if (req.dependsOn.includes(req.id)) {
+      throw new ConnectError(`Task ${req.id} cannot depend on itself`, Code.InvalidArgument);
+    }
+    for (const depId of req.dependsOn) {
+      if (!taskStore.getTask(depId)) {
+        throw new ConnectError(`Dependency task not found: ${depId}`, Code.NotFound);
+      }
+    }
+    const cycle = taskStore.detectDependencyCycle(req.id, [...req.dependsOn]);
+    if (cycle) {
+      throw new ConnectError(
+        `Circular dependency detected: ${req.id} → ${cycle.join(" → ")} → ${req.id}`,
+        Code.InvalidArgument,
+      );
+    }
   }
 
   taskStore.updateTask(

--- a/packages/plugin-core/src/test-utils/mock-database.ts
+++ b/packages/plugin-core/src/test-utils/mock-database.ts
@@ -70,6 +70,7 @@ export function createDatabaseMock() {
       getUnblockedTasks: vi.fn(() => []),
       checkAndUnblock: vi.fn(() => []),
       areDependenciesMet: vi.fn(() => true),
+      detectDependencyCycle: vi.fn(() => null),
       buildChildIdsMap: vi.fn(() => new Map()),
       getChildren: vi.fn(() => []),
       getDescendants: vi.fn(() => []),


### PR DESCRIPTION
## Summary
- Add `detectDependencyCycle()` BFS function to `task-store.ts` that walks the dependency graph and detects self-deps, direct cycles, and transitive cycles
- Add dependency existence validation in `createTask` handler — rejects references to nonexistent task IDs
- Add self-dependency, existence, and cycle validation in `updateTask` handler — only when `dependsOn` is being changed
- 11 new tests across both layers (6 store-level cycle detection + 5 handler-level validation)

## Test plan
- [x] `rushx test` in `packages/database` — 310/310 pass (6 new cycle detection tests)
- [x] `rushx test` in `packages/plugin-core` — 461/461 pass (5 new handler validation tests)
- [ ] Manual: create tasks with `--depends-on` pointing to self or forming a cycle, verify clear error messages

Closes #1484