### PR TITLE
Add session summary status line to Code context header

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-code-header-status_2026-06-04-05-58.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-code-header-status_2026-06-04-05-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "placeholder",
+      "type": "none",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/changes/@grackle-ai/cli/nick-pape-code-header-status_2026-06-04-05-58.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-code-header-status_2026-06-04-05-58.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "placeholder",
+      "comment": "Add session summary status line to Code context header",
       "type": "none",
       "packageName": "@grackle-ai/cli"
     }

--- a/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
+++ b/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
@@ -37,7 +37,7 @@ describe("describeCodeStatus", () => {
       makeSession({ id: "s2", status: "running", startedAt: "2026-06-01T11:00:00Z" }),
       makeSession({
         id: "s3",
-        status: "completed",
+        status: "stopped",
         endReason: "completed",
         startedAt: "2026-06-01T12:00:00Z",
       }),
@@ -51,7 +51,7 @@ describe("describeCodeStatus", () => {
     const sessions = [
       makeSession({
         id: "s1",
-        status: "completed",
+        status: "stopped",
         endReason: "completed",
         startedAt: "2026-06-01T10:00:00Z",
       }),

--- a/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
+++ b/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import type { Session } from "../../hooks/types.js";
+import { describeCodeStatus } from "./CodeHeaderStatus.js";
+
+/** Build a session with sensible defaults, overridable per-test. */
+function makeSession(over: Partial<Session> & { id: string }): Session {
+  return {
+    environmentId: "env-1",
+    runtime: "claude-code",
+    status: "running",
+    prompt: "Do the thing",
+    startedAt: "2026-02-27T08:00:00Z",
+    ...over,
+  };
+}
+
+describe("describeCodeStatus", () => {
+  it("returns zero active and undefined lastActivityAt for empty sessions", () => {
+    const result = describeCodeStatus([]);
+    expect(result).toEqual({ activeCount: 0, lastActivityAt: undefined });
+  });
+
+  it("counts all running sessions as active", () => {
+    const sessions = [
+      makeSession({ id: "s1", status: "running", startedAt: "2026-06-01T10:00:00Z" }),
+      makeSession({ id: "s2", status: "running", startedAt: "2026-06-01T11:00:00Z" }),
+      makeSession({ id: "s3", status: "running", startedAt: "2026-06-01T12:00:00Z" }),
+    ];
+    const result = describeCodeStatus(sessions);
+    expect(result.activeCount).toBe(3);
+    expect(result.lastActivityAt).toBe("2026-06-01T12:00:00Z");
+  });
+
+  it("distinguishes active from ended sessions", () => {
+    const sessions = [
+      makeSession({ id: "s1", status: "running", startedAt: "2026-06-01T10:00:00Z" }),
+      makeSession({ id: "s2", status: "running", startedAt: "2026-06-01T11:00:00Z" }),
+      makeSession({
+        id: "s3",
+        status: "completed",
+        endReason: "completed",
+        startedAt: "2026-06-01T12:00:00Z",
+      }),
+    ];
+    const result = describeCodeStatus(sessions);
+    expect(result.activeCount).toBe(2);
+    expect(result.lastActivityAt).toBe("2026-06-01T12:00:00Z");
+  });
+
+  it("returns zero active when all sessions are ended", () => {
+    const sessions = [
+      makeSession({
+        id: "s1",
+        status: "completed",
+        endReason: "completed",
+        startedAt: "2026-06-01T10:00:00Z",
+      }),
+      makeSession({
+        id: "s2",
+        status: "error",
+        endReason: "error",
+        startedAt: "2026-06-01T09:00:00Z",
+      }),
+    ];
+    const result = describeCodeStatus(sessions);
+    expect(result.activeCount).toBe(0);
+    expect(result.lastActivityAt).toBe("2026-06-01T10:00:00Z");
+  });
+
+  it("picks the latest startedAt regardless of session order", () => {
+    const sessions = [
+      makeSession({ id: "s1", status: "running", startedAt: "2026-06-01T12:00:00Z" }),
+      makeSession({ id: "s2", status: "running", startedAt: "2026-06-01T08:00:00Z" }),
+      makeSession({ id: "s3", status: "running", startedAt: "2026-06-01T15:00:00Z" }),
+      makeSession({ id: "s4", status: "running", startedAt: "2026-06-01T10:00:00Z" }),
+    ];
+    const result = describeCodeStatus(sessions);
+    expect(result.lastActivityAt).toBe("2026-06-01T15:00:00Z");
+  });
+});

--- a/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
+++ b/packages/web-components/src/components/layout/CodeHeaderStatus.test.ts
@@ -57,7 +57,7 @@ describe("describeCodeStatus", () => {
       }),
       makeSession({
         id: "s2",
-        status: "error",
+        status: "stopped",
         endReason: "error",
         startedAt: "2026-06-01T09:00:00Z",
       }),

--- a/packages/web-components/src/components/layout/CodeHeaderStatus.tsx
+++ b/packages/web-components/src/components/layout/CodeHeaderStatus.tsx
@@ -6,7 +6,7 @@
  * @module
  */
 
-import type { JSX } from "react";
+import type { CSSProperties, JSX } from "react";
 import type { Session } from "../../hooks/types.js";
 import { isActiveSession } from "../sessions/sessionsView.js";
 import { formatRelativeTime } from "../../utils/time.js";
@@ -45,7 +45,7 @@ export function describeCodeStatus(
 // ---------------------------------------------------------------------------
 
 /** Inline styles matching the agent header's HeartbeatStatus pattern. */
-const STATUS_ITEM_STYLE: React.CSSProperties = {
+const STATUS_ITEM_STYLE: CSSProperties = {
   fontSize: "var(--font-size-xs)",
   color: "var(--text-tertiary)",
   whiteSpace: "nowrap",

--- a/packages/web-components/src/components/layout/CodeHeaderStatus.tsx
+++ b/packages/web-components/src/components/layout/CodeHeaderStatus.tsx
@@ -1,0 +1,85 @@
+/**
+ * CodeHeaderStatus — presentational status line for the Code context header.
+ * Contains both the pure computation ({@link describeCodeStatus}) and the
+ * React component ({@link CodeHeaderStatus}).
+ *
+ * @module
+ */
+
+import type { JSX } from "react";
+import type { Session } from "../../hooks/types.js";
+import { isActiveSession } from "../sessions/sessionsView.js";
+import { formatRelativeTime } from "../../utils/time.js";
+
+// ---------------------------------------------------------------------------
+// Pure logic
+// ---------------------------------------------------------------------------
+
+/** Summary of session activity for the Code context header. */
+export interface CodeStatusSummary {
+  /** Number of currently active (live) sessions. */
+  activeCount: number;
+  /** ISO timestamp of the most recently started session, or `undefined` if none. */
+  lastActivityAt: string | undefined;
+}
+
+/** Derive a Code context status summary from the sessions array. */
+export function describeCodeStatus(
+  sessions: readonly Pick<Session, "status" | "endReason" | "startedAt">[],
+): CodeStatusSummary {
+  let activeCount: number = 0;
+  let lastActivityAt: string | undefined;
+  for (const s of sessions) {
+    if (isActiveSession(s)) {
+      activeCount++;
+    }
+    if (!lastActivityAt || s.startedAt > lastActivityAt) {
+      lastActivityAt = s.startedAt;
+    }
+  }
+  return { activeCount, lastActivityAt };
+}
+
+// ---------------------------------------------------------------------------
+// Presentational component
+// ---------------------------------------------------------------------------
+
+/** Inline styles matching the agent header's HeartbeatStatus pattern. */
+const STATUS_ITEM_STYLE: React.CSSProperties = {
+  fontSize: "var(--font-size-xs)",
+  color: "var(--text-tertiary)",
+  whiteSpace: "nowrap",
+};
+
+/** Props for {@link CodeHeaderStatus}. */
+export interface CodeHeaderStatusProps {
+  /** Summary computed by {@link describeCodeStatus}. */
+  summary: CodeStatusSummary;
+}
+
+/** Renders the Code context header status line. Returns nothing when there is no data. */
+export function CodeHeaderStatus({ summary }: CodeHeaderStatusProps): JSX.Element | undefined {
+  const { activeCount, lastActivityAt } = summary;
+
+  if (activeCount === 0 && !lastActivityAt) {
+    return undefined;
+  }
+
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}
+      data-testid="code-header-status"
+    >
+      {activeCount > 0 && (
+        <span style={STATUS_ITEM_STYLE} data-testid="code-header-active-sessions">
+          {activeCount} active {activeCount === 1 ? "session" : "sessions"}
+        </span>
+      )}
+      {lastActivityAt && (
+        <span style={STATUS_ITEM_STYLE} data-testid="code-header-last-activity">
+          Last activity {formatRelativeTime(lastActivityAt)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/web-components/src/components/layout/ContextDetailShell.stories.tsx
+++ b/packages/web-components/src/components/layout/ContextDetailShell.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, userEvent } from "@storybook/test";
 import { Activity, MessageSquare, Settings } from "lucide-react";
 import { ContextDetailShell, AGENT_DETAIL_TABS, CODE_HEADER_ICON } from "./ContextDetailShell.js";
 import type { ContextDetailTab } from "./ContextDetailShell.js";
+import { CodeHeaderStatus } from "./CodeHeaderStatus.js";
 
 const ICON_SIZE: number = 18;
 
@@ -43,6 +44,14 @@ export const CodeContext: Story = {
   args: {
     icon: CODE_HEADER_ICON,
     name: "Code",
+    statusContent: (
+      <CodeHeaderStatus
+        summary={{
+          activeCount: 2,
+          lastActivityAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        }}
+      />
+    ),
     tabs: CODE_TABS,
     activeTab: "chat",
     ariaLabel: "App navigation",
@@ -52,9 +61,32 @@ export const CodeContext: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByTestId("code-header-name")).toHaveTextContent("Code");
     await expect(canvas.getByTestId("code-header-back")).toBeInTheDocument();
+    await expect(canvas.getByTestId("code-header-status")).toBeInTheDocument();
+    await expect(canvas.getByTestId("code-header-active-sessions")).toHaveTextContent(
+      "2 active sessions",
+    );
+    await expect(canvas.getByTestId("code-header-last-activity")).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Chat/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Sessions/ })).toBeInTheDocument();
     await expect(canvas.getByRole("tab", { name: /Settings/ })).toBeInTheDocument();
+  },
+};
+
+export const CodeContextNoSessions: Story = {
+  args: {
+    icon: CODE_HEADER_ICON,
+    name: "Code",
+    statusContent: <CodeHeaderStatus summary={{ activeCount: 0, lastActivityAt: undefined }} />,
+    tabs: CODE_TABS,
+    activeTab: "chat",
+    ariaLabel: "App navigation",
+    headerTestId: "code-header",
+    tabBarTestId: "code-tab-bar",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByTestId("code-header-name")).toHaveTextContent("Code");
+    const status = canvas.queryByTestId("code-header-status");
+    await expect(status).toBeNull();
   },
 };
 

--- a/packages/web-components/src/components/layout/index.ts
+++ b/packages/web-components/src/components/layout/index.ts
@@ -9,6 +9,8 @@ export { ContextNav, CONTEXTS, DEFAULT_CONTEXT_ID } from "./ContextNav.js";
 export type { ContextItem, ContextNavProps } from "./ContextNav.js";
 export { ContextDetailShell, CODE_HEADER_ICON, AGENT_DETAIL_TABS } from "./ContextDetailShell.js";
 export type { ContextDetailShellProps, ContextDetailTab } from "./ContextDetailShell.js";
+export { describeCodeStatus, CodeHeaderStatus } from "./CodeHeaderStatus.js";
+export type { CodeStatusSummary, CodeHeaderStatusProps } from "./CodeHeaderStatus.js";
 export { Sidebar } from "./Sidebar.js";
 export { BottomStatusBar } from "./BottomStatusBar.js";
 export { PageHeader } from "./PageHeader.js";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -95,6 +95,8 @@ export {
   ContextDetailShell,
   CODE_HEADER_ICON,
   AGENT_DETAIL_TABS,
+  describeCodeStatus,
+  CodeHeaderStatus,
 } from "./components/layout/index.js";
 export type {
   AppTab,
@@ -105,6 +107,8 @@ export type {
   ContextNavProps,
   ContextDetailShellProps,
   ContextDetailTab,
+  CodeStatusSummary,
+  CodeHeaderStatusProps,
   PageHeaderProps,
 } from "./components/layout/index.js";
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -31,6 +31,8 @@ import {
   type ContextItem,
   type ContextDetailTab,
   CODE_HEADER_ICON,
+  describeCodeStatus,
+  CodeHeaderStatus,
 } from "@grackle-ai/web-components";
 import {
   useCallback,
@@ -245,6 +247,8 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
     }));
   }, [tabs]);
 
+  const codeStatusSummary = useMemo(() => describeCodeStatus(sessions), [sessions]);
+
   const handleCodeTabSelect = useCallback(
     (tabId: string) => {
       const tab = tabs.find((t) => t.view === tabId);
@@ -368,6 +372,7 @@ function AppShellBody({ tabs }: { tabs: AppTab[] }): JSX.Element {
               icon={CODE_HEADER_ICON}
               name="Code"
               onNavigateBack={() => navigate("/chat")}
+              statusContent={<CodeHeaderStatus summary={codeStatusSummary} />}
               tabs={codeDetailTabs}
               activeTab={activeView}
               onSelectTab={handleCodeTabSelect}


### PR DESCRIPTION
## Summary

- Add a session summary status line ("N active sessions · Last activity Xm ago") to the Code context header, matching the Agent header's heartbeat status pattern
- Equalizes the height of the Code and Agent `ContextDetailShell` headers — the Agent version passed `statusContent` while Code passed nothing, causing a ~16px height mismatch
- Extracted `describeCodeStatus()` pure function + `CodeHeaderStatus` presentational component in `web-components`, with unit tests

## Test plan
- [ ] `rush build -t @grackle-ai/web` passes without warnings
- [ ] `rush test -t @grackle-ai/web-components` — new `describeCodeStatus` unit tests pass (empty, all active, mixed, all ended, max timestamp)
- [ ] Storybook: `CodeContext` story shows status line; `CodeContextNoSessions` story hides it
- [ ] Launch app — Code header shows "N active sessions · Last activity Xm ago" below "Code"
- [ ] Navigate to an Agent — both headers now have the same height
- [ ] Fresh install with no sessions — status line hidden gracefully