### PR TITLE
Fix duplicate user messages in chat

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-fix-duplicate-user-messages_2026-06-03-16-52.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-fix-duplicate-user-messages_2026-06-03-16-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix duplicate user messages in chat by rendering turn_started as the canonical user input instead of emitting a separate USER_INPUT event",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -43,7 +43,7 @@ export interface EventStreamOptions {
   taskId?: string;
   /** System context injected into the agent session. Emitted as the first event in the stream. */
   systemContext?: string;
-  /** Initial user prompt sent to the agent. Emitted as a user_input event after systemContext. */
+  /** Initial user prompt. Retained for call-site compatibility; no longer emitted as a user_input event (the runtime's turn_started event serves that role). */
   prompt?: string;
   /** Trace ID for correlating logs across the request lifecycle. */
   traceId?: string;
@@ -216,17 +216,10 @@ export function processEventStream(
         await logWriter.writeEvent(logPath, sysCtxEvent);
         streamHub.publish(sysCtxEvent);
       }
-      if (options.prompt && options.taskId) {
-        const promptEvent = create(grackle.SessionEventSchema, {
-          sessionId,
-          type: grackle.EventType.USER_INPUT,
-          timestamp: new Date().toISOString(),
-          content: options.prompt,
-        });
-        promptEvent.serverSeq = recordSessionAction(promptEvent) ?? "";
-        await logWriter.writeEvent(logPath, promptEvent);
-        streamHub.publish(promptEvent);
-      }
+      // The initial prompt is NOT emitted as a USER_INPUT event here.
+      // The runtime emits a turn_started event (AHP HR2) carrying the user
+      // message, which the UI renders as the user input bubble — emitting a
+      // separate USER_INPUT would duplicate it.
 
       for await (const envelope of envelopes) {
         const event = envelope.event;

--- a/packages/knowledge-core/src/transcript-chunker.ts
+++ b/packages/knowledge-core/src/transcript-chunker.ts
@@ -40,6 +40,7 @@ const DEFAULT_MAX_CHUNK_SIZE: number = 4000;
 /** Labels used when rendering events into readable text. */
 const EVENT_LABELS: Record<string, string> = {
   user_input: "User",
+  turn_started: "User",
   text: "Assistant",
   tool_use: "Tool",
   tool_result: "Result",
@@ -126,13 +127,13 @@ function parseJsonl(content: string): LogEntry[] {
   return entries;
 }
 
-/** Group log entries into turns, splitting on `user_input` events. */
+/** Group log entries into turns, splitting on `user_input` or `turn_started` events. */
 function groupByTurn(entries: LogEntry[]): LogEntry[][] {
   const turns: LogEntry[][] = [];
   let current: LogEntry[] = [];
 
   for (const entry of entries) {
-    if (entry.type === "user_input" && current.length > 0) {
+    if ((entry.type === "user_input" || entry.type === "turn_started") && current.length > 0) {
       turns.push(current);
       current = [];
     }

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -359,22 +359,12 @@ export async function sendInput(req: grackle.InputMessage): Promise<grackle.Empt
     );
   }
 
-  // Persist and publish user input event so subscribers see the text in the event stream
-  const userInputEvent = create(grackle.SessionEventSchema, {
-    sessionId: req.sessionId,
-    type: grackle.EventType.USER_INPUT,
-    timestamp: new Date().toISOString(),
-    content: req.text,
-    raw: "",
-  });
-  if (session.logPath) {
-    await logWriter.writeEvent(session.logPath, userInputEvent);
-  }
-  streamHub.publish(userInputEvent);
-
   logger.debug({ sessionId: req.sessionId }, "User input received");
 
-  // Route through stdin stream — the async listener delivers to PowerLine
+  // Route through stdin stream — the async listener delivers to PowerLine.
+  // The runtime emits a turn_started event with the user's text (AHP HR2),
+  // which the UI renders as the user message — no separate USER_INPUT event
+  // needed here.
   publishToStdin(req.sessionId, req.text);
 
   return create(grackle.EmptySchema, {});

--- a/packages/web-components/src/components/display/EventRenderer.tsx
+++ b/packages/web-components/src/components/display/EventRenderer.tsx
@@ -473,7 +473,10 @@ export function EventRenderer({
     case "status":
       return <StatusEvent content={event.content} />;
     case "user_input":
+    case "turn_started":
       return <UserInputEvent content={event.content} />;
+    case "turn_complete":
+      return <></>;
     case "signal":
       return <SignalEvent content={event.content} />;
     case "usage":

--- a/packages/web-components/src/components/display/VirtualEventItem.tsx
+++ b/packages/web-components/src/components/display/VirtualEventItem.tsx
@@ -14,6 +14,7 @@ function buildCheckboxLabel(event: SessionEvent): string {
     case "output":
       return `Select message from assistant at ${time}`;
     case "user_input":
+    case "turn_started":
       return `Select message from user at ${time}`;
     case "tool_result":
     case "tool_use":

--- a/packages/web-components/src/utils/eventContent.ts
+++ b/packages/web-components/src/utils/eventContent.ts
@@ -14,6 +14,7 @@ const CONTENT_BEARING_TYPES: ReadonlySet<string> = new Set([
   "text",
   "output",
   "user_input",
+  "turn_started",
   "tool_use",
   "tool_result",
   "error",
@@ -124,7 +125,8 @@ export function formatEventsAsMarkdown(events: DisplayEvent[]): string {
         parts.push(`**Assistant** (${time}):\n${event.content}`);
         break;
       }
-      case "user_input": {
+      case "user_input":
+      case "turn_started": {
         parts.push(`**User** (${time}):\n${event.content}`);
         break;
       }


### PR DESCRIPTION
## Summary
- User messages appeared twice in the chat stream: once styled (from `sendInput`'s `USER_INPUT` event) and once as plain unformatted text (from the runtime's `turn_started` event falling through to the `DefaultEvent` renderer)
- Root cause: `sendInput()` and `processEventStream()` both emitted `USER_INPUT` events, while the runtime independently emitted `turn_started` carrying the same user text — but `EventRenderer` had no case for `turn_started`, so it rendered as unstyled `DefaultEvent`
- Fix: remove the redundant `USER_INPUT` emissions and use the runtime's `turn_started` as the canonical source of truth for user messages. `EventRenderer` now renders `turn_started` as `UserInputEvent` and hides `turn_complete`

## Test plan
- [x] `event-processor.test.ts` — 53 tests pass (turn_id threading still works)
- [x] `grpc-send-input.test.ts` — 4 tests pass (sendInput still routes through stdin)
- [x] `eventContent.test.ts` — 38 tests pass (content classification/formatting)
- [ ] Manual: verify user messages appear once with correct styling in the chat UI
- [ ] Manual: verify copy/paste of user messages works correctly