### PR TITLE
UX consistency: sidebar nav, breadcrumbs, back-navigation

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-ux-consistency-overhaul_2026-06-03-14-41.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-ux-consistency-overhaul_2026-06-03-14-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "UX consistency: sidebar nav for Personas/Schedules/Coordination, PageHeader with breadcrumbs and back-navigation on all pages",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/layout/PageHeader.module.scss
+++ b/packages/web-components/src/components/layout/PageHeader.module.scss
@@ -1,0 +1,59 @@
+@use "../../styles/mixins" as *;
+
+.pageHeader {
+  display: flex;
+  align-items: center;
+  padding: var(--space-xs) var(--space-md);
+  flex-shrink: 0;
+  min-height: 0;
+  gap: 0;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 2px var(--space-xs);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--bg-overlay);
+    color: var(--text-secondary);
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--accent-blue);
+    outline-offset: 1px;
+  }
+}
+
+.backLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.backSeparator {
+  color: var(--text-tertiary);
+  opacity: 0.4;
+  font-size: var(--font-size-xs);
+  margin: 0 var(--space-xs);
+  flex-shrink: 0;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}

--- a/packages/web-components/src/components/layout/PageHeader.tsx
+++ b/packages/web-components/src/components/layout/PageHeader.tsx
@@ -1,0 +1,78 @@
+/**
+ * PageHeader — standardized breadcrumb row with optional back-navigation and actions.
+ *
+ * @module
+ */
+
+import type { JSX, ReactNode } from "react";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "react-router";
+import { Breadcrumbs } from "../display/Breadcrumbs.js";
+import type { BreadcrumbSegment } from "../../utils/breadcrumbs.js";
+import { ICON_SM } from "../../utils/iconSize.js";
+import styles from "./PageHeader.module.scss";
+
+/** Props for {@link PageHeader}. */
+export interface PageHeaderProps {
+  /** Breadcrumb segments to render. */
+  segments: BreadcrumbSegment[];
+  /** Optional back-navigation label (e.g., "Home"). Renders ArrowLeft + label. */
+  backLabel?: string;
+  /** URL to navigate to when the back button is clicked. */
+  backUrl?: string;
+  /** Optional callback for back navigation (overrides backUrl if provided). */
+  onNavigateBack?: () => void;
+  /** Optional actions to render in the right slot. */
+  actions?: ReactNode;
+}
+
+/** Standardized page header with breadcrumbs, optional back-navigation, and actions. */
+export function PageHeader({
+  segments,
+  backLabel,
+  backUrl,
+  onNavigateBack,
+  actions,
+}: PageHeaderProps): JSX.Element {
+  const showBack = Boolean(backLabel || backUrl || onNavigateBack);
+
+  return (
+    <header className={styles.pageHeader} data-testid="page-header">
+      {showBack && (
+        <>
+          {onNavigateBack ? (
+            <button
+              type="button"
+              className={styles.backButton}
+              onClick={onNavigateBack}
+              aria-label={backLabel ? `Back to ${backLabel}` : "Back"}
+              data-testid="page-header-back"
+            >
+              <ArrowLeft size={ICON_SM} />
+              {backLabel && <span className={styles.backLabel}>{backLabel}</span>}
+            </button>
+          ) : backUrl ? (
+            <Link
+              to={backUrl}
+              className={styles.backButton}
+              aria-label={backLabel ? `Back to ${backLabel}` : "Back"}
+              data-testid="page-header-back"
+            >
+              <ArrowLeft size={ICON_SM} />
+              {backLabel && <span className={styles.backLabel}>{backLabel}</span>}
+            </Link>
+          ) : null}
+          <span className={styles.backSeparator} aria-hidden="true">
+            /
+          </span>
+        </>
+      )}
+      <Breadcrumbs segments={segments} />
+      {actions && (
+        <div className={styles.actions} data-testid="page-header-actions">
+          {actions}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/packages/web-components/src/components/layout/PageHeader.tsx
+++ b/packages/web-components/src/components/layout/PageHeader.tsx
@@ -34,7 +34,7 @@ export function PageHeader({
   onNavigateBack,
   actions,
 }: PageHeaderProps): JSX.Element {
-  const showBack = Boolean(backLabel || backUrl || onNavigateBack);
+  const showBack = Boolean(backUrl || onNavigateBack);
 
   return (
     <header className={styles.pageHeader} data-testid="page-header">

--- a/packages/web-components/src/components/layout/index.ts
+++ b/packages/web-components/src/components/layout/index.ts
@@ -9,3 +9,5 @@ export { ContextNav, CONTEXTS, DEFAULT_CONTEXT_ID } from "./ContextNav.js";
 export type { ContextItem, ContextNavProps } from "./ContextNav.js";
 export { Sidebar } from "./Sidebar.js";
 export { BottomStatusBar } from "./BottomStatusBar.js";
+export { PageHeader } from "./PageHeader.js";
+export type { PageHeaderProps } from "./PageHeader.js";

--- a/packages/web-components/src/components/lists/PersonaNav.module.scss
+++ b/packages/web-components/src/components/lists/PersonaNav.module.scss
@@ -1,0 +1,118 @@
+@use "../../styles/mixins" as *;
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  width: 100%;
+  padding: var(--space-md);
+  overflow-y: auto;
+
+  @include mobile {
+    flex-direction: row;
+    width: 100%;
+    min-width: unset;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: var(--space-xs) var(--space-sm);
+    gap: 0;
+    flex-wrap: nowrap;
+  }
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: var(--bg-overlay);
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-green);
+    outline-offset: -2px;
+  }
+
+  @include mobile {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--font-size-xs);
+    width: auto;
+    border-radius: 0;
+  }
+}
+
+.tabActive {
+  border-left-color: var(--accent-green);
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
+
+  @include mobile {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent-green);
+  }
+}
+
+.tabLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.typeDot {
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+}
+
+.defaultBadge {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  color: var(--accent-green);
+  font-weight: var(--font-weight-medium);
+}
+
+.addButton {
+  @include btn-ghost;
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-top: var(--space-sm);
+  text-align: left;
+  width: 100%;
+  color: var(--text-tertiary);
+
+  &:hover {
+    color: var(--accent-green);
+  }
+}
+
+.empty {
+  padding: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+  text-align: center;
+}

--- a/packages/web-components/src/components/lists/PersonaNav.tsx
+++ b/packages/web-components/src/components/lists/PersonaNav.tsx
@@ -1,0 +1,136 @@
+/**
+ * PersonaNav — vertical sidebar navigation for the Persona Library.
+ *
+ * @module
+ */
+
+import { useCallback, useRef, type JSX, type KeyboardEvent } from "react";
+import { Circle } from "lucide-react";
+import { ICON_XS } from "../../utils/iconSize.js";
+import { useMatch } from "react-router";
+import type { PersonaData } from "../../hooks/types.js";
+import { personaUrl, NEW_PERSONA_URL, useAppNavigate } from "../../utils/navigation.js";
+import styles from "./PersonaNav.module.scss";
+
+/** Type-indicator color mapping. */
+const TYPE_COLORS: Record<string, string> = {
+  agent: "var(--accent-green)",
+  script: "var(--accent-blue)",
+};
+
+/** Props for the PersonaNav component. */
+export interface PersonaNavProps {
+  /** List of all personas to display in the nav. */
+  personas: PersonaData[];
+  /** The app-level default persona ID, used to show the "Default" badge. */
+  appDefaultPersonaId: string;
+}
+
+/** Vertical nav rail listing personas with type indicators. */
+export function PersonaNav({ personas, appDefaultPersonaId }: PersonaNavProps): JSX.Element {
+  const navigate = useAppNavigate();
+  const tabListRef = useRef<HTMLElement>(null);
+
+  const detailMatch = useMatch("/personas/:personaId");
+  const rawId = detailMatch?.params.personaId;
+  const activeId = rawId === "new" ? undefined : rawId;
+
+  const handleClick = useCallback(
+    (personaId: string) => {
+      navigate(personaUrl(personaId));
+    },
+    [navigate],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLElement>) => {
+      const buttons = tabListRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      if (!buttons || buttons.length === 0) {
+        return;
+      }
+      const focusedIndex = Array.from(buttons).findIndex((b) => b === document.activeElement);
+      const currentIndex =
+        focusedIndex >= 0 ? focusedIndex : personas.findIndex((p) => p.id === activeId);
+      let nextIndex = currentIndex;
+
+      if (e.key === "ArrowDown" || e.key === "j" || e.key === "J") {
+        e.preventDefault();
+        nextIndex = (currentIndex + 1) % buttons.length;
+      } else if (e.key === "ArrowUp" || e.key === "k" || e.key === "K") {
+        e.preventDefault();
+        nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        nextIndex = 0;
+      } else if (e.key === "End") {
+        e.preventDefault();
+        nextIndex = buttons.length - 1;
+      } else {
+        return;
+      }
+
+      if (nextIndex < personas.length) {
+        navigate(personaUrl(personas[nextIndex].id));
+      }
+      buttons[nextIndex].focus();
+    },
+    [activeId, personas, navigate],
+  );
+
+  const focusableId = activeId ?? (personas.length > 0 ? personas[0].id : undefined);
+
+  return (
+    <div className={styles.nav} data-testid="persona-nav">
+      <nav
+        ref={tabListRef}
+        role="tablist"
+        aria-orientation="vertical"
+        aria-label="Personas"
+        onKeyDown={handleKeyDown}
+      >
+        {personas.map((persona) => {
+          const isActive = persona.id === activeId;
+          const isFocusable = persona.id === focusableId;
+          const typeColor = TYPE_COLORS[persona.type] || "var(--text-tertiary)";
+          const isDefault = persona.id === appDefaultPersonaId;
+          return (
+            <button
+              key={persona.id}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              tabIndex={isFocusable ? 0 : -1}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
+              onClick={() => handleClick(persona.id)}
+              data-testid="persona-nav-item"
+            >
+              <span className={styles.typeDot} style={{ color: typeColor }} aria-hidden="true">
+                <Circle size={ICON_XS} fill="currentColor" />
+              </span>
+              <span className={styles.tabLabel} title={persona.name}>
+                {persona.name}
+              </span>
+              {isDefault && (
+                <span className={styles.defaultBadge} data-testid="persona-nav-default-badge">
+                  Default
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      <button
+        type="button"
+        className={styles.addButton}
+        onClick={() => navigate(NEW_PERSONA_URL)}
+        title="New persona"
+        data-testid="persona-nav-add"
+      >
+        + New Persona
+      </button>
+
+      {personas.length === 0 && <div className={styles.empty}>No personas yet.</div>}
+    </div>
+  );
+}

--- a/packages/web-components/src/components/lists/ScheduleNav.module.scss
+++ b/packages/web-components/src/components/lists/ScheduleNav.module.scss
@@ -1,0 +1,121 @@
+@use "../../styles/mixins" as *;
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  width: 100%;
+  padding: var(--space-md);
+  overflow-y: auto;
+
+  @include mobile {
+    flex-direction: row;
+    width: 100%;
+    min-width: unset;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: var(--space-xs) var(--space-sm);
+    gap: 0;
+    flex-wrap: nowrap;
+  }
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: var(--bg-overlay);
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-green);
+    outline-offset: -2px;
+  }
+
+  @include mobile {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--font-size-xs);
+    width: auto;
+    border-radius: 0;
+  }
+}
+
+.tabActive {
+  border-left-color: var(--accent-green);
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
+
+  @include mobile {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent-green);
+  }
+}
+
+.tabLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statusDot {
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+}
+
+.trailingBadge {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 80px;
+}
+
+.addButton {
+  @include btn-ghost;
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-top: var(--space-sm);
+  text-align: left;
+  width: 100%;
+  color: var(--text-tertiary);
+
+  &:hover {
+    color: var(--accent-green);
+  }
+}
+
+.empty {
+  padding: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+  text-align: center;
+}

--- a/packages/web-components/src/components/lists/ScheduleNav.tsx
+++ b/packages/web-components/src/components/lists/ScheduleNav.tsx
@@ -1,0 +1,137 @@
+/**
+ * ScheduleNav — vertical sidebar navigation for the Schedules page.
+ *
+ * @module
+ */
+
+import { useCallback, useRef, type JSX, type KeyboardEvent } from "react";
+import { Circle } from "lucide-react";
+import { ICON_XS } from "../../utils/iconSize.js";
+import { useMatch } from "react-router";
+import type { PersonaData, ScheduleData } from "../../hooks/types.js";
+import { scheduleUrl, NEW_SCHEDULE_URL, useAppNavigate } from "../../utils/navigation.js";
+import { formatCountdown } from "../../utils/time.js";
+import styles from "./ScheduleNav.module.scss";
+
+/** Props for the ScheduleNav component. */
+export interface ScheduleNavProps {
+  /** List of all schedules to display in the nav. */
+  schedules: ScheduleData[];
+  /** All personas — used to resolve persona names for trailing badges. */
+  personas: PersonaData[];
+}
+
+/** Vertical nav rail listing schedules with enabled/disabled status dots. */
+export function ScheduleNav({ schedules, personas }: ScheduleNavProps): JSX.Element {
+  const navigate = useAppNavigate();
+  const tabListRef = useRef<HTMLElement>(null);
+
+  const detailMatch = useMatch("/schedules/:scheduleId");
+  const rawId = detailMatch?.params.scheduleId;
+  const activeId = rawId === "new" ? undefined : rawId;
+
+  const personaMap = new Map(personas.map((p) => [p.id, p]));
+
+  const handleClick = useCallback(
+    (scheduleId: string) => {
+      navigate(scheduleUrl(scheduleId));
+    },
+    [navigate],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLElement>) => {
+      const buttons = tabListRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      if (!buttons || buttons.length === 0) {
+        return;
+      }
+      const focusedIndex = Array.from(buttons).findIndex((b) => b === document.activeElement);
+      const currentIndex =
+        focusedIndex >= 0 ? focusedIndex : schedules.findIndex((s) => s.id === activeId);
+      let nextIndex = currentIndex;
+
+      if (e.key === "ArrowDown" || e.key === "j" || e.key === "J") {
+        e.preventDefault();
+        nextIndex = (currentIndex + 1) % buttons.length;
+      } else if (e.key === "ArrowUp" || e.key === "k" || e.key === "K") {
+        e.preventDefault();
+        nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        nextIndex = 0;
+      } else if (e.key === "End") {
+        e.preventDefault();
+        nextIndex = buttons.length - 1;
+      } else {
+        return;
+      }
+
+      if (nextIndex < schedules.length) {
+        navigate(scheduleUrl(schedules[nextIndex].id));
+      }
+      buttons[nextIndex].focus();
+    },
+    [activeId, schedules, navigate],
+  );
+
+  const focusableId = activeId ?? (schedules.length > 0 ? schedules[0].id : undefined);
+
+  return (
+    <div className={styles.nav} data-testid="schedule-nav">
+      <nav
+        ref={tabListRef}
+        role="tablist"
+        aria-orientation="vertical"
+        aria-label="Schedules"
+        onKeyDown={handleKeyDown}
+      >
+        {schedules.map((schedule) => {
+          const isActive = schedule.id === activeId;
+          const isFocusable = schedule.id === focusableId;
+          const statusColor = schedule.enabled ? "var(--accent-green)" : "var(--text-tertiary)";
+          const persona = personaMap.get(schedule.personaId);
+          const trailingText =
+            schedule.enabled && schedule.nextRunAt
+              ? formatCountdown(schedule.nextRunAt)
+              : persona?.name;
+          return (
+            <button
+              key={schedule.id}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              tabIndex={isFocusable ? 0 : -1}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
+              onClick={() => handleClick(schedule.id)}
+              data-testid="schedule-nav-item"
+            >
+              <span className={styles.statusDot} style={{ color: statusColor }} aria-hidden="true">
+                <Circle size={ICON_XS} fill="currentColor" />
+              </span>
+              <span className={styles.tabLabel} title={schedule.title}>
+                {schedule.title}
+              </span>
+              {trailingText && (
+                <span className={styles.trailingBadge} title={trailingText}>
+                  {trailingText}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      <button
+        type="button"
+        className={styles.addButton}
+        onClick={() => navigate(NEW_SCHEDULE_URL)}
+        title="New schedule"
+        data-testid="schedule-nav-add"
+      >
+        + New Schedule
+      </button>
+
+      {schedules.length === 0 && <div className={styles.empty}>No schedules yet.</div>}
+    </div>
+  );
+}

--- a/packages/web-components/src/components/lists/index.ts
+++ b/packages/web-components/src/components/lists/index.ts
@@ -3,3 +3,7 @@
  * @module lists
  */
 export { EnvironmentNav } from "./EnvironmentNav.js";
+export { PersonaNav } from "./PersonaNav.js";
+export type { PersonaNavProps } from "./PersonaNav.js";
+export { ScheduleNav } from "./ScheduleNav.js";
+export type { ScheduleNavProps } from "./ScheduleNav.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -86,6 +86,7 @@ export {
   AppNav,
   Sidebar,
   BottomStatusBar,
+  PageHeader,
   TABS,
   getActiveView,
   ContextNav,
@@ -99,10 +100,11 @@ export type {
   NavGroup,
   ContextItem,
   ContextNavProps,
+  PageHeaderProps,
 } from "./components/layout/index.js";
 
 // Lists
-export { EnvironmentNav } from "./components/lists/index.js";
+export { EnvironmentNav, PersonaNav, ScheduleNav } from "./components/lists/index.js";
 export { TaskList } from "./components/lists/TaskList.js";
 export {
   HighlightedText,
@@ -353,6 +355,12 @@ export {
   buildNewTaskBreadcrumbs,
   buildPersonaLibraryBreadcrumbs,
   buildPersonaDetailBreadcrumbs,
+  buildCoordinationBreadcrumbs,
+  buildSchedulesBreadcrumbs,
+  buildScheduleDetailBreadcrumbs,
+  buildSessionsListBreadcrumbs,
+  buildAgentBreadcrumbs,
+  buildAgentCreateBreadcrumbs,
 } from "./utils/breadcrumbs.js";
 
 export { groupConsecutiveTextEvents, pairToolEvents } from "./utils/sessionEvents.js";

--- a/packages/web-components/src/utils/breadcrumbs.ts
+++ b/packages/web-components/src/utils/breadcrumbs.ts
@@ -4,6 +4,7 @@ import {
   environmentUrl,
   HOME_URL,
   PERSONAS_URL,
+  SCHEDULES_URL,
   SETTINGS_URL,
   taskUrl,
   workspaceUrl,
@@ -67,6 +68,9 @@ const ENVIRONMENTS_SEGMENT: BreadcrumbSegment = { label: "Environments", url: EN
 /** Personas breadcrumb segment (links back to the top-level Persona Library). */
 const PERSONAS_SEGMENT: BreadcrumbSegment = { label: "Personas", url: PERSONAS_URL };
 
+/** Schedules breadcrumb segment (links back to the top-level Schedules page). */
+const SCHEDULES_SEGMENT: BreadcrumbSegment = { label: "Schedules", url: SCHEDULES_URL };
+
 /** Build breadcrumbs for the top-level Persona Library page. */
 export function buildPersonaLibraryBreadcrumbs(): BreadcrumbSegment[] {
   return [HOME_SEGMENT, { label: "Personas", url: undefined }];
@@ -75,6 +79,36 @@ export function buildPersonaLibraryBreadcrumbs(): BreadcrumbSegment[] {
 /** Build breadcrumbs for a persona detail (create or edit) page. */
 export function buildPersonaDetailBreadcrumbs(label: string): BreadcrumbSegment[] {
   return [HOME_SEGMENT, PERSONAS_SEGMENT, { label, url: undefined }];
+}
+
+/** Build breadcrumbs for the coordination page. */
+export function buildCoordinationBreadcrumbs(): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, { label: "Coordination", url: undefined }];
+}
+
+/** Build breadcrumbs for the schedules list page. */
+export function buildSchedulesBreadcrumbs(): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, { label: "Schedules", url: undefined }];
+}
+
+/** Build breadcrumbs for a schedule detail (create or edit) page. */
+export function buildScheduleDetailBreadcrumbs(label: string): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, SCHEDULES_SEGMENT, { label, url: undefined }];
+}
+
+/** Build breadcrumbs for the sessions list page. */
+export function buildSessionsListBreadcrumbs(): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, { label: "Sessions", url: undefined }];
+}
+
+/** Build breadcrumbs for an agent detail page. */
+export function buildAgentBreadcrumbs(agentName: string): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, { label: agentName, url: undefined }];
+}
+
+/** Build breadcrumbs for the new agent page. */
+export function buildAgentCreateBreadcrumbs(): BreadcrumbSegment[] {
+  return [HOME_SEGMENT, { label: "New Agent", url: undefined }];
 }
 
 /** Build breadcrumbs for the environments landing page. */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -56,7 +56,13 @@ import {
   useLocation,
   useParams,
 } from "react-router";
-import { EmptyPage, TasksEmptyPage, EnvironmentsEmptyPage } from "./pages/EmptyPage.js";
+import {
+  EmptyPage,
+  TasksEmptyPage,
+  EnvironmentsEmptyPage,
+  PersonasEmptyPage,
+  SchedulesEmptyPage,
+} from "./pages/EmptyPage.js";
 import { ChatPage } from "./pages/ChatPage.js";
 import { CoordinationPage } from "./pages/CoordinationPage.js";
 import { NewChatPage } from "./pages/NewChatPage.js";
@@ -72,16 +78,16 @@ import { EnvironmentDetailPage } from "./pages/EnvironmentDetailPage.js";
 import { SettingsPage } from "./pages/SettingsPage.js";
 import { SettingsCredentialsTab } from "./pages/settings/SettingsCredentialsTab.js";
 import { SettingsGitHubAccountsTab } from "./pages/settings/SettingsGitHubAccountsTab.js";
-import { PersonaLibraryPage } from "./pages/PersonaLibraryPage.js";
 import { PersonaDetailPage } from "./pages/PersonaDetailPage.js";
+import { PersonasHubPage } from "./pages/PersonasHubPage.js";
 import { AgentCreatePage } from "./pages/AgentCreatePage.js";
 import { AgentLayout } from "./pages/AgentLayout.js";
 import { AgentChatTab } from "./pages/agent-tabs/AgentChatTab.js";
 import { AgentSessionsTab } from "./pages/agent-tabs/AgentSessionsTab.js";
 import { AgentSchedulesTab } from "./pages/agent-tabs/AgentSchedulesTab.js";
 import { AgentSettingsTab } from "./pages/agent-tabs/AgentSettingsTab.js";
-import { SchedulesPage } from "./pages/SchedulesPage.js";
 import { ScheduleDetailPage } from "./pages/ScheduleDetailPage.js";
+import { SchedulesHubPage } from "./pages/SchedulesHubPage.js";
 import { SettingsAppearanceTab } from "./pages/settings/SettingsAppearanceTab.js";
 import { SettingsAboutTab } from "./pages/settings/SettingsAboutTab.js";
 import { SettingsShortcutsTab } from "./pages/settings/SettingsShortcutsTab.js";
@@ -92,6 +98,9 @@ import {
   WithEnvironmentSidebar,
   WithSettingsSidebar,
   WithKnowledgeSidebar,
+  WithPersonaSidebar,
+  WithScheduleSidebar,
+  WithCoordinationSidebar,
 } from "./components/layout/WithSidebar.js";
 import { SetupWizard } from "./pages/SetupWizard.js";
 import styles from "./App.module.scss";
@@ -516,8 +525,10 @@ function AppRoutes(): JSX.Element {
         {/* Legacy per-stream chat URLs now live on Coordination */}
         <Route path="chat/:streamId" element={<Navigate to="/coordination" replace />} />
 
-        {/* Coordination: read-only IPC stream inventory (no sidebar) */}
-        <Route path="coordination" element={<CoordinationPage />} />
+        {/* Coordination: IPC stream inventory (list in sidebar, graph in main) */}
+        <Route element={<WithCoordinationSidebar />}>
+          <Route path="coordination" element={<CoordinationPage />} />
+        </Route>
 
         <Route
           path="sessions"
@@ -553,10 +564,14 @@ function AppRoutes(): JSX.Element {
               <Route path="tasks/:taskId/edit" element={<TaskPage />} />
               <Route path="tasks/:taskId/stream" element={<TaskPage />} />
             </Route>
-            {/* Persona Library — top-level surface (no sidebar), like /chat and /coordination */}
-            <Route path="personas" element={<PersonaLibraryPage />} />
-            <Route path="personas/new" element={<PersonaDetailPage />} />
-            <Route path="personas/:personaId" element={<PersonaDetailPage />} />
+            {/* Persona Library — sidebar nav + detail in main area */}
+            <Route element={<WithPersonaSidebar />}>
+              <Route path="personas" element={<PersonasHubPage />}>
+                <Route index element={<PersonasEmptyPage />} />
+                <Route path="new" element={<PersonaDetailPage />} />
+                <Route path=":personaId" element={<PersonaDetailPage />} />
+              </Route>
+            </Route>
             {/* Agent create form (no tabs, standalone) */}
             <Route path="agents/new" element={<AgentCreatePage />} />
             {/* Agent detail — nested layout with tabs (#1419) */}
@@ -569,14 +584,15 @@ function AppRoutes(): JSX.Element {
           </>
         )}
 
-        {/* Schedules — top-level surface (no sidebar), relocated out of Settings (#1416).
-            A holding home at the fleet altitude until per-agent ownership (#1418). */}
+        {/* Schedules — sidebar nav + detail in main area (#1416) */}
         {hasScheduling && (
-          <>
-            <Route path="schedules" element={<SchedulesPage />} />
-            <Route path="schedules/new" element={<ScheduleDetailPage />} />
-            <Route path="schedules/:scheduleId" element={<ScheduleDetailPage />} />
-          </>
+          <Route element={<WithScheduleSidebar />}>
+            <Route path="schedules" element={<SchedulesHubPage />}>
+              <Route index element={<SchedulesEmptyPage />} />
+              <Route path="new" element={<ScheduleDetailPage />} />
+              <Route path=":scheduleId" element={<ScheduleDetailPage />} />
+            </Route>
+          </Route>
         )}
 
         {/* Environments sidebar */}

--- a/packages/web/src/components/layout/WithSidebar.tsx
+++ b/packages/web/src/components/layout/WithSidebar.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useMemo, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { Outlet } from "react-router";
 import { useGrackle } from "../../context/GrackleContext.js";
 import { useSidebarSlot } from "../../hooks/useSidebarSlot.js";
-import { TaskList, EnvironmentNav, SettingsNav, KnowledgeNav } from "@grackle-ai/web-components";
+import {
+  TaskList,
+  EnvironmentNav,
+  SettingsNav,
+  KnowledgeNav,
+  PersonaNav,
+  ScheduleNav,
+  CoordinationList,
+  useThemeContext,
+} from "@grackle-ai/web-components";
+import type { StreamData, StreamMessageData } from "@grackle-ai/web-components";
 
 /** Layout route wrapper that shows the TaskList in the sidebar. */
 export function WithTaskSidebar(): JSX.Element {
@@ -91,4 +101,154 @@ export function WithKnowledgeSidebar(): JSX.Element {
   );
   useSidebarSlot(sidebar);
   return <Outlet />;
+}
+
+/** Layout route wrapper that shows the PersonaNav in the sidebar. */
+export function WithPersonaSidebar(): JSX.Element {
+  const {
+    personas: { personas },
+    appDefaultPersonaId,
+  } = useGrackle();
+  const sidebar = useMemo(
+    () => <PersonaNav personas={personas} appDefaultPersonaId={appDefaultPersonaId} />,
+    [personas, appDefaultPersonaId],
+  );
+  useSidebarSlot(sidebar);
+  return <Outlet />;
+}
+
+/** Layout route wrapper that shows the ScheduleNav in the sidebar. */
+export function WithScheduleSidebar(): JSX.Element {
+  const {
+    schedules: { schedules },
+    personas: { personas },
+  } = useGrackle();
+  const sidebar = useMemo(
+    () => <ScheduleNav schedules={schedules} personas={personas} />,
+    [schedules, personas],
+  );
+  useSidebarSlot(sidebar);
+  return <Outlet />;
+}
+
+/** Context passed to CoordinationPage via outlet context. */
+export interface CoordinationOutletContext {
+  /** Currently selected stream, if any. */
+  selectedStream: StreamData | undefined;
+  /** Currently selected stream ID. */
+  selectedStreamId: string | undefined;
+  /** Set the selected stream ID. */
+  setSelectedStreamId: (id: string | undefined) => void;
+  /** Whether a transcript is currently loading. */
+  transcriptLoading: boolean;
+  /** Live messages keyed by stream ID. */
+  liveMessages: Record<string, StreamMessageData[]>;
+  /** Resolved theme ID for graph rendering. */
+  resolvedThemeId: string;
+}
+
+/** Layout route wrapper that shows the CoordinationList in the sidebar. */
+export function WithCoordinationSidebar(): JSX.Element {
+  const {
+    streams: {
+      streams,
+      streamsLoading,
+      streamsLoadedOnce,
+      streamsLoadError,
+      loadStreams,
+      liveMessages,
+      loadTranscript,
+    },
+    sessions: { sessions },
+    tasks: { tasks },
+  } = useGrackle();
+
+  const [showInternals, setShowInternals] = useState(false);
+  const [selectedStreamId, setSelectedStreamId] = useState<string | undefined>(undefined);
+  const [transcriptLoading, setTranscriptLoading] = useState(false);
+
+  useEffect(() => {
+    if (selectedStreamId === undefined) {
+      setTranscriptLoading(false);
+      return;
+    }
+    let active = true;
+    setTranscriptLoading(true);
+    loadTranscript(selectedStreamId)
+      .then(() => {
+        if (active) {
+          setTranscriptLoading(false);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setTranscriptLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedStreamId, loadTranscript]);
+
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    loadStreams(showInternals).catch(() => {});
+  }, [showInternals, loadStreams]);
+
+  const handleRefresh = useCallback(() => {
+    loadStreams(showInternals).catch(() => {});
+  }, [loadStreams, showInternals]);
+
+  const selectedStream =
+    selectedStreamId !== undefined ? streams.find((s) => s.id === selectedStreamId) : undefined;
+
+  const sidebar = useMemo(
+    () => (
+      <CoordinationList
+        streams={streams}
+        sessions={sessions}
+        tasks={tasks}
+        loading={streamsLoading}
+        loadError={streamsLoadError}
+        loadedOnce={streamsLoadedOnce}
+        showInternals={showInternals}
+        onToggleInternals={setShowInternals}
+        selectedStreamId={selectedStreamId}
+        onSelectStream={setSelectedStreamId}
+        onRefresh={handleRefresh}
+      />
+    ),
+    [
+      streams,
+      sessions,
+      tasks,
+      streamsLoading,
+      streamsLoadError,
+      streamsLoadedOnce,
+      showInternals,
+      selectedStreamId,
+      handleRefresh,
+    ],
+  );
+  useSidebarSlot(sidebar);
+
+  const { resolvedThemeId } = useThemeContext();
+
+  const outletContext = useMemo<CoordinationOutletContext>(
+    () => ({
+      selectedStream,
+      selectedStreamId,
+      setSelectedStreamId,
+      transcriptLoading,
+      liveMessages,
+      resolvedThemeId,
+    }),
+    [selectedStream, selectedStreamId, transcriptLoading, liveMessages, resolvedThemeId],
+  );
+
+  return <Outlet context={outletContext} />;
 }

--- a/packages/web/src/components/layout/WithSidebar.tsx
+++ b/packages/web/src/components/layout/WithSidebar.tsx
@@ -12,7 +12,7 @@ import {
   CoordinationList,
   useThemeContext,
 } from "@grackle-ai/web-components";
-import type { StreamData, StreamMessageData } from "@grackle-ai/web-components";
+import type { StreamData } from "@grackle-ai/web-components";
 
 /** Layout route wrapper that shows the TaskList in the sidebar. */
 export function WithTaskSidebar(): JSX.Element {
@@ -141,8 +141,6 @@ export interface CoordinationOutletContext {
   setSelectedStreamId: (id: string | undefined) => void;
   /** Whether a transcript is currently loading. */
   transcriptLoading: boolean;
-  /** Live messages keyed by stream ID. */
-  liveMessages: Record<string, StreamMessageData[]>;
   /** Resolved theme ID for graph rendering. */
   resolvedThemeId: string;
 }
@@ -156,7 +154,6 @@ export function WithCoordinationSidebar(): JSX.Element {
       streamsLoadedOnce,
       streamsLoadError,
       loadStreams,
-      liveMessages,
       loadTranscript,
     },
     sessions: { sessions },
@@ -244,10 +241,9 @@ export function WithCoordinationSidebar(): JSX.Element {
       selectedStreamId,
       setSelectedStreamId,
       transcriptLoading,
-      liveMessages,
       resolvedThemeId,
     }),
-    [selectedStream, selectedStreamId, transcriptLoading, liveMessages, resolvedThemeId],
+    [selectedStream, selectedStreamId, transcriptLoading, resolvedThemeId],
   );
 
   return <Outlet context={outletContext} />;

--- a/packages/web/src/pages/AgentCreatePage.tsx
+++ b/packages/web/src/pages/AgentCreatePage.tsx
@@ -6,7 +6,15 @@
  */
 
 import { useGrackle } from "../context/GrackleContext.js";
-import { AgentManager, agentUrl, useAppNavigate, useToast } from "@grackle-ai/web-components";
+import {
+  AgentManager,
+  PageHeader,
+  buildAgentCreateBreadcrumbs,
+  agentUrl,
+  HOME_URL,
+  useAppNavigate,
+  useToast,
+} from "@grackle-ai/web-components";
 import type { JSX } from "react";
 
 export function AgentCreatePage(): JSX.Element {
@@ -35,14 +43,17 @@ export function AgentCreatePage(): JSX.Element {
   };
 
   return (
-    <AgentManager
-      agents={agents}
-      personas={personas}
-      environments={environments}
-      agentsLoading={agentsLoading}
-      onCreate={handleCreate}
-      onDelete={() => {}}
-      onNavigateBack={() => navigate("/")}
-    />
+    <>
+      <PageHeader segments={buildAgentCreateBreadcrumbs()} backUrl={HOME_URL} />
+      <AgentManager
+        agents={agents}
+        personas={personas}
+        environments={environments}
+        agentsLoading={agentsLoading}
+        onCreate={handleCreate}
+        onDelete={() => {}}
+        onNavigateBack={() => navigate("/")}
+      />
+    </>
   );
 }

--- a/packages/web/src/pages/AgentCreatePage.tsx
+++ b/packages/web/src/pages/AgentCreatePage.tsx
@@ -52,7 +52,7 @@ export function AgentCreatePage(): JSX.Element {
         agentsLoading={agentsLoading}
         onCreate={handleCreate}
         onDelete={() => {}}
-        onNavigateBack={() => navigate("/")}
+        onNavigateBack={() => navigate(HOME_URL)}
       />
     </>
   );

--- a/packages/web/src/pages/AgentLayout.tsx
+++ b/packages/web/src/pages/AgentLayout.tsx
@@ -11,6 +11,8 @@ import { useGrackle } from "../context/GrackleContext.js";
 import {
   AgentHeader,
   AgentTabBar,
+  PageHeader,
+  buildAgentBreadcrumbs,
   useAppNavigate,
   type AgentTab,
   type AgentData,
@@ -72,6 +74,7 @@ export function AgentLayout(): JSX.Element {
 
   return (
     <div className={styles.container} data-testid="agent-layout">
+      <PageHeader segments={buildAgentBreadcrumbs(agent.name)} />
       <AgentHeader
         name={agent.name}
         avatar={agent.avatar}

--- a/packages/web/src/pages/CoordinationPage.module.scss
+++ b/packages/web/src/pages/CoordinationPage.module.scss
@@ -1,5 +1,5 @@
 // =============================================================================
-// CoordinationPage — IPC stream inventory layout
+// CoordinationPage — graph-only main content area (list is in the sidebar)
 // =============================================================================
 
 .container {
@@ -8,69 +8,4 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-}
-
-// Toolbar: List/Graph toggle + shared stream controls (apply to both views)
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border-subtle);
-  flex-shrink: 0;
-}
-
-.viewToggle {
-  display: flex;
-  gap: var(--space-xs);
-}
-
-.toolbarControls {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-}
-
-.internalsToggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
-.refreshButton {
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-  background: var(--bg-inset);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  padding: var(--space-xs) var(--space-md);
-  cursor: pointer;
-}
-
-.refreshButton:hover {
-  color: var(--text-primary);
-}
-
-.toggleButton {
-  padding: var(--space-xs) var(--space-md);
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-  background: var(--bg-inset);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-}
-
-.toggleButton:hover {
-  color: var(--text-primary);
-}
-
-.toggleActive {
-  color: var(--text-primary);
-  background: var(--bg-elevated);
-  border-color: var(--accent-blue);
 }

--- a/packages/web/src/pages/CoordinationPage.tsx
+++ b/packages/web/src/pages/CoordinationPage.tsx
@@ -1,166 +1,39 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import type { JSX } from "react";
+import { useOutletContext } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
-import {
-  CoordinationGraph,
-  CoordinationList,
-  StreamDetailPanel,
-  useThemeContext,
-} from "@grackle-ai/web-components";
+import { CoordinationGraph, StreamDetailPanel } from "@grackle-ai/web-components";
+import type { CoordinationOutletContext } from "../components/layout/WithSidebar.js";
 import styles from "./CoordinationPage.module.scss";
 
 /**
- * Coordination page — a read-only inventory of IPC streams, grouped by the task
- * that owns them. Internal plumbing (lifecycle/pipe/stdin) is hidden behind a
- * "Show internals" toggle. Selecting a stream opens its detail drawer. A
- * List/Graph toggle switches between the inventory and a live network graph.
+ * Coordination page — always shows the live network graph in the main content
+ * area. The stream list lives in the sidebar (via WithCoordinationSidebar).
+ * Selecting a stream in either the list or graph opens the detail drawer.
  */
 export function CoordinationPage(): JSX.Element {
   const {
-    streams: {
-      streams,
-      streamsLoading,
-      streamsLoadedOnce,
-      streamsLoadError,
-      loadStreams,
-      liveMessages,
-      loadTranscript,
-    },
+    streams: { streams, liveMessages },
     sessions: { sessions },
-    tasks: { tasks },
   } = useGrackle();
-  const { resolvedThemeId } = useThemeContext();
 
-  const [viewMode, setViewMode] = useState<"list" | "graph">("list");
-  const [showInternals, setShowInternals] = useState(false);
-  const [selectedStreamId, setSelectedStreamId] = useState<string | undefined>(undefined);
-  const [transcriptLoading, setTranscriptLoading] = useState(false);
-
-  // Fetch the durable transcript (scrollback) when a stream is selected; live
-  // messages merge into the same buffer via the streams hook.
-  useEffect(() => {
-    if (selectedStreamId === undefined) {
-      setTranscriptLoading(false);
-      return;
-    }
-    let active = true;
-    setTranscriptLoading(true);
-    loadTranscript(selectedStreamId)
-      .then(() => {
-        if (active) {
-          setTranscriptLoading(false);
-        }
-      })
-      .catch(() => {
-        if (active) {
-          setTranscriptLoading(false);
-        }
-      });
-    return () => {
-      active = false;
-    };
-  }, [selectedStreamId, loadTranscript]);
-
-  // Re-fetch when the internals toggle changes. The initial (default-false)
-  // load is already performed by the streams domain hook's onConnect, so skip
-  // the mount run to avoid a duplicate ListStreams RPC.
-  const didMountRef = useRef(false);
-  useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      return;
-    }
-    loadStreams(showInternals).catch(() => {});
-  }, [showInternals, loadStreams]);
-
-  const handleRefresh = useCallback(() => {
-    loadStreams(showInternals).catch(() => {});
-  }, [loadStreams, showInternals]);
-
-  const selectedStream =
-    selectedStreamId !== undefined ? streams.find((s) => s.id === selectedStreamId) : undefined;
+  const {
+    selectedStream,
+    selectedStreamId,
+    setSelectedStreamId,
+    transcriptLoading,
+    resolvedThemeId,
+  } = useOutletContext<CoordinationOutletContext>();
 
   return (
     <div className={styles.container} data-testid="coordination-page">
-      <div className={styles.toolbar}>
-        <div
-          className={styles.viewToggle}
-          role="group"
-          aria-label="Coordination view"
-          data-testid="coordination-view-toggle"
-        >
-          <button
-            type="button"
-            className={
-              viewMode === "list"
-                ? `${styles.toggleButton} ${styles.toggleActive}`
-                : styles.toggleButton
-            }
-            aria-pressed={viewMode === "list"}
-            data-testid="coordination-view-list"
-            onClick={() => setViewMode("list")}
-          >
-            List
-          </button>
-          <button
-            type="button"
-            className={
-              viewMode === "graph"
-                ? `${styles.toggleButton} ${styles.toggleActive}`
-                : styles.toggleButton
-            }
-            aria-pressed={viewMode === "graph"}
-            data-testid="coordination-view-graph"
-            onClick={() => setViewMode("graph")}
-          >
-            Graph
-          </button>
-        </div>
-        <div className={styles.toolbarControls}>
-          <label className={styles.internalsToggle}>
-            <input
-              type="checkbox"
-              checked={showInternals}
-              onChange={(e) => setShowInternals(e.target.checked)}
-              data-testid="coordination-show-internals"
-            />
-            Show internals
-          </label>
-          <button
-            type="button"
-            className={styles.refreshButton}
-            onClick={handleRefresh}
-            aria-label="Refresh streams"
-            data-testid="coordination-refresh"
-          >
-            Refresh
-          </button>
-        </div>
-      </div>
-      {viewMode === "list" ? (
-        <CoordinationList
-          streams={streams}
-          sessions={sessions}
-          tasks={tasks}
-          loading={streamsLoading}
-          loadError={streamsLoadError}
-          loadedOnce={streamsLoadedOnce}
-          showInternals={showInternals}
-          onToggleInternals={setShowInternals}
-          selectedStreamId={selectedStreamId}
-          onSelectStream={setSelectedStreamId}
-          onRefresh={handleRefresh}
-          hideHeaderControls
-        />
-      ) : (
-        <CoordinationGraph
-          streams={streams}
-          sessions={sessions}
-          selectedStreamId={selectedStreamId}
-          onSelectStream={setSelectedStreamId}
-          recentMessages={liveMessages}
-          resolvedThemeId={resolvedThemeId}
-        />
-      )}
+      <CoordinationGraph
+        streams={streams}
+        sessions={sessions}
+        selectedStreamId={selectedStreamId}
+        onSelectStream={setSelectedStreamId}
+        recentMessages={liveMessages}
+        resolvedThemeId={resolvedThemeId}
+      />
       {selectedStream && (
         <StreamDetailPanel
           stream={selectedStream}

--- a/packages/web/src/pages/EmptyPage.tsx
+++ b/packages/web/src/pages/EmptyPage.tsx
@@ -18,6 +18,24 @@ export function EnvironmentsEmptyPage(): JSX.Element {
   );
 }
 
+/** Empty page shown at /personas when no persona is selected. */
+export function PersonasEmptyPage(): JSX.Element {
+  return (
+    <div className={styles.emptyState}>
+      Select a persona to view or edit it, or create a new one.
+    </div>
+  );
+}
+
+/** Empty page shown at /schedules when no schedule is selected. */
+export function SchedulesEmptyPage(): JSX.Element {
+  return (
+    <div className={styles.emptyState}>
+      Select a schedule to view or edit it, or create a new one.
+    </div>
+  );
+}
+
 /** Home page — shows the operations dashboard when workspaces exist, or the welcome CTA for first-time users. */
 export function EmptyPage(): JSX.Element {
   const {

--- a/packages/web/src/pages/EnvironmentsPage.tsx
+++ b/packages/web/src/pages/EnvironmentsPage.tsx
@@ -1,6 +1,6 @@
 import { type JSX } from "react";
 import { Outlet } from "react-router";
-import { Breadcrumbs, buildEnvironmentsBreadcrumbs } from "@grackle-ai/web-components";
+import { PageHeader, buildEnvironmentsBreadcrumbs, HOME_URL } from "@grackle-ai/web-components";
 import styles from "./SettingsPage.module.scss";
 
 /** Environments hub page with breadcrumbs and routed content area. */
@@ -9,7 +9,7 @@ export function EnvironmentsPage(): JSX.Element {
 
   return (
     <div className={styles.layout}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} backUrl={HOME_URL} />
       <div className={styles.content}>
         <Outlet />
       </div>

--- a/packages/web/src/pages/KnowledgePage.test.tsx
+++ b/packages/web/src/pages/KnowledgePage.test.tsx
@@ -21,7 +21,9 @@ vi.mock("../context/GrackleContext.js", () => ({
 
 vi.mock("@grackle-ai/web-components", () => ({
   KNOWLEDGE_URL: "/knowledge",
-  Breadcrumbs: () => null,
+  HOME_URL: "/",
+  buildHomeBreadcrumbs: () => [{ label: "Home", url: undefined }],
+  PageHeader: () => null,
   KnowledgeGraph: () => null,
   KnowledgeDetailPanel: () => null,
 }));

--- a/packages/web/src/pages/KnowledgePage.tsx
+++ b/packages/web/src/pages/KnowledgePage.tsx
@@ -9,10 +9,11 @@
 
 import { useCallback, useEffect, type JSX } from "react";
 import {
-  Breadcrumbs,
+  HOME_URL,
   KNOWLEDGE_URL,
   KnowledgeDetailPanel,
   KnowledgeGraph,
+  PageHeader,
 } from "@grackle-ai/web-components";
 import { useGrackle } from "../context/GrackleContext.js";
 import styles from "./KnowledgePage.module.scss";
@@ -67,7 +68,7 @@ export function KnowledgePage(): JSX.Element {
 
   return (
     <div className={styles.layout} data-testid="knowledge-page">
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} backUrl={HOME_URL} />
 
       <div className={styles.graphArea}>
         {showError ? (

--- a/packages/web/src/pages/NewChatPage.tsx
+++ b/packages/web/src/pages/NewChatPage.tsx
@@ -2,8 +2,8 @@ import { type JSX } from "react";
 import { useSearchParams } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
-  Breadcrumbs,
   ChatInput,
+  PageHeader,
   buildNewChatBreadcrumbs,
   useToast,
 } from "@grackle-ai/web-components";
@@ -24,7 +24,7 @@ export function NewChatPage(): JSX.Element {
 
   return (
     <div className={styles.panelContainer}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} />
       <div className={styles.emptyState}>Enter a prompt below to start a new session</div>
       <ChatInput
         mode="spawn"

--- a/packages/web/src/pages/PersonaDetail.module.scss
+++ b/packages/web/src/pages/PersonaDetail.module.scss
@@ -11,7 +11,6 @@
 }
 
 .form {
-  @include surface-card;
   padding: var(--space-lg);
   margin-bottom: var(--space-lg);
 

--- a/packages/web/src/pages/PersonaDetailPage.tsx
+++ b/packages/web/src/pages/PersonaDetailPage.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect, type JSX, type FormEvent } from "react";
 import { useParams, Navigate } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
-  Breadcrumbs,
-  buildPersonaDetailBreadcrumbs,
   Button,
   ConfirmDialog,
   EditableSelect,
@@ -54,13 +52,8 @@ export function PersonaDetailPage(): JSX.Element {
     return <Navigate to={PERSONAS_URL} replace />;
   }
 
-  const breadcrumbs = buildPersonaDetailBreadcrumbs(
-    isNew ? "New Persona" : (existing?.name ?? "Persona"),
-  );
-
   return (
     <div className={styles.container}>
-      <Breadcrumbs segments={breadcrumbs} />
       <PersonaForm
         existing={existing}
         isNew={isNew}

--- a/packages/web/src/pages/PersonasHubPage.tsx
+++ b/packages/web/src/pages/PersonasHubPage.tsx
@@ -1,0 +1,15 @@
+import { type JSX } from "react";
+import { Outlet } from "react-router";
+import { PageHeader, buildPersonaLibraryBreadcrumbs, HOME_URL } from "@grackle-ai/web-components";
+
+/** Personas hub page with breadcrumbs, back-navigation, and routed content area. */
+export function PersonasHubPage(): JSX.Element {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      <PageHeader segments={buildPersonaLibraryBreadcrumbs()} backUrl={HOME_URL} />
+      <div style={{ flex: 1, overflow: "auto" }}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/ScheduleDetailPage.tsx
+++ b/packages/web/src/pages/ScheduleDetailPage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, type JSX, type FormEvent } from "react";
 import { useParams, Navigate } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
-  Breadcrumbs,
   Button,
   ConfirmDialog,
   EditableSelect,
@@ -14,12 +13,7 @@ import {
   formatRelativeTime,
   formatCountdown,
 } from "@grackle-ai/web-components";
-import type {
-  BreadcrumbSegment,
-  ScheduleData,
-  ScheduleUpdate,
-  SelectOption,
-} from "@grackle-ai/web-components";
+import type { ScheduleData, ScheduleUpdate, SelectOption } from "@grackle-ai/web-components";
 import styles from "./ScheduleDetail.module.scss";
 
 /** ScheduleDetailPage handles both create (/schedules/new) and edit (/schedules/:scheduleId). */
@@ -43,14 +37,8 @@ export function ScheduleDetailPage(): JSX.Element {
     return <Navigate to={SCHEDULES_URL} replace />;
   }
 
-  const breadcrumbs: BreadcrumbSegment[] = [
-    { label: "Schedules", url: SCHEDULES_URL },
-    { label: isNew ? "New Schedule" : (existing?.title ?? "Schedule"), url: undefined },
-  ];
-
   return (
     <div className={styles.container}>
-      <Breadcrumbs segments={breadcrumbs} />
       <ScheduleForm
         existing={existing}
         isNew={isNew}

--- a/packages/web/src/pages/SchedulesHubPage.tsx
+++ b/packages/web/src/pages/SchedulesHubPage.tsx
@@ -1,0 +1,15 @@
+import { type JSX } from "react";
+import { Outlet } from "react-router";
+import { PageHeader, buildSchedulesBreadcrumbs, HOME_URL } from "@grackle-ai/web-components";
+
+/** Schedules hub page with breadcrumbs, back-navigation, and routed content area. */
+export function SchedulesHubPage(): JSX.Element {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      <PageHeader segments={buildSchedulesBreadcrumbs()} backUrl={HOME_URL} />
+      <div style={{ flex: 1, overflow: "auto" }}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/SessionPage.tsx
+++ b/packages/web/src/pages/SessionPage.tsx
@@ -3,9 +3,9 @@ import { useParams, Link } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import { useSandboxProxyUrl } from "../context/ManifestContext.js";
 import {
-  Breadcrumbs,
   ChatInput,
   EventStream,
+  PageHeader,
   SplitButton,
   buildSessionBreadcrumbs,
   formatCost,
@@ -145,7 +145,7 @@ export function SessionPage(): JSX.Element {
 
   return (
     <div className={styles.panelContainer}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} />
       <SessionHeader
         sessionId={sessionId!}
         session={session}

--- a/packages/web/src/pages/SessionsListPage.tsx
+++ b/packages/web/src/pages/SessionsListPage.tsx
@@ -10,6 +10,8 @@
 import { useMemo, type JSX } from "react";
 import {
   SessionsTable,
+  PageHeader,
+  buildSessionsListBreadcrumbs,
   isActiveSession,
   sessionUrl,
   taskUrl,
@@ -49,6 +51,7 @@ export function SessionsListPage(): JSX.Element {
 
   return (
     <div className={styles.page} data-testid="sessions-page">
+      <PageHeader segments={buildSessionsListBreadcrumbs()} />
       <header className={styles.header}>
         <h1 className={styles.title}>Sessions</h1>
         <p className={styles.subtitle} data-testid="sessions-summary">

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { type JSX } from "react";
 import { Outlet, useLocation } from "react-router";
-import { Breadcrumbs, buildSettingsBreadcrumbs } from "@grackle-ai/web-components";
+import { PageHeader, buildSettingsBreadcrumbs } from "@grackle-ai/web-components";
 import styles from "./SettingsPage.module.scss";
 
 /** Maps settings URL path segments to display labels. */
@@ -22,7 +22,7 @@ export function SettingsPage(): JSX.Element {
 
   return (
     <div className={styles.layout}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} />
       <div className={styles.content}>
         <div key={tabSegment} className={styles.tabPanel}>
           <Outlet />

--- a/packages/web/src/pages/TaskPage.tsx
+++ b/packages/web/src/pages/TaskPage.tsx
@@ -4,12 +4,12 @@ import { ConnectError } from "@connectrpc/connect";
 import { useGrackle } from "../context/GrackleContext.js";
 import { useSandboxProxyUrl } from "../context/ManifestContext.js";
 import {
-  Breadcrumbs,
   ChatInput,
   ConfirmDialog,
   EventStream,
   SessionAttemptSelector,
   TaskActionButtons,
+  PageHeader,
   TaskEditPanel,
   TaskOverviewPanel,
   buildTaskBreadcrumbs,
@@ -272,7 +272,7 @@ export function TaskPage(): JSX.Element {
 
   return (
     <div className={styles.panelContainer}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} />
       {/* Task header */}
       <div className={styles.header}>
         <span className={styles.headerTitle}>

--- a/packages/web/src/pages/WorkspaceCreatePage.tsx
+++ b/packages/web/src/pages/WorkspaceCreatePage.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState, type JSX } from "react";
 import { useSearchParams } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
-  Breadcrumbs,
   HOME_URL,
   Spinner,
   WorkspaceFormFields,
   defaultFormValues,
+  PageHeader,
   environmentUrl,
   useAppNavigate,
   useToast,
@@ -114,7 +114,7 @@ export function WorkspaceCreatePage(): JSX.Element {
       {/* Header */}
       <div className={styles.header}>
         <div className={styles.headerTitle}>
-          <Breadcrumbs segments={breadcrumbs} />
+          <PageHeader segments={breadcrumbs} />
         </div>
         <div className={styles.headerActions}>
           <button

--- a/packages/web/src/pages/WorkspaceCreatePage.tsx
+++ b/packages/web/src/pages/WorkspaceCreatePage.tsx
@@ -112,29 +112,29 @@ export function WorkspaceCreatePage(): JSX.Element {
   return (
     <div className={styles.container}>
       {/* Header */}
-      <div className={styles.header}>
-        <div className={styles.headerTitle}>
-          <PageHeader segments={breadcrumbs} />
-        </div>
-        <div className={styles.headerActions}>
-          <button
-            className={styles.btnGhost}
-            onClick={handleCancel}
-            disabled={workspaceCreating}
-            data-testid="workspace-create-cancel"
-          >
-            Cancel
-          </button>
-          <button
-            className={styles.btnPrimary}
-            onClick={handleSave}
-            disabled={workspaceCreating || !values.name.trim() || !values.environmentId}
-            data-testid="workspace-create-save"
-          >
-            {workspaceCreating ? <Spinner size="sm" label="Creating" /> : "Create Workspace"}
-          </button>
-        </div>
-      </div>
+      <PageHeader
+        segments={breadcrumbs}
+        actions={
+          <>
+            <button
+              className={styles.btnGhost}
+              onClick={handleCancel}
+              disabled={workspaceCreating}
+              data-testid="workspace-create-cancel"
+            >
+              Cancel
+            </button>
+            <button
+              className={styles.btnPrimary}
+              onClick={handleSave}
+              disabled={workspaceCreating || !values.name.trim() || !values.environmentId}
+              data-testid="workspace-create-save"
+            >
+              {workspaceCreating ? <Spinner size="sm" label="Creating" /> : "Create Workspace"}
+            </button>
+          </>
+        }
+      />
 
       {/* Form body */}
       <div className={styles.body}>

--- a/packages/web/src/pages/WorkspacePage.tsx
+++ b/packages/web/src/pages/WorkspacePage.tsx
@@ -2,13 +2,13 @@ import { useEffect, useRef, useState, type JSX } from "react";
 import { useParams } from "react-router";
 import { useGrackle } from "../context/GrackleContext.js";
 import {
-  Breadcrumbs,
   ConfirmDialog,
   DagView,
   EditableCheckbox,
   EditableSelect,
   EditableTextArea,
   EditableTextField,
+  PageHeader,
   WorkspaceBoard,
   buildWorkspaceBreadcrumbs,
   formatCost,
@@ -139,7 +139,7 @@ export function WorkspacePage(): JSX.Element {
 
   return (
     <div className={styles.panelContainer}>
-      <Breadcrumbs segments={breadcrumbs} />
+      <PageHeader segments={breadcrumbs} />
 
       {/* Workspace header */}
       <div className={styles.workspaceHeader}>

--- a/tests/e2e-tests/tests/coordination.spec.ts
+++ b/tests/e2e-tests/tests/coordination.spec.ts
@@ -23,29 +23,23 @@ test.describe("Coordination tab", { tag: ["@session"] }, () => {
     await expect(toggle).not.toBeChecked();
   });
 
-  test("List/Graph toggle switches the Coordination view", async ({ appPage }) => {
+  test("Sidebar list and main graph are both visible simultaneously", async ({ appPage }) => {
     const page = appPage;
 
-    await page.getByTestId("sidebar-tab-coordination").click();
+    const coordTab = page.getByTestId("context-nav").getByTestId("sidebar-tab-coordination");
+    await coordTab.click();
     await expect(page.getByTestId("coordination-page")).toBeVisible();
 
-    // Defaults to the list view.
+    // The stream list lives in the sidebar — always visible alongside the page.
     await expect(page.getByTestId("coordination-list")).toBeVisible();
-    await expect(page.getByTestId("coordination-view-graph")).toBeVisible();
 
-    // Switching to Graph hides the list and shows the graph (or its empty state).
-    await page.getByTestId("coordination-view-graph").click();
-    await expect(page.getByTestId("coordination-list")).toHaveCount(0);
+    // The graph (or its empty state) is always in the main content area.
     await expect(
       page.getByTestId("coordination-graph").or(page.getByTestId("coordination-graph-empty")),
     ).toBeVisible();
 
-    // Stream controls are page-level, so they remain available in Graph mode.
+    // Stream controls remain accessible in the sidebar list header.
     await expect(page.getByTestId("coordination-show-internals")).toBeVisible();
-
-    // Switching back restores the list.
-    await page.getByTestId("coordination-view-list").click();
-    await expect(page.getByTestId("coordination-list")).toBeVisible();
   });
 
   test("Root has no stream inventory (that lives on Coordination)", async ({ appPage }) => {

--- a/tests/e2e-tests/tests/persona-library.spec.ts
+++ b/tests/e2e-tests/tests/persona-library.spec.ts
@@ -21,8 +21,8 @@ test.describe(
         "page",
         { timeout: 5_000 },
       );
-      // The PersonaManager renders an h2 with the page title.
-      await expect(page.getByRole("heading", { name: "Personas" })).toBeVisible({ timeout: 5_000 });
+      // The PersonaNav sidebar renders the persona navigation rail.
+      await expect(page.getByTestId("persona-nav")).toBeVisible({ timeout: 5_000 });
     });
 
     test("legacy /settings/personas redirects to /personas", async ({ appPage }) => {

--- a/tests/e2e-tests/tests/persona.spec.ts
+++ b/tests/e2e-tests/tests/persona.spec.ts
@@ -23,12 +23,12 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
     // Navigate to persona management view via the personas button in status bar
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
 
-    // Verify the persona management view is shown with our persona
-    await expect(page.getByRole("heading", { name: "Personas" })).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("Security Reviewer")).toBeVisible({
+    // Verify the persona nav sidebar is shown with our persona
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
+    await expect(nav.getByText("Security Reviewer")).toBeVisible({
       timeout: 5_000,
     });
-    await expect(page.getByText("Reviews code for vulnerabilities")).toBeVisible();
   });
 
   test("created persona appears in management view with all details", async ({
@@ -47,11 +47,11 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
 
     // Navigate to persona management view
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await expect(page.getByRole("heading", { name: "Personas" })).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("Detailed Persona")).toBeVisible({
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
+    await expect(nav.getByText("Detailed Persona")).toBeVisible({
       timeout: 5_000,
     });
-    await expect(page.getByText("A persona with full details")).toBeVisible();
   });
 
   test("delete persona removes it from management view", async ({
@@ -68,8 +68,9 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
 
     // Navigate to management view and verify it appears
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await expect(page.getByRole("heading", { name: "Personas" })).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("Soon Deleted")).toBeVisible({
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
+    await expect(nav.getByText("Soon Deleted")).toBeVisible({
       timeout: 5_000,
     });
 
@@ -81,7 +82,7 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
     await client.orchestration.deletePersona({ id: toDelete!.id });
 
     // The management view should no longer show the persona
-    await expect(page.getByText("Soon Deleted")).not.toBeVisible({
+    await expect(nav.getByText("Soon Deleted")).not.toBeVisible({
       timeout: 5_000,
     });
   });
@@ -102,10 +103,11 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
       allowedMcpTools: [...WORKER_MCP_TOOLS],
     });
 
-    // Navigate to the persona detail page
+    // Navigate to the persona detail page via sidebar nav
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await expect(page.getByText("Worker Agent")).toBeVisible({ timeout: 5_000 });
-    await page.getByTestId(`persona-card-${persona.id}`).click();
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav.getByText("Worker Agent")).toBeVisible({ timeout: 5_000 });
+    await nav.getByText("Worker Agent").click();
     await page.waitForURL(`**/personas/${persona.id}`, { timeout: 5_000 });
 
     // Verify the MCP tool selector is visible with the correct count
@@ -135,10 +137,11 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
       model: "sonnet",
     });
 
-    // Navigate to persona detail
+    // Navigate to persona detail via sidebar nav
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await expect(page.getByText("Unscoped Tester")).toBeVisible({ timeout: 5_000 });
-    await page.getByTestId(`persona-card-${persona.id}`).click();
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav.getByText("Unscoped Tester")).toBeVisible({ timeout: 5_000 });
+    await nav.getByText("Unscoped Tester").click();
     await page.waitForURL(`**/personas/${persona.id}`, { timeout: 5_000 });
 
     // Verify it shows "Using default" message
@@ -160,10 +163,11 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
       model: "sonnet",
     });
 
-    // Navigate to persona detail
+    // Navigate to persona detail via sidebar nav
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await expect(page.getByText("Preset Test Agent")).toBeVisible({ timeout: 5_000 });
-    await page.getByTestId(`persona-card-${persona.id}`).click();
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav.getByText("Preset Test Agent")).toBeVisible({ timeout: 5_000 });
+    await nav.getByText("Preset Test Agent").click();
     await page.waitForURL(`**/personas/${persona.id}`, { timeout: 5_000 });
 
     // Click "Worker" preset
@@ -201,7 +205,9 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
     const page = appPage;
 
     await page.locator('[data-testid="sidebar-tab-personas"]').click();
-    await page.getByTestId("persona-new-button").click();
+    const nav = page.getByTestId("persona-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId("persona-nav-add").click();
 
     await page.waitForURL("**/personas/new", { timeout: 5_000 });
     // Personas is a fleet-rail item (#1419), not an AppNav tab.
@@ -244,12 +250,12 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
 
     await page.getByTestId("persona-detail-cancel").click();
     await expect(page).toHaveURL(/\/personas$/, { timeout: 5_000 });
-    await expect(page.getByTestId(`persona-card-${createdPersona!.id}`)).toContainText(
-      "Route Created Persona",
-      { timeout: 5_000 },
-    );
+    await expect(nav.getByText("Route Created Persona")).toBeVisible({
+      timeout: 5_000,
+    });
 
-    await page.getByTestId(`persona-card-${createdPersona!.id}`).click();
+    // Click the persona in the sidebar nav to navigate to its detail page
+    await nav.getByText("Route Created Persona").click();
     await page.waitForURL(`**/personas/${createdPersona!.id}`, { timeout: 5_000 });
     // Personas is a fleet-rail item (#1419), not an AppNav tab.
     await expect(page.locator('[data-testid="sidebar-tab-personas"]')).toHaveAttribute(
@@ -285,12 +291,12 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
       .toBeDefined();
 
     await expect(page).toHaveURL(/\/personas$/, { timeout: 5_000 });
-    await expect(page.getByTestId(`persona-card-${updatedPersona!.id}`)).toContainText(
-      "Route Updated Persona",
-      { timeout: 5_000 },
-    );
+    await expect(nav.getByText("Route Updated Persona")).toBeVisible({
+      timeout: 5_000,
+    });
 
-    await page.getByTestId(`persona-card-${updatedPersona!.id}`).click();
+    // Click the updated persona in the sidebar nav to navigate to its detail page
+    await nav.getByText("Route Updated Persona").click();
     await page.waitForURL(`**/personas/${updatedPersona!.id}`, { timeout: 5_000 });
     await page.getByTestId("persona-detail-delete").click();
 
@@ -299,6 +305,6 @@ test.describe("Persona Management — UI", { tag: ["@persona"] }, () => {
     await dialog.getByRole("button", { name: "Delete" }).click();
 
     await expect(page).toHaveURL(/\/personas$/, { timeout: 5_000 });
-    await expect(page.getByTestId(`persona-card-${updatedPersona!.id}`)).toHaveCount(0);
+    await expect(nav.getByText("Route Updated Persona")).not.toBeVisible({ timeout: 5_000 });
   });
 });

--- a/tests/e2e-tests/tests/schedule.spec.ts
+++ b/tests/e2e-tests/tests/schedule.spec.ts
@@ -29,9 +29,9 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
 
     await page.locator('[data-testid="sidebar-tab-schedules"]').click();
 
-    await expect(page.getByRole("heading", { name: "Schedules" })).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("Nightly Review")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("0 21 * * *")).toBeVisible({ timeout: 5_000 });
+    const nav = page.getByTestId("schedule-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
+    await expect(nav.getByText("Nightly Review")).toBeVisible({ timeout: 5_000 });
   });
 
   test("empty state is shown when no schedules exist", async ({ appPage }) => {
@@ -39,7 +39,10 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
 
     await page.locator('[data-testid="sidebar-tab-schedules"]').click();
 
-    await expect(page.getByTestId("schedule-empty-state")).toBeVisible({ timeout: 5_000 });
+    // With sidebar nav, empty state text shows in the main content area
+    await expect(page.getByText("Select a schedule to view or edit it")).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("delete schedule removes it from management view", async ({
@@ -61,7 +64,8 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     });
 
     await page.locator('[data-testid="sidebar-tab-schedules"]').click();
-    await expect(page.getByText("Soon Deleted Schedule")).toBeVisible({ timeout: 5_000 });
+    const nav = page.getByTestId("schedule-nav");
+    await expect(nav.getByText("Soon Deleted Schedule")).toBeVisible({ timeout: 5_000 });
 
     // Delete via RPC
     const list = await client.scheduling.listSchedules({});
@@ -69,7 +73,7 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     expect(toDelete).toBeDefined();
     await client.scheduling.deleteSchedule({ id: toDelete!.id });
 
-    await expect(page.getByText("Soon Deleted Schedule")).not.toBeVisible({ timeout: 5_000 });
+    await expect(nav.getByText("Soon Deleted Schedule")).not.toBeVisible({ timeout: 5_000 });
   });
 
   test("create, edit, and delete schedule via UI", async ({ appPage, grackle: { client } }) => {
@@ -83,10 +87,11 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     });
 
     await page.locator('[data-testid="sidebar-tab-schedules"]').click();
-    await expect(page.getByRole("heading", { name: "Schedules" })).toBeVisible({ timeout: 5_000 });
+    const nav = page.getByTestId("schedule-nav");
+    await expect(nav).toBeVisible({ timeout: 5_000 });
 
-    // Open the create form
-    await page.getByTestId("schedule-new-button").click();
+    // Open the create form via sidebar button
+    await page.getByTestId("schedule-nav-add").click();
     await page.waitForURL("**/schedules/new", { timeout: 5_000 });
     // Schedules is a fleet surface (#1416): its entry lives in the context rail
     // (#1415) and marks the active route via aria-current rather than a tab's
@@ -125,10 +130,7 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     await page.getByTestId("schedule-detail-title-input").fill("UI Updated Schedule");
     await page.getByTestId("schedule-detail-title-input").press("Enter");
 
-    // Go back to list and verify updated title appears
-    await page.getByTestId("schedule-detail-cancel").click();
-    await expect(page).toHaveURL(/\/schedules$/, { timeout: 5_000 });
-
+    // Verify updated title appears in the sidebar nav
     let updatedSchedule: { id: string; title: string } | undefined;
     await expect
       .poll(
@@ -141,13 +143,10 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
       )
       .toBeDefined();
 
-    await expect(page.getByTestId(`schedule-card-${updatedSchedule!.id}`)).toContainText(
-      "UI Updated Schedule",
-      { timeout: 5_000 },
-    );
+    await expect(nav.getByText("UI Updated Schedule")).toBeVisible({ timeout: 5_000 });
 
-    // Delete via UI
-    await page.getByTestId(`schedule-card-${updatedSchedule!.id}`).click();
+    // Navigate to the schedule detail via sidebar and delete
+    await nav.getByText("UI Updated Schedule").click();
     await page.waitForURL(`**/schedules/${updatedSchedule!.id}`, { timeout: 5_000 });
     await page.getByTestId("schedule-detail-delete").click();
 
@@ -156,7 +155,7 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     await dialog.getByRole("button", { name: "Delete" }).click();
 
     await expect(page).toHaveURL(/\/schedules$/, { timeout: 5_000 });
-    await expect(page.getByTestId(`schedule-card-${updatedSchedule!.id}`)).toHaveCount(0);
+    await expect(nav.getByText("UI Updated Schedule")).not.toBeVisible({ timeout: 5_000 });
   });
 
   test("legacy /settings/schedules* URLs redirect to /schedules*", async ({
@@ -171,7 +170,7 @@ test.describe("Schedule Management — UI", { tag: ["@schedule"] }, () => {
     // List: /settings/schedules -> /schedules
     await page.goto("/settings/schedules");
     await expect(page).toHaveURL(/\/schedules$/, { timeout: 5_000 });
-    await expect(page.getByRole("heading", { name: "Schedules" })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("schedule-nav")).toBeVisible({ timeout: 5_000 });
 
     // Create form: /settings/schedules/new -> /schedules/new
     await page.goto("/settings/schedules/new");

--- a/tests/e2e-tests/tests/stream-scroll.spec.ts
+++ b/tests/e2e-tests/tests/stream-scroll.spec.ts
@@ -71,9 +71,11 @@ test.describe("Stream smart scroll", { tag: ["@webui"] }, () => {
     await expect(toggle).toBeVisible();
     await toggle.click();
 
-    // Get text content after toggle — should be different (reversed order)
-    const textAfter = await scrollContainer.innerText();
-    expect(textBefore).not.toEqual(textAfter);
+    // The virtualized list remounts on toggle (key={String(isReversed)}), so
+    // poll until the text content changes — the remount is async.
+    await expect
+      .poll(async () => scrollContainer.innerText(), { timeout: 5_000 })
+      .not.toEqual(textBefore);
   });
 
   test("scroll-to-anchor FAB appears when scrolled away", async ({ stubTask }) => {


### PR DESCRIPTION
## Summary

- **Sidebar nav for Personas, Schedules, and Coordination**: Replaces card-based list layouts with the same left-sidebar pattern used by Environments/Tasks/Settings. Personas and Schedules get new `PersonaNav`/`ScheduleNav` components with type dots, status indicators, trailing badges, ghost create buttons, and keyboard navigation. Coordination moves the stream list into the sidebar and always shows the graph in the main area (removes the List/Graph toggle).
- **Consistent breadcrumbs via PageHeader**: New `PageHeader` component wraps breadcrumbs with optional back-navigation and actions. All pages now render breadcrumbs through this component, including pages that previously had none (SessionsListPage, AgentLayout, AgentCreatePage).
- **Back-navigation on fleet pages**: Fleet pages (Environments, Knowledge, Personas, Schedules) now show a `←` back arrow since they hide the AppNav horizontal tabs. Clicking navigates to the dashboard (which IS the fleet overview).

## Screenshots

### Personas — sidebar with type dots and "Default" badge
![02-personas-empty](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/02-personas-empty.svg)

### Persona detail — form renders in main area (no surface-card wrapper)
![03-persona-detail](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/03-persona-detail.svg)

### Schedules — sidebar with enabled dots and next-run countdown
![04-schedules](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/04-schedules.svg)

### Coordination — stream list in sidebar, graph always visible
![05-coordination](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/05-coordination.svg)

### Environments — existing sidebar pattern (now with back-nav arrow)
![06-environments](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/06-environments.svg)

### Settings — workbench page (no back-nav, AppNav visible)
![07-settings](https://gist.githubusercontent.com/nick-pape/232e3f2ed5fc4097a005882b34eb0b59/raw/07-settings.svg)

## Test plan

- [x] `rush build` — clean SUCCESS, no warnings
- [x] `rushx test` in web-components — 271 tests pass
- [x] `rushx test` in web — 286 tests pass
- [x] Manual: Personas sidebar shows items with type dots, "Default" badge, ghost create button
- [x] Manual: Persona detail renders in main area when sidebar item clicked
- [x] Manual: Schedules sidebar shows items with enabled dots and countdown badges
- [x] Manual: Coordination shows stream list in sidebar, graph in main area
- [x] Manual: Fleet pages show back-nav arrow; workbench pages do not
- [x] Manual: Breadcrumbs render on all pages via PageHeader
- [ ] E2E Playwright tests (CI)