### PR TITLE
fix: Enter submits chat, Shift+Enter inserts newline

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-chat-enter-submit_2026-06-03-16-09.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-chat-enter-submit_2026-06-03-16-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Chat input now submits on Enter and inserts a newline on Shift+Enter",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web-components/src/components/chat/ChatInput.stories.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.stories.tsx
@@ -140,9 +140,9 @@ export const SendModeActive: Story = {
 };
 
 /**
- * The composer is multiline: a plain Enter inserts a newline and does NOT submit.
+ * Shift+Enter inserts a newline without submitting.
  */
-export const ComposerEnterInsertsNewline: Story = {
+export const ComposerShiftEnterInsertsNewline: Story = {
   args: {
     mode: "send",
     sessionId: "sess-1",
@@ -150,16 +150,16 @@ export const ComposerEnterInsertsNewline: Story = {
   },
   play: async ({ canvas, args }) => {
     const input = canvas.getByPlaceholderText("Type a message...");
-    await userEvent.type(input, "line one{Enter}line two");
+    await userEvent.type(input, "line one{Shift>}{Enter}{/Shift}line two");
     await expect(input).toHaveValue("line one\nline two");
     await expect(args.onSendInput).not.toHaveBeenCalled();
   },
 };
 
 /**
- * Ctrl/Cmd+Enter submits the composer (mirrors clicking Send) and clears the box.
+ * Enter submits the composer (mirrors clicking Send) and clears the box.
  */
-export const ComposerCtrlEnterSubmits: Story = {
+export const ComposerEnterSubmits: Story = {
   args: {
     mode: "send",
     sessionId: "sess-1",
@@ -168,7 +168,7 @@ export const ComposerCtrlEnterSubmits: Story = {
   play: async ({ canvas, args }) => {
     const input = canvas.getByPlaceholderText("Type a message...");
     await userEvent.type(input, "hello there");
-    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await userEvent.keyboard("{Enter}");
     await expect(args.onSendInput).toHaveBeenCalledWith("sess-1", "hello there");
     await expect(input).toHaveValue("");
   },

--- a/packages/web-components/src/components/chat/ChatInput.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.tsx
@@ -106,7 +106,7 @@ function ComposerTextArea({
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
     // Enter submits; Shift+Enter falls through to insert a newline.
     // The isComposing guard avoids submitting mid-IME composition (e.g. CJK input).
-    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+    if (e.key === "Enter" && !e.shiftKey && !e.repeat && !e.nativeEvent.isComposing) {
       e.preventDefault();
       onSubmit();
     }

--- a/packages/web-components/src/components/chat/ChatInput.tsx
+++ b/packages/web-components/src/components/chat/ChatInput.tsx
@@ -63,7 +63,7 @@ interface ComposerTextAreaProps {
   value: string;
   /** Called on every keystroke with the new value. */
   onChange: (value: string) => void;
-  /** Called when the user submits via Ctrl/Cmd+Enter. */
+  /** Called when the user submits via Enter (Shift+Enter inserts a newline). */
   onSubmit: () => void;
   /** Placeholder text shown when empty. */
   placeholder: string;
@@ -78,7 +78,7 @@ interface ComposerTextAreaProps {
 /**
  * Auto-resizing multiline chat composer.
  *
- * Enter inserts a newline; Ctrl/Cmd+Enter submits (the Send button submits too).
+ * Enter submits; Shift+Enter inserts a newline (the Send button submits too).
  * The textarea grows with its content up to {@link MAX_COMPOSER_HEIGHT_PX}, then
  * scrolls internally.
  */
@@ -104,9 +104,9 @@ function ComposerTextArea({
   }, [value]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
-    // Ctrl/Cmd+Enter submits; plain Enter falls through to insert a newline.
+    // Enter submits; Shift+Enter falls through to insert a newline.
     // The isComposing guard avoids submitting mid-IME composition (e.g. CJK input).
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       onSubmit();
     }
@@ -178,7 +178,7 @@ export function ChatInput({
 
   const envDisconnected = isEnvDisconnected(environmentId, environments);
 
-  /** Performs the mode-specific submit action. Called by the form and Ctrl/Cmd+Enter. */
+  /** Performs the mode-specific submit action. Called by the form and Enter key. */
   const submit = (): void => {
     if (!text.trim()) {
       return;


### PR DESCRIPTION
## Summary
- Chat composer now submits on **Enter** and inserts a newline on **Shift+Enter**, matching the convention used by Slack, Discord, ChatGPT, etc.
- Previously the behavior was inverted: plain Enter inserted a newline and Ctrl/Cmd+Enter submitted.

## Test plan
- [x] Storybook `ComposerEnterSubmits` story verifies Enter submits and clears the input
- [x] Storybook `ComposerShiftEnterInsertsNewline` story verifies Shift+Enter inserts a newline without submitting
- [x] All 271 web-components unit tests pass
- [ ] Manual verification in browser