### PR TITLE
Fix TOCTOU race in findFreePort with retry wrapper (#1486)

### DIFF
--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -228,6 +228,9 @@ export interface IHostTransport {
 // @public
 export function isDevMode(): boolean;
 
+// @public
+export function isPortConflictError(err: unknown): boolean;
+
 export { JsonRpcErrorCodes }
 
 // @public
@@ -408,6 +411,9 @@ export interface WaitForLocalPortOptions {
     portProber?: PortProber;
     sleep?: (ms: number) => Promise<void>;
 }
+
+// @public
+export function withFreePort<T>(action: (port: number) => Promise<T>, maxAttempts?: number): Promise<T>;
 
 // @public
 export function writeRemoteEnvFile(executor: RemoteExecutor, powerlineToken: string, extraEnv?: Record<string, string>, logger?: AdapterLogger): Promise<void>;

--- a/common/changes/@grackle-ai/cli/nick-pape-1486-toctou-findFreePort_2026-06-03-03-46.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1486-toctou-findFreePort_2026-06-03-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix TOCTOU race in findFreePort by adding withFreePort retry wrapper for port-conflict errors",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/adapter-codespace/src/codespace.test.ts
+++ b/packages/adapter-codespace/src/codespace.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   closeTunnel: vi.fn().mockResolvedValue(undefined),
   registerTunnel: vi.fn(),
   findFreePort: vi.fn().mockResolvedValue(9999),
+  withFreePort: vi.fn(),
   startRemotePowerLine: vi.fn().mockResolvedValue({ alreadyRunning: true }),
   bootstrapPowerLine: vi.fn(),
   tunnelInstances: [] as MockTunnelInstance[],
@@ -28,6 +29,7 @@ vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => {
     closeTunnel: mocks.closeTunnel,
     registerTunnel: mocks.registerTunnel,
     findFreePort: mocks.findFreePort,
+    withFreePort: mocks.withFreePort,
     startRemotePowerLine: mocks.startRemotePowerLine,
     bootstrapPowerLine: async function* () {
       yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
@@ -81,6 +83,9 @@ describe("CodespaceAdapter.reconnect()", () => {
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
     mocks.startRemotePowerLine.mockResolvedValue({ alreadyRunning: true });
+    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
+      action(9999),
+    );
     adapter = new CodespaceAdapter({
       exec: mockExec,
       sleep: mockSleep,
@@ -183,6 +188,9 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
+      action(9999),
+    );
     adapter = new CodespaceAdapter({ exec: mockExec, sleep: mockSleep });
   });
 
@@ -286,6 +294,9 @@ describe("CodespaceAdapter.provision() — tunnel cleanup", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
+    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
+      action(9999),
+    );
     adapter = new CodespaceAdapter({ exec: mockExec, sleep: mockSleep });
   });
 

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -18,7 +18,7 @@ import {
   registerTunnel,
   getTunnel,
   closeTunnel,
-  findFreePort,
+  withFreePort,
   remoteStop,
   remoteDestroy,
   remoteHealthCheck,
@@ -295,16 +295,22 @@ export class CodespaceAdapter implements EnvironmentAdapter {
       defaultRuntime: (config.defaultRuntime as string) || undefined,
     });
 
-    // Open port-forward tunnel (host → codespace PowerLine)
-    const localPort = cfg.localPort || (await findFreePort());
+    // Open port-forward tunnel (retry on port conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: CodespaceTunnel }> => {
+      const t = new CodespaceTunnel(port, cfg.codespaceName, undefined, undefined, ghToken);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await withFreePort(openTunnel);
+
     yield {
       stage: "tunneling",
       message: `Forwarding local port ${localPort} to codespace...`,
       progress: 0.8,
     };
-
-    const tunnel = new CodespaceTunnel(localPort, cfg.codespaceName, undefined, undefined, ghToken);
-    await tunnel.open();
 
     // Open reverse tunnel (codespace → host MCP server) for agent tool calls.
     // Wrap in try/catch so the forward tunnel is cleaned up if the reverse fails.
@@ -369,15 +375,22 @@ export class CodespaceAdapter implements EnvironmentAdapter {
       yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };
     }
 
-    // 3. Open new port-forward tunnel + reverse tunnel for MCP
-    const localPort = cfg.localPort || (await findFreePort());
+    // 3. Open new port-forward tunnel + reverse tunnel for MCP (retry on port conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: CodespaceTunnel }> => {
+      const t = new CodespaceTunnel(port, cfg.codespaceName, undefined, undefined, ghToken);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await withFreePort(openTunnel);
+
     yield {
       stage: "reconnecting",
       message: `Forwarding local port ${localPort} to codespace...`,
       progress: 0.7,
     };
-    const tunnel = new CodespaceTunnel(localPort, cfg.codespaceName, undefined, undefined, ghToken);
-    await tunnel.open();
 
     try {
       const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);

--- a/packages/adapter-docker/src/docker-attach.test.ts
+++ b/packages/adapter-docker/src/docker-attach.test.ts
@@ -381,3 +381,59 @@ describe("DockerAdapter attach mode — reconnect", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("DockerAdapter attach mode — socat sidecar retry cleanup (#1486)", () => {
+  it("removes the sidecar on port-conflict failure before withFreePort retries", async () => {
+    let runCallCount = 0;
+    const execFn = vi.fn(async (command: string, args: string[]) => {
+      if (command === "docker" && args[0] === "inspect") {
+        const fmtIdx = args.indexOf("-f");
+        const fmt = fmtIdx >= 0 ? (args[fmtIdx + 1] ?? "") : "";
+        if (fmt.includes("State.Running")) {
+          return { stdout: "true", stderr: "" };
+        }
+        if (fmt.includes("IPAddress")) {
+          return { stdout: "172.18.0.7", stderr: "" };
+        }
+        if (fmt.includes("NetworkSettings.Networks")) {
+          return { stdout: "bridge", stderr: "" };
+        }
+      }
+      if (command === "docker" && args[0] === "run") {
+        runCallCount++;
+        if (runCallCount === 1) {
+          throw new Error("port is already allocated");
+        }
+        return { stdout: "", stderr: "" };
+      }
+      if (command === "docker" && args[0] === "rm") {
+        return { stdout: "", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    pingMock.mockRejectedValue(new Error("unreachable"));
+    const adapter = new DockerAdapter({ exec: execFn, logger: mockLogger });
+
+    await drain(
+      adapter.provision(
+        "env-retry",
+        { attach: ATTACH } as unknown as Record<string, unknown>,
+        TOKEN,
+      ),
+    );
+
+    // sidecar should have been attempted twice (first failed, second succeeded)
+    expect(runCallCount).toBe(2);
+
+    // The sidecar should have been removed after the first failure
+    const rmCalls = execFn.mock.calls.filter(
+      ([cmd, args]: [string, string[]]) =>
+        cmd === "docker" &&
+        args[0] === "rm" &&
+        args.some((a: string) => a.includes("grackle-attach")),
+    );
+    // At least 2 rm calls: one before first attempt (stale cleanup) + one after failure
+    expect(rmCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/adapter-docker/src/docker.test.ts
+++ b/packages/adapter-docker/src/docker.test.ts
@@ -188,3 +188,59 @@ describe("DockerAdapter — DI exec for stop/destroy", () => {
     await expect(adapter.destroy("env-1", { containerName: "test" })).resolves.toBeUndefined();
   });
 });
+
+describe("DockerAdapter — create retry cleanup (#1486)", () => {
+  it("removes the container on port-conflict failure before withFreePort retries", async () => {
+    let runCallCount = 0;
+    let containerCreated = false;
+    const execFn = vi.fn(async (command: string, args: string[]) => {
+      if (command === "docker" && args[0] === "inspect") {
+        if (!containerCreated) {
+          throw new Error("No such object");
+        }
+        const fmtIdx = args.indexOf("-f");
+        const fmt = fmtIdx >= 0 ? (args[fmtIdx + 1] ?? "") : "";
+        if (fmt.includes("State.Running")) {
+          return { stdout: "true", stderr: "" };
+        }
+        if (fmt.includes("State.Status")) {
+          return { stdout: "running", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      }
+      if (command === "docker" && args[0] === "run") {
+        runCallCount++;
+        if (runCallCount === 1) {
+          throw new Error("address already in use");
+        }
+        containerCreated = true;
+        return { stdout: "", stderr: "" };
+      }
+      if (command === "docker" && args[0] === "rm") {
+        containerCreated = false;
+        return { stdout: "", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const adapter = new DockerAdapter({ exec: execFn, sleep: mockSleep, logger: mockLogger });
+
+    const events: unknown[] = [];
+    for await (const event of adapter.provision(
+      "env-retry",
+      baseCfg() as unknown as Record<string, unknown>,
+      "test-token",
+    )) {
+      events.push(event);
+    }
+
+    // Container create should have been attempted twice
+    expect(runCallCount).toBe(2);
+
+    // The failed container should have been removed (docker rm -f) before retry
+    const rmCalls = execFn.mock.calls.filter(
+      ([cmd, args]: [string, string[]]) => cmd === "docker" && args[0] === "rm" && args[1] === "-f",
+    );
+    expect(rmCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -14,7 +14,7 @@ import {
   isDevMode,
   bootstrapPowerLine,
   startRemotePowerLine,
-  findFreePort,
+  withFreePort,
   remoteStop,
   remoteDestroy,
   exec as defaultExec,
@@ -499,7 +499,6 @@ export class DockerAdapter implements EnvironmentAdapter {
 
     const image = cfg.image || DEFAULT_IMAGE;
     const containerName = cfg.containerName || `grackle-${environmentId}`;
-    const localPort = cfg.localPort || (await findFreePort());
 
     // Build or pull the base image
     const isDefault = image === DEFAULT_IMAGE;
@@ -514,9 +513,16 @@ export class DockerAdapter implements EnvironmentAdapter {
 
     yield { stage: "creating", message: `Creating container ${containerName}...`, progress: 0.1 };
 
-    const runArgs = this.buildRunArgs(containerName, localPort, image, cfg, powerlineToken);
+    // Create or start the container (retry with a fresh port on TOCTOU conflict, #1486)
+    const createContainer = async (port: number): Promise<{ port: number; isNew: boolean }> => {
+      const runArgs = this.buildRunArgs(containerName, port, image, cfg, powerlineToken);
+      const created = await createOrStartContainer(this.execFn, containerName, runArgs);
+      return { port, isNew: created };
+    };
 
-    const isNew = await createOrStartContainer(this.execFn, containerName, runArgs);
+    const { port: localPort, isNew } = cfg.localPort
+      ? await createContainer(cfg.localPort)
+      : await withFreePort(createContainer);
     let actualPort = localPort;
     if (!isNew) {
       yield { stage: "starting", message: "Container exists, starting...", progress: 0.12 };
@@ -664,10 +670,13 @@ export class DockerAdapter implements EnvironmentAdapter {
 
     const network = (await inspectContainerNetwork(this.execFn, target)) || "bridge";
     const sidecarName = `${ATTACH_SIDECAR_PREFIX}${environmentId}`;
-    const hostPort = await findFreePort();
     // Clear any stale sidecar from a previous attach before starting a fresh one.
     await removeSidecar(this.execFn, sidecarName, this.logger);
-    await startSocatSidecar(this.execFn, sidecarName, network, ip, hostPort);
+    // Retry with a fresh port on TOCTOU conflict (#1486)
+    const hostPort = await withFreePort(async (port) => {
+      await startSocatSidecar(this.execFn, sidecarName, network, ip, port);
+      return port;
+    });
     this.logger.info(
       { environmentId, target, network, hostPort },
       "Started socat sidecar for attach connectivity",

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -514,8 +514,8 @@ export class DockerAdapter implements EnvironmentAdapter {
     yield { stage: "creating", message: `Creating container ${containerName}...`, progress: 0.1 };
 
     // Create or start the container (retry with a fresh port on TOCTOU conflict, #1486).
-    // On port-conflict failure, remove the partially-created container so the
-    // next attempt can recreate it with a fresh port mapping.
+    // On any failure, remove the partially-created container so a retry can
+    // recreate it with a fresh port mapping.
     const createContainer = async (port: number): Promise<{ port: number; isNew: boolean }> => {
       const runArgs = this.buildRunArgs(containerName, port, image, cfg, powerlineToken);
       try {

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -513,11 +513,18 @@ export class DockerAdapter implements EnvironmentAdapter {
 
     yield { stage: "creating", message: `Creating container ${containerName}...`, progress: 0.1 };
 
-    // Create or start the container (retry with a fresh port on TOCTOU conflict, #1486)
+    // Create or start the container (retry with a fresh port on TOCTOU conflict, #1486).
+    // On port-conflict failure, remove the partially-created container so the
+    // next attempt can recreate it with a fresh port mapping.
     const createContainer = async (port: number): Promise<{ port: number; isNew: boolean }> => {
       const runArgs = this.buildRunArgs(containerName, port, image, cfg, powerlineToken);
-      const created = await createOrStartContainer(this.execFn, containerName, runArgs);
-      return { port, isNew: created };
+      try {
+        const created = await createOrStartContainer(this.execFn, containerName, runArgs);
+        return { port, isNew: created };
+      } catch (err) {
+        await this.execFn("docker", ["rm", "-f", containerName]).catch(() => {});
+        throw err;
+      }
     };
 
     const { port: localPort, isNew } = cfg.localPort
@@ -672,9 +679,16 @@ export class DockerAdapter implements EnvironmentAdapter {
     const sidecarName = `${ATTACH_SIDECAR_PREFIX}${environmentId}`;
     // Clear any stale sidecar from a previous attach before starting a fresh one.
     await removeSidecar(this.execFn, sidecarName, this.logger);
-    // Retry with a fresh port on TOCTOU conflict (#1486)
+    // Retry with a fresh port on TOCTOU conflict (#1486).
+    // Remove the partially-created sidecar on failure so the next attempt
+    // can recreate it with a fresh port mapping.
     const hostPort = await withFreePort(async (port) => {
-      await startSocatSidecar(this.execFn, sidecarName, network, ip, port);
+      try {
+        await startSocatSidecar(this.execFn, sidecarName, network, ip, port);
+      } catch (err) {
+        await removeSidecar(this.execFn, sidecarName, this.logger);
+        throw err;
+      }
       return port;
     });
     this.logger.info(

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -57,6 +57,8 @@ export type { ExecFunction, AdapterDependencies } from "./adapter-dependencies.j
 export {
   sleep,
   findFreePort,
+  isPortConflictError,
+  withFreePort,
   isDevMode,
   getPackageVersion,
   shellEscape,

--- a/packages/adapter-sdk/src/tunnel.test.ts
+++ b/packages/adapter-sdk/src/tunnel.test.ts
@@ -114,6 +114,23 @@ describe("ProcessTunnel", () => {
       // Process should have been cleaned up
       expect(tunnel.isAlive()).toBe(false);
     });
+
+    it("surfaces stderr when the process exits before the port becomes ready", async () => {
+      const proc = createMockProcess();
+      factory = createMockProcessFactory(proc);
+      // Make waitForPort hang until the process exits
+      (probe.waitForPort as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise(() => {}),
+      );
+      tunnel = new TestTunnel(9999, "ssh", ["-N"], factory, probe);
+
+      const openPromise = tunnel.open();
+      // Simulate stderr output followed by early exit (e.g. port conflict)
+      proc.stderr!.emit("data", Buffer.from("bind: Address already in use\n"));
+      proc.emit("close", 255);
+
+      await expect(openPromise).rejects.toThrow("bind: Address already in use");
+    });
   });
 
   describe("close()", () => {

--- a/packages/adapter-sdk/src/tunnel.test.ts
+++ b/packages/adapter-sdk/src/tunnel.test.ts
@@ -10,6 +10,7 @@ vi.mock("./utils.js", async (importOriginal) => {
 
 import type { TunnelProcessFactory, TunnelPortProbe } from "./tunnel.js";
 import { ProcessTunnel } from "./tunnel.js";
+import { withFreePort, isPortConflictError } from "./utils.js";
 
 // ── Silent logger ────────────────────────────────────────────
 
@@ -131,6 +132,50 @@ describe("ProcessTunnel", () => {
 
       await expect(openPromise).rejects.toThrow("bind: Address already in use");
     });
+
+    it("detects early exit during a sleep-based waitForReady override (reverse tunnel pattern)", async () => {
+      const proc = createMockProcess();
+      factory = createMockProcessFactory(proc);
+
+      class SleepyTunnel extends ProcessTunnel {
+        protected spawnArgs(): { command: string; args: string[] } {
+          return { command: "gh", args: ["codespace", "ssh", "-R"] };
+        }
+        protected waitForReady(): Promise<void> {
+          // Simulates the reverse tunnel pattern: wait a fixed delay
+          return new Promise(() => {});
+        }
+      }
+
+      const sleepyTunnel = new SleepyTunnel(9999, silentLogger, factory, probe);
+      const openPromise = sleepyTunnel.open();
+
+      proc.stderr!.emit("data", Buffer.from("remote port forwarding failed\n"));
+      proc.emit("close", 1);
+
+      await expect(openPromise).rejects.toThrow("remote port forwarding failed");
+    });
+
+    it("does not produce unhandled rejections when the process exits after a successful open", async () => {
+      const proc = createMockProcess();
+      factory = createMockProcessFactory(proc);
+      tunnel = new TestTunnel(9999, "ssh", ["-N"], factory, probe);
+
+      await tunnel.open();
+      expect(tunnel.isAlive()).toBe(true);
+
+      // Process exits after open() already resolved — the earlyExit promise
+      // rejects, but the .catch(() => {}) should swallow it silently.
+      (proc as unknown as { exitCode: number | null }).exitCode = 1;
+      proc.emit("close", 1);
+
+      // Flush microtasks to give any unhandled rejection a chance to fire.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // No assertion needed — if an unhandled rejection fired, vitest would
+      // fail the test. Verify the tunnel correctly reports as dead.
+      expect(tunnel.isAlive()).toBe(false);
+    });
   });
 
   describe("close()", () => {
@@ -210,5 +255,54 @@ describe("ProcessTunnel", () => {
       expect(customWaitFn).toHaveBeenCalledOnce();
       expect(probe.waitForPort).not.toHaveBeenCalled();
     });
+  });
+});
+
+// ── Full-chain integration: withFreePort + ProcessTunnel + isPortConflictError ──
+
+describe("withFreePort + ProcessTunnel full retry chain", () => {
+  it("retries with a new port when the tunnel process exits with a port-conflict error", async () => {
+    let openCallCount = 0;
+
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: TestTunnel }> => {
+      openCallCount++;
+      const proc = createMockProcess();
+      const fac = createMockProcessFactory(proc);
+
+      if (openCallCount === 1) {
+        // First attempt: process exits immediately with port-conflict stderr
+        const prb: TunnelPortProbe = {
+          waitForPort: vi.fn().mockImplementation(() => new Promise(() => {})),
+        };
+        const t = new TestTunnel(port, "ssh", ["-N", "-L", `${port}:127.0.0.1:7433`], fac, prb);
+        const openPromise = t.open();
+
+        // Simulate SSH failing to bind
+        proc.stderr!.emit("data", Buffer.from("bind: Address already in use\n"));
+        proc.emit("close", 255);
+
+        // This should throw, which withFreePort will catch and retry
+        await openPromise;
+        throw new Error("should not reach here");
+      }
+
+      // Second attempt: succeeds normally
+      const prb = createMockPortProbe();
+      const t = new TestTunnel(port, "ssh", ["-N", "-L", `${port}:127.0.0.1:7433`], fac, prb);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const result = await withFreePort(openTunnel);
+
+    expect(openCallCount).toBe(2);
+    expect(result.tunnel).toBeDefined();
+    expect(result.tunnel.isAlive()).toBe(true);
+
+    // Verify the error from the first attempt would have been detected
+    const portConflictErr = new Error(
+      "Tunnel process exited with code 255: bind: Address already in use",
+    );
+    expect(isPortConflictError(portConflictErr)).toBe(true);
   });
 });

--- a/packages/adapter-sdk/src/tunnel.ts
+++ b/packages/adapter-sdk/src/tunnel.ts
@@ -91,10 +91,6 @@ export abstract class ProcessTunnel implements RemoteTunnel {
       env,
     });
 
-    this.process.on("error", (err) => {
-      this.logger.error({ err }, "Tunnel process error");
-    });
-
     // Capture stderr so early-exit errors (e.g. port conflicts) propagate
     // with enough detail for isPortConflictError to match.
     const stderrChunks: string[] = [];
@@ -104,12 +100,17 @@ export abstract class ProcessTunnel implements RemoteTunnel {
       this.logger.debug({ stderr: text }, "Tunnel stderr");
     });
 
-    // Race the readiness probe against early process exit so port-conflict
-    // errors from SSH/gh surface immediately instead of timing out.
+    // Race the readiness probe against early process exit or spawn failure
+    // so port-conflict errors from SSH/gh surface immediately instead of
+    // timing out. Uses .once to avoid listener leaks.
     const earlyExit = new Promise<never>((_resolve, reject) => {
-      this.process!.on("close", (code) => {
+      this.process!.once("close", (code) => {
         const stderr = stderrChunks.join("").trim();
         reject(new Error(`Tunnel process exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
+      });
+      this.process!.once("error", (err) => {
+        this.logger.error({ err }, "Tunnel process error");
+        reject(err);
       });
     });
     // Prevent unhandled rejection if the process exits after open() succeeds.

--- a/packages/adapter-sdk/src/tunnel.ts
+++ b/packages/adapter-sdk/src/tunnel.ts
@@ -95,13 +95,28 @@ export abstract class ProcessTunnel implements RemoteTunnel {
       this.logger.error({ err }, "Tunnel process error");
     });
 
+    // Capture stderr so early-exit errors (e.g. port conflicts) propagate
+    // with enough detail for isPortConflictError to match.
+    const stderrChunks: string[] = [];
     this.process.stderr?.on("data", (data: Buffer) => {
-      this.logger.debug({ stderr: data.toString() }, "Tunnel stderr");
+      const text = data.toString();
+      stderrChunks.push(text);
+      this.logger.debug({ stderr: text }, "Tunnel stderr");
     });
 
-    // Wait for the tunnel to become ready. Kill the process if it fails.
+    // Race the readiness probe against early process exit so port-conflict
+    // errors from SSH/gh surface immediately instead of timing out.
+    const earlyExit = new Promise<never>((_resolve, reject) => {
+      this.process!.on("close", (code) => {
+        const stderr = stderrChunks.join("").trim();
+        reject(new Error(`Tunnel process exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
+      });
+    });
+    // Prevent unhandled rejection if the process exits after open() succeeds.
+    earlyExit.catch(() => {});
+
     try {
-      await this.waitForReady();
+      await Promise.race([this.waitForReady(), earlyExit]);
     } catch (err) {
       await this.close();
       throw err;

--- a/packages/adapter-sdk/src/utils.test.ts
+++ b/packages/adapter-sdk/src/utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { isPortConflictError, withFreePort, findFreePort } from "./utils.js";
+
+// ─── isPortConflictError ────────────────────────────────────
+
+describe("isPortConflictError", () => {
+  it("returns true for EADDRINUSE", () => {
+    const err = Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+    expect(isPortConflictError(err)).toBe(true);
+  });
+
+  it("returns true for Docker port-already-allocated message", () => {
+    const err = new Error(
+      "Error response from daemon: driver failed programming external connectivity: port is already allocated",
+    );
+    expect(isPortConflictError(err)).toBe(true);
+  });
+
+  it("returns true for address-already-in-use message (SSH / generic)", () => {
+    const err = new Error("bind: Address already in use");
+    expect(isPortConflictError(err)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isPortConflictError(new Error("connection refused"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isPortConflictError("EADDRINUSE")).toBe(false);
+    expect(isPortConflictError(null)).toBe(false);
+    expect(isPortConflictError(undefined)).toBe(false);
+  });
+});
+
+// ─── findFreePort ───────────────────────────────────────────
+
+describe("findFreePort", () => {
+  it("returns a valid ephemeral port", async () => {
+    const port = await findFreePort();
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+});
+
+// ─── withFreePort ───────────────────────────────────────────
+
+describe("withFreePort", () => {
+  it("returns the action result on first success", async () => {
+    const result = await withFreePort(async (port) => `bound:${port}`);
+    expect(result).toMatch(/^bound:\d+$/);
+  });
+
+  it("retries on port-conflict error and eventually succeeds", async () => {
+    let callCount = 0;
+    const result = await withFreePort(async (port) => {
+      callCount++;
+      if (callCount === 1) {
+        throw Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+      }
+      return `ok:${port}`;
+    });
+    expect(callCount).toBe(2);
+    expect(result).toMatch(/^ok:\d+$/);
+  });
+
+  it("throws after exhausting all attempts", async () => {
+    const err = Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
+    const action = vi.fn().mockRejectedValue(err);
+
+    await expect(withFreePort(action, 3)).rejects.toThrow("EADDRINUSE");
+    expect(action).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-port-conflict errors", async () => {
+    const action = vi.fn().mockRejectedValueOnce(new Error("timeout"));
+
+    await expect(withFreePort(action)).rejects.toThrow("timeout");
+    expect(action).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/adapter-sdk/src/utils.test.ts
+++ b/packages/adapter-sdk/src/utils.test.ts
@@ -77,4 +77,12 @@ describe("withFreePort", () => {
     await expect(withFreePort(action)).rejects.toThrow("timeout");
     expect(action).toHaveBeenCalledOnce();
   });
+
+  it("rejects invalid maxAttempts values", async () => {
+    const action = vi.fn();
+    await expect(withFreePort(action, 0)).rejects.toThrow(RangeError);
+    await expect(withFreePort(action, -1)).rejects.toThrow(RangeError);
+    await expect(withFreePort(action, 1.5)).rejects.toThrow(RangeError);
+    expect(action).not.toHaveBeenCalled();
+  });
 });

--- a/packages/adapter-sdk/src/utils.ts
+++ b/packages/adapter-sdk/src/utils.ts
@@ -68,6 +68,11 @@ export async function withFreePort<T>(
   action: (port: number) => Promise<T>,
   maxAttempts: number = MAX_PORT_ATTEMPTS,
 ): Promise<T> {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError(
+      `withFreePort: maxAttempts must be a positive integer, got ${maxAttempts}`,
+    );
+  }
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const port = await findFreePort();
     try {

--- a/packages/adapter-sdk/src/utils.ts
+++ b/packages/adapter-sdk/src/utils.ts
@@ -37,6 +37,50 @@ export function findFreePort(): Promise<number> {
   });
 }
 
+/** Maximum number of port-discovery attempts before giving up. */
+const MAX_PORT_ATTEMPTS: number = 3;
+
+/** Port-conflict error strings emitted by Docker, SSH, and Node. */
+const PORT_CONFLICT_PATTERNS: string[] = ["address already in use", "port is already allocated"];
+
+/**
+ * Return true if an error indicates a port-binding conflict (EADDRINUSE or
+ * equivalent messages from Docker / SSH / gh CLI).
+ */
+export function isPortConflictError(err: unknown): boolean {
+  if (err instanceof Error) {
+    if ("code" in err && (err as NodeJS.ErrnoException).code === "EADDRINUSE") {
+      return true;
+    }
+    const message = err.message.toLowerCase();
+    return PORT_CONFLICT_PATTERNS.some((pattern) => message.includes(pattern));
+  }
+  return false;
+}
+
+/**
+ * Discover a free port and pass it to `action`. If the action throws a
+ * port-conflict error, retry with a freshly discovered port up to
+ * `maxAttempts` times (default 3). When the caller already has a
+ * preferred port, call the action directly instead of using this wrapper.
+ */
+export async function withFreePort<T>(
+  action: (port: number) => Promise<T>,
+  maxAttempts: number = MAX_PORT_ATTEMPTS,
+): Promise<T> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const port = await findFreePort();
+    try {
+      return await action(port);
+    } catch (err) {
+      if (attempt === maxAttempts || !isPortConflictError(err)) {
+        throw err;
+      }
+    }
+  }
+  throw new Error("withFreePort: exhausted all attempts");
+}
+
 /**
  * Check if we are running from a monorepo source checkout.
  * We detect this by checking for `rush.json` at the repo root,

--- a/packages/adapter-ssh/src/ssh.test.ts
+++ b/packages/adapter-ssh/src/ssh.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   closeTunnel: vi.fn().mockResolvedValue(undefined),
   registerTunnel: vi.fn(),
   findFreePort: vi.fn().mockResolvedValue(9999),
+  withFreePort: vi.fn(),
   startRemotePowerLine: vi.fn().mockResolvedValue({ alreadyRunning: true }),
   bootstrapPowerLine: vi.fn(),
   tunnelInstances: [] as MockTunnelInstance[],
@@ -26,6 +27,7 @@ vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => {
     closeTunnel: mocks.closeTunnel,
     registerTunnel: mocks.registerTunnel,
     findFreePort: mocks.findFreePort,
+    withFreePort: mocks.withFreePort,
     startRemotePowerLine: mocks.startRemotePowerLine,
     bootstrapPowerLine: async function* () {
       yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
@@ -79,6 +81,9 @@ describe("SshAdapter.reconnect()", () => {
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
     mocks.startRemotePowerLine.mockResolvedValue({ alreadyRunning: true });
+    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
+      action(9999),
+    );
     adapter = new SshAdapter({
       exec: mockExec,
       sleep: mockSleep,
@@ -191,6 +196,9 @@ describe("SshAdapter.provision() — tunnel cleanup", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
+    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
+      action(9999),
+    );
     adapter = new SshAdapter({
       exec: mockExec,
       sleep: mockSleep,

--- a/packages/adapter-ssh/src/ssh.ts
+++ b/packages/adapter-ssh/src/ssh.ts
@@ -17,7 +17,7 @@ import {
   registerTunnel,
   getTunnel,
   closeTunnel,
-  findFreePort,
+  withFreePort,
   remoteStop,
   remoteDestroy,
   remoteHealthCheck,
@@ -247,16 +247,22 @@ export class SshAdapter implements EnvironmentAdapter {
       defaultRuntime: (config.defaultRuntime as string) || undefined,
     });
 
-    // Open SSH tunnel
-    const localPort = cfg.localPort || (await findFreePort());
+    // Open SSH tunnel (retry with a fresh port on TOCTOU conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: SshTunnel }> => {
+      const t = new SshTunnel(port, cfg);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await withFreePort(openTunnel);
+
     yield {
       stage: "tunneling",
       message: `Opening SSH tunnel on local port ${localPort}...`,
       progress: 0.8,
     };
-
-    const tunnel = new SshTunnel(localPort, cfg);
-    await tunnel.open();
 
     // Open reverse tunnel (remote → host MCP server) for agent tool calls.
     // Wrap in try/catch so the forward tunnel is cleaned up if the reverse fails.
@@ -313,15 +319,22 @@ export class SshAdapter implements EnvironmentAdapter {
       yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };
     }
 
-    // 3. Open new SSH tunnel + reverse tunnel for MCP
-    const localPort = cfg.localPort || (await findFreePort());
+    // 3. Open new SSH tunnel + reverse tunnel for MCP (retry on port conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: SshTunnel }> => {
+      const t = new SshTunnel(port, cfg);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await withFreePort(openTunnel);
+
     yield {
       stage: "reconnecting",
       message: `Opening SSH tunnel on local port ${localPort}...`,
       progress: 0.7,
     };
-    const tunnel = new SshTunnel(localPort, cfg);
-    await tunnel.open();
 
     try {
       const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);

--- a/packages/core/src/utils/ports.ts
+++ b/packages/core/src/utils/ports.ts
@@ -1,18 +1,1 @@
-import { createServer } from "node:net";
-
-/** Find and return an available TCP port by briefly binding to port 0. */
-export function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const addr = server.address();
-      if (addr && typeof addr === "object") {
-        const port = addr.port;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error("Failed to get port")));
-      }
-    });
-    server.on("error", reject);
-  });
-}
+export { findFreePort, withFreePort, isPortConflictError } from "@grackle-ai/adapter-sdk";


### PR DESCRIPTION
## Summary
- Add `withFreePort()` retry wrapper and `isPortConflictError()` detector to `@grackle-ai/adapter-sdk` — discovers a free port and retries the caller's action up to 3 times if the downstream bind fails with a port-conflict error (EADDRINUSE / Docker / SSH messages)
- Refactor all 6 production call sites (SSH provision/reconnect, Codespace provision/reconnect, Docker create/attach-sidecar) to use `withFreePort` instead of raw `findFreePort`, closing the TOCTOU window between port discovery and actual use
- Deduplicate `core/utils/ports.ts` to re-export from adapter-sdk instead of maintaining an identical copy

## Test plan
- [x] New unit tests for `isPortConflictError` (EADDRINUSE, Docker message, SSH message, non-matching, non-Error)
- [x] New unit tests for `withFreePort` (first-attempt success, retry on conflict, exhaustion, no retry on non-port error)
- [x] Existing adapter-sdk tests pass (77/77)
- [x] Existing adapter-ssh tests pass (10/10)
- [x] Existing adapter-codespace tests pass (15/15)
- [x] Existing adapter-docker tests pass (27/27)
- [x] Core tests pass
- [x] Full `rush build` clean (no warnings)

Closes #1486