### PR TITLE
Add per-package CLAUDE.md architectural guardrails

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-per-package-claude-md_2026-06-04.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-per-package-claude-md_2026-06-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@grackle-ai/cli",
+      "comment": "Add per-package CLAUDE.md architectural guardrails",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/adapter-codespace/CLAUDE.md
+++ b/packages/adapter-codespace/CLAUDE.md
@@ -1,0 +1,4 @@
+# Codespace Adapter Rules
+
+- **Before implementing a method, check if another adapter already has the same logic.** If so, extract to a shared base in adapter-sdk rather than duplicating.
+- **All lifecycle operations (provision, connect, stop, destroy) must go through shared infrastructure (tunnel registry).** No parallel tracking in adapter-local globals.

--- a/packages/adapter-docker/CLAUDE.md
+++ b/packages/adapter-docker/CLAUDE.md
@@ -1,0 +1,4 @@
+# Docker Adapter Rules
+
+- **Before implementing a method, check if another adapter already has the same logic.** If so, extract to a shared base in adapter-sdk rather than duplicating.
+- **All lifecycle operations (provision, connect, stop, destroy) must go through shared infrastructure (tunnel registry).** No parallel tracking in adapter-local globals. Attach mode is not special — it uses the same infrastructure as tunnel mode.

--- a/packages/adapter-sdk/CLAUDE.md
+++ b/packages/adapter-sdk/CLAUDE.md
@@ -1,0 +1,4 @@
+# Adapter SDK Rules
+
+- **This package defines interfaces and shared utilities.** If your code references a specific adapter's infrastructure (codespace paths, docker hosts, SSH commands), it belongs in that adapter's package, not here.
+- **No module-level mutable state (Maps, arrays, singletons).** Stateful objects must be instantiable and passed via context.

--- a/packages/adapter-ssh/CLAUDE.md
+++ b/packages/adapter-ssh/CLAUDE.md
@@ -1,0 +1,4 @@
+# SSH Adapter Rules
+
+- **Before implementing a method, check if another adapter already has the same logic.** If so, extract to a shared base in adapter-sdk rather than duplicating.
+- **All lifecycle operations (provision, connect, stop, destroy) must go through shared infrastructure (tunnel registry).** No parallel tracking in adapter-local globals.

--- a/packages/common/CLAUDE.md
+++ b/packages/common/CLAUDE.md
@@ -1,0 +1,3 @@
+# Common Package Rules
+
+- **If you find yourself defining a type or utility that another package already has, move the existing one here instead of creating a second copy.**

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,0 +1,5 @@
+# Core Package Rules
+
+- **New `process.env` reads must go through the centralized config provider, not inline.**
+- **Before adding a new utility (retry, timestamp, etc.), check if one already exists in common.** Don't re-implement.
+- **If a file exceeds ~400 lines, split before adding to it.**

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -1,0 +1,4 @@
+# Database Package Rules
+
+- **Stores are pure data access.** If you're writing an `if` that isn't about query construction, it belongs in a service layer, not here.
+- **Types exported from this package are persistence types.** Domain consumers should not import them directly — wrap or re-export through core.

--- a/packages/plugin-core/CLAUDE.md
+++ b/packages/plugin-core/CLAUDE.md
@@ -1,0 +1,5 @@
+# Plugin Core Rules
+
+- **Handlers are thin routing** — validate input, call a service, return the result. If your handler function exceeds ~40 lines, the business logic needs its own module.
+- **Never import from a sibling plugin package.** If two plugins need the same logic, extract it to `common` or `plugin-sdk`.
+- **Use `??` for all optional/default value handling, never `||`** (which swallows `""` and `0`).

--- a/packages/powerline/CLAUDE.md
+++ b/packages/powerline/CLAUDE.md
@@ -1,0 +1,4 @@
+# PowerLine Package Rules
+
+- **For any multi-step lifecycle (session, connection, forwarding), define an explicit state machine with typed states and validated transitions.** No boolean-flag state management.
+- **New files must have a single concern.** If you're adding a new handler domain (auth, resources, channels), it gets its own file — don't append to an existing handlers file.

--- a/packages/runtime-sdk/CLAUDE.md
+++ b/packages/runtime-sdk/CLAUDE.md
@@ -1,0 +1,3 @@
+# Runtime SDK Rules
+
+- **If a feature only works on some runtimes, it must be expressed through a capability interface, not documented as "X only, others ignore."**

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -1,3 +1,3 @@
 # Server Package Rules
 
-- **New plugins must be registered through the plugin registry, not by adding imports and conditionals to `index.ts`.**
+- **New plugins must be registered through the plugin registry (`@grackle-ai/plugin-core` `plugin-registry.ts`), not by adding imports and conditionals to `index.ts`.**

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -1,0 +1,3 @@
+# Server Package Rules
+
+- **New plugins must be registered through the plugin registry, not by adding imports and conditionals to `index.ts`.**

--- a/packages/web-components/CLAUDE.md
+++ b/packages/web-components/CLAUDE.md
@@ -1,0 +1,4 @@
+# Web Components Package Rules
+
+- **Any list that can grow beyond ~100 items must be virtualized from the start.** Don't add virtualization later — it's a different component architecture.
+- **Components rendered in loops must use `React.memo()`.**

--- a/packages/web-components/CLAUDE.md
+++ b/packages/web-components/CLAUDE.md
@@ -1,4 +1,4 @@
 # Web Components Package Rules
 
 - **Any list that can grow beyond ~100 items must be virtualized from the start.** Don't add virtualization later — it's a different component architecture.
-- **Components rendered in loops must use `React.memo()`.**
+- **Consider `React.memo()` for components rendered in large lists with stable props.** Don't cargo-cult it on every loop — only where re-renders are measurably costly.

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -1,0 +1,4 @@
+# Web Package Rules
+
+- **No transport-layer types (`ConnectError`, gRPC `Code`) outside the data layer.** If you need error discrimination in a hook or component, use normalized UI error types.
+- **Components in `components/` must not call `useGrackle()`.** Data comes in via props; only `pages/*.tsx` wires the data layer.

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -1,4 +1,4 @@
 # Web Package Rules
 
-- **No transport-layer types (`ConnectError`, gRPC `Code`) outside the data layer.** If you need error discrimination in a hook or component, use normalized UI error types.
-- **Components in `components/` must not call `useGrackle()`.** Data comes in via props; only `pages/*.tsx` wires the data layer.
+- **Keep transport-layer types (`ConnectError`, gRPC `Code`) out of presentational components.** Hooks that talk to the server may use them, but map to UI-friendly error types before passing to components.
+- **Presentational components must not call `useGrackle()`.** Data comes in via props. Route/layout components and `pages/**/*.tsx` wire the data layer.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` files to 13 packages with forward-looking architectural rules
- Rules are preventive guardrails to stop anti-patterns from forming in new code, derived from the patterns found across #1454–#1517
- Packages covered: `database`, `core`, `plugin-core`, `powerline`, `server`, `adapter-sdk`, `adapter-ssh`, `adapter-codespace`, `adapter-docker`, `runtime-sdk`, `web`, `web-components`, `common`

## Key anti-patterns these rules target
- God handlers / god objects growing unchecked
- Business logic drifting into the wrong layer (DB, transport, UI)
- Copy-paste over extract across adapters/runtimes
- Implicit contracts (boolean flags instead of state machines, "keep in sync" comments instead of shared imports)
- Global mutable state in SDKs
- Inconsistent conventions (`||` vs `??`, scattered `process.env`, ad-hoc validation)

## Test plan
- [ ] Docs-only change — no code affected
- [ ] Verify CLAUDE.md files are picked up by Claude Code when working in each package