### PR TITLE
Fix persona detail page stuck on first persona navigated to

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-fix-persona-nav-stuck_2026-06-04-02-31.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-fix-persona-nav-stuck_2026-06-04-02-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix persona detail page staying stuck on the first persona navigated to",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web/src/pages/PersonaDetailPage.tsx
+++ b/packages/web/src/pages/PersonaDetailPage.tsx
@@ -55,6 +55,7 @@ export function PersonaDetailPage(): JSX.Element {
   return (
     <div className={styles.container}>
       <PersonaForm
+        key={personaId ?? "new"}
         existing={existing}
         isNew={isNew}
         appDefaultPersonaId={appDefaultPersonaId}


### PR DESCRIPTION
## Summary
- Add `key={personaId}` to `PersonaForm` in `PersonaDetailPage` so React remounts the form when navigating between different personas
- Without the key, React reused the same component instance across persona navigations — the `hydrated` flag stayed `true` and `useState` initializers kept stale data from the first persona visited, causing the form to appear stuck

## Test plan
- [ ] Navigate to Personas, click into a persona, then use browser back and click a different persona — verify the detail page shows the correct persona's data
- [ ] Create a new persona, verify the form is blank
- [ ] Edit a persona, verify fields reflect that persona's actual values