### PR TITLE
Fix AgentChatTab: render ChatInput for suspended sessions (#1507)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1507-agent-chat-suspended-sessions_2026-06-03-06-08.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1507-agent-chat-suspended-sessions_2026-06-03-06-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix AgentChatTab to render ChatInput for suspended sessions so the reconnect button remains reachable",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web/src/pages/agent-tabs/AgentChatTab.tsx
+++ b/packages/web/src/pages/agent-tabs/AgentChatTab.tsx
@@ -71,6 +71,7 @@ export function AgentChatTab(): JSX.Element {
   }, [events, latestSession?.id]);
 
   const isActive = latestSession ? ACTIVE_STATUSES.has(latestSession.status) : false;
+  const showSend = isActive || latestSession?.status === "suspended";
 
   const docEnvironmentId = latestSession?.environmentId;
 
@@ -107,11 +108,11 @@ export function AgentChatTab(): JSX.Element {
         />
       </div>
       <ChatInput
-        mode={isActive ? "send" : "start"}
-        sessionId={isActive ? latestSession!.id : undefined}
+        mode={showSend ? "send" : "start"}
+        sessionId={showSend ? latestSession!.id : undefined}
         taskId={rootTask.id}
         environmentId={
-          isActive
+          showSend
             ? latestSession!.environmentId
             : (environments.find((e) => e.id === agent.environmentId)?.id ?? environments[0]?.id)
         }

--- a/tests/e2e-tests/tests/agent-disconnected-env.spec.ts
+++ b/tests/e2e-tests/tests/agent-disconnected-env.spec.ts
@@ -111,6 +111,7 @@ test.describe(
       appPage,
       grackle: { client },
     }) => {
+      test.setTimeout(60_000);
       await setupDisconnectedAgent(appPage, client);
 
       const reconnectBtn = appPage.locator('[data-testid="reconnect-btn"]');
@@ -122,6 +123,7 @@ test.describe(
       appPage,
       grackle: { client },
     }) => {
+      test.setTimeout(60_000);
       await setupDisconnectedAgent(appPage, client);
 
       const sendBtn = appPage.locator("button", { hasText: "Send" });
@@ -135,6 +137,7 @@ test.describe(
       appPage,
       grackle: { client },
     }) => {
+      test.setTimeout(60_000);
       await setupDisconnectedAgent(appPage, client);
 
       await expect(appPage.locator('[data-testid="env-disconnect-hint"]')).toBeVisible({
@@ -149,6 +152,7 @@ test.describe(
       appPage,
       grackle: { client },
     }) => {
+      test.setTimeout(60_000);
       await setupDisconnectedAgent(appPage, client);
 
       const sendBtn = appPage.locator("button", { hasText: "Send" });

--- a/tests/e2e-tests/tests/agent-disconnected-env.spec.ts
+++ b/tests/e2e-tests/tests/agent-disconnected-env.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for #1507: AgentChatTab renders ChatInput for suspended sessions.
+ *
+ * When an agent's session is suspended (via environment stop), the Agent
+ * chat tab must keep ChatInput in "send" mode so the disconnected-env
+ * hint and Reconnect button remain reachable.
+ *
+ * Strategy: create an agent, start its root task with the stub runtime
+ * (goes idle automatically), navigate to the agent chat tab, stop the
+ * environment (suspends the session), and assert the reconnect UI appears.
+ */
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures.js";
+import type { GrackleClient } from "./rpc-client.js";
+import { provisionEnvironmentDirect } from "./helpers.js";
+
+const POLL_INTERVAL_MS = 250;
+
+/** Generate a unique agent name to avoid cross-test collisions. */
+function uniqueAgentName(prefix: string): string {
+  return `${prefix}-${Math.floor(Date.now() / 1000)}-${Math.floor(Math.random() * 10000)}`;
+}
+
+/** Poll until the agent's root task exists and return its ID. */
+async function waitForRootTask(
+  client: GrackleClient,
+  agentId: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const resp = await client.orchestration.listTasks({});
+    const root = resp.tasks.find(
+      (t: { agentId: string; kind: string }) => t.agentId === agentId && t.kind === "root",
+    );
+    if (root) {
+      return root.id as string;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`Timed out waiting for root task of agent ${agentId}`);
+}
+
+/** Poll until the task has at least one session in "idle" status. */
+async function waitForIdleSession(
+  client: GrackleClient,
+  taskId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const resp = await client.core.getTaskSessions({ id: taskId });
+    if (resp.sessions.some((s: { status: string }) => s.status === "idle")) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`Timed out waiting for idle session on task ${taskId}`);
+}
+
+test.describe(
+  "Agent chat tab — disconnected environment (#1507)",
+  { tag: ["@agent", "@error"] },
+  () => {
+    /**
+     * Create an agent, start its root task with the stub runtime, wait for
+     * idle, navigate to the agent chat tab, and stop the environment.
+     * Returns after the reconnect button is visible.
+     */
+    async function setupDisconnectedAgent(
+      page: Page,
+      client: GrackleClient,
+    ): Promise<{ agentId: string }> {
+      const agentName = uniqueAgentName("AgentDisc");
+      const agent = await client.orchestration.createAgent({
+        name: agentName,
+        environmentId: "test-local",
+        primaryPersonaId: "stub",
+      });
+
+      const rootTaskId = await waitForRootTask(client, agent.id, 5_000);
+
+      await client.orchestration.startTask({
+        taskId: rootTaskId,
+        personaId: "stub",
+        environmentId: "test-local",
+      });
+
+      await waitForIdleSession(client, rootTaskId, 15_000);
+
+      const contextItem = page.locator(`[data-testid="context-agent-${agent.id}"]`);
+      await contextItem.waitFor({ state: "visible", timeout: 10_000 });
+      await contextItem.click();
+
+      await expect(page.locator('[data-testid="agent-chat-tab"]')).toBeVisible({ timeout: 5_000 });
+
+      await page
+        .locator('textarea[placeholder="Type a message..."]')
+        .waitFor({ state: "visible", timeout: 10_000 });
+
+      await client.core.stopEnvironment({ id: "test-local" });
+
+      await page
+        .locator('[data-testid="reconnect-btn"]')
+        .waitFor({ state: "visible", timeout: 10_000 });
+
+      return { agentId: agent.id };
+    }
+
+    test("Reconnect button is visible when agent session is suspended", async ({
+      appPage,
+      grackle: { client },
+    }) => {
+      await setupDisconnectedAgent(appPage, client);
+
+      const reconnectBtn = appPage.locator('[data-testid="reconnect-btn"]');
+      await expect(reconnectBtn).toBeVisible({ timeout: 5_000 });
+      await expect(reconnectBtn).toContainText("Reconnect");
+    });
+
+    test("Send button and input are disabled when agent session is suspended", async ({
+      appPage,
+      grackle: { client },
+    }) => {
+      await setupDisconnectedAgent(appPage, client);
+
+      const sendBtn = appPage.locator("button", { hasText: "Send" });
+      await expect(sendBtn).toBeDisabled({ timeout: 5_000 });
+
+      const inputField = appPage.locator('textarea[placeholder="Type a message..."]');
+      await expect(inputField).toBeDisabled({ timeout: 5_000 });
+    });
+
+    test("disconnect hint is visible when agent session is suspended", async ({
+      appPage,
+      grackle: { client },
+    }) => {
+      await setupDisconnectedAgent(appPage, client);
+
+      await expect(appPage.locator('[data-testid="env-disconnect-hint"]')).toBeVisible({
+        timeout: 5_000,
+      });
+      await expect(appPage.locator('[data-testid="env-disconnect-hint"]')).toContainText(
+        /unavailable/i,
+      );
+    });
+
+    test("Send button re-enables when environment reconnects", async ({
+      appPage,
+      grackle: { client },
+    }) => {
+      await setupDisconnectedAgent(appPage, client);
+
+      const sendBtn = appPage.locator("button", { hasText: "Send" });
+      await expect(sendBtn).toBeDisabled({ timeout: 5_000 });
+
+      await provisionEnvironmentDirect("test-local", client);
+
+      const inputField = appPage.locator('textarea[placeholder="Type a message..."]');
+      await expect(inputField).toBeEnabled({ timeout: 10_000 });
+      await inputField.fill("hello");
+
+      await expect(sendBtn).toBeEnabled({ timeout: 5_000 });
+
+      await expect(appPage.locator('[data-testid="reconnect-btn"]')).not.toBeVisible({
+        timeout: 5_000,
+      });
+      await expect(appPage.locator('[data-testid="env-disconnect-hint"]')).not.toBeVisible({
+        timeout: 5_000,
+      });
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- AgentChatTab now keeps ChatInput in `"send"` mode when the session is suspended, so the disconnected-env hint and Reconnect button remain reachable
- Adds `showSend` flag (mirrors `SessionPage.tsx` pattern) that includes `"suspended"` status alongside `isActive`
- New E2E test suite (`agent-disconnected-env.spec.ts`) covers reconnect button visibility, disabled send/input, disconnect hint, and re-enable on reconnect

## Test plan
- [x] `rush build -t @grackle-ai/web` — clean (no warnings)
- [x] `rushx test` in `packages/web` — 282 tests pass
- [x] E2E type-check passes (`tsc --noEmit` in `tests/e2e-tests`)
- [x] Prettier formatting clean
- [ ] E2E: `agent-disconnected-env.spec.ts` — reconnect button visible, send disabled, hint visible, re-enable on reconnect

Closes #1507