### PR TITLE
Extract RemoteTunnelAdapter base class (#1473)

### DIFF
--- a/common/api/adapter-codespace.public.api.md
+++ b/common/api/adapter-codespace.public.api.md
@@ -4,33 +4,34 @@
 
 ```ts
 
-import type { AdapterDependencies } from '@grackle-ai/adapter-sdk';
-import { BaseAdapter } from '@grackle-ai/adapter-sdk';
-import type { BaseEnvironmentConfig } from '@grackle-ai/adapter-sdk';
 import { FatalAdapterError } from '@grackle-ai/adapter-sdk';
-import type { PowerLineConnection } from '@grackle-ai/adapter-sdk';
-import type { ProvisionEvent } from '@grackle-ai/adapter-sdk';
+import { ProcessTunnel } from '@grackle-ai/adapter-sdk';
+import { RemoteExecutor } from '@grackle-ai/adapter-sdk';
+import { RemoteTunnelAdapter } from '@grackle-ai/adapter-sdk';
+import type { RemoteTunnelConfig } from '@grackle-ai/adapter-sdk';
+import type { RemoteTunnelMeta } from '@grackle-ai/adapter-sdk';
 
 // @public
-export class CodespaceAdapter extends BaseAdapter {
-    constructor(deps?: AdapterDependencies);
-    protected doConnect(environmentId: string, _config: Record<string, unknown>, powerlineToken: string): Promise<PowerLineConnection>;
-    protected doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void>;
-    protected doDisconnect(environmentId: string): Promise<void>;
-    protected doProvision(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
-    protected doStop(environmentId: string, config: Record<string, unknown>): Promise<void>;
-    healthCheck(connection: PowerLineConnection): Promise<boolean>;
-    reconnect(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
+export class CodespaceAdapter extends RemoteTunnelAdapter<CodespaceEnvironmentConfig> {
+    protected createExecutor(cfg: CodespaceEnvironmentConfig): RemoteExecutor;
+    protected createForwardTunnel(localPort: number, cfg: CodespaceEnvironmentConfig): ProcessTunnel;
+    protected createReverseTunnel(localPort: number, remotePort: number, cfg: CodespaceEnvironmentConfig): ProcessTunnel;
+    protected preBootstrap(executor: RemoteExecutor, _config: CodespaceEnvironmentConfig): Promise<{
+        workingDirectory?: string;
+    }>;
+    protected reconnectBootstrapOptions(_config: CodespaceEnvironmentConfig): Record<string, unknown>;
+    protected resolveConfig(config: Record<string, unknown>): {
+        config: CodespaceEnvironmentConfig;
+        meta: RemoteTunnelMeta;
+    };
     // (undocumented)
     type: string;
 }
 
 // @public
-export interface CodespaceEnvironmentConfig extends BaseEnvironmentConfig {
+export interface CodespaceEnvironmentConfig extends RemoteTunnelConfig {
     codespaceName: string;
-    env?: Record<string, string>;
     githubAccountId?: string;
-    localPort?: number;
 }
 
 // @public

--- a/common/api/adapter-codespace.public.api.md
+++ b/common/api/adapter-codespace.public.api.md
@@ -10,6 +10,7 @@ import { RemoteExecutor } from '@grackle-ai/adapter-sdk';
 import { RemoteTunnelAdapter } from '@grackle-ai/adapter-sdk';
 import type { RemoteTunnelConfig } from '@grackle-ai/adapter-sdk';
 import type { RemoteTunnelMeta } from '@grackle-ai/adapter-sdk';
+import type { StartRemotePowerLineOptions } from '@grackle-ai/adapter-sdk';
 
 // @public
 export class CodespaceAdapter extends RemoteTunnelAdapter<CodespaceEnvironmentConfig> {
@@ -19,7 +20,7 @@ export class CodespaceAdapter extends RemoteTunnelAdapter<CodespaceEnvironmentCo
     protected preBootstrap(executor: RemoteExecutor, _config: CodespaceEnvironmentConfig): Promise<{
         workingDirectory?: string;
     }>;
-    protected reconnectBootstrapOptions(_config: CodespaceEnvironmentConfig): Record<string, unknown>;
+    protected reconnectBootstrapOptions(_config: CodespaceEnvironmentConfig): Partial<StartRemotePowerLineOptions>;
     protected resolveConfig(config: Record<string, unknown>): {
         config: CodespaceEnvironmentConfig;
         meta: RemoteTunnelMeta;

--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -391,7 +391,7 @@ export abstract class RemoteTunnelAdapter<TConfig extends RemoteTunnelConfig = R
         workingDirectory?: string;
     }>;
     reconnect(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
-    protected reconnectBootstrapOptions(_config: TConfig): Record<string, unknown>;
+    protected reconnectBootstrapOptions(_config: TConfig): Partial<StartRemotePowerLineOptions>;
     protected registerTunnelForEnvironment(environmentId: string, state: TunnelState): void;
     protected abstract resolveConfig(config: Record<string, unknown>): {
         config: TConfig;

--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -280,6 +280,16 @@ export interface PowerLineConnection {
 export function probeRemotePowerLine(executor: RemoteExecutor): Promise<void>;
 
 // @public
+export abstract class ProcessReverseTunnel extends ProcessTunnel {
+    constructor(localPort: number, remotePort: number, sleepFn: (ms: number) => Promise<void>, processFactory?: TunnelProcessFactory, portProbe?: TunnelPortProbe);
+    // (undocumented)
+    protected readonly remotePort: number;
+    // (undocumented)
+    protected readonly sleepFn: (ms: number) => Promise<void>;
+    protected waitForReady(): Promise<void>;
+}
+
+// @public
 export abstract class ProcessTunnel implements RemoteTunnel {
     constructor(localPort: number, logger?: AdapterLogger, processFactory?: TunnelProcessFactory, portProbe?: TunnelPortProbe);
     close(): Promise<void>;
@@ -357,6 +367,60 @@ export interface RemoteTunnel {
     open(): Promise<void>;
 }
 
+// @public
+export abstract class RemoteTunnelAdapter<TConfig extends RemoteTunnelConfig = RemoteTunnelConfig> extends BaseAdapter {
+    constructor(deps?: AdapterDependencies);
+    protected closeTunnelForEnvironment(environmentId: string): Promise<void>;
+    protected connectToTunnel(environmentId: string, localPort: number, powerlineToken: string): Promise<PowerLineConnection>;
+    protected abstract createExecutor(config: TConfig): RemoteExecutor;
+    protected abstract createForwardTunnel(localPort: number, config: TConfig): ProcessTunnel;
+    protected abstract createReverseTunnel(localPort: number, remotePort: number, config: TConfig): ProcessTunnel;
+    protected doConnect(environmentId: string, _config: Record<string, unknown>, powerlineToken: string): Promise<PowerLineConnection>;
+    protected doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void>;
+    protected doDisconnect(environmentId: string): Promise<void>;
+    protected doProvision(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
+    protected doStop(environmentId: string, config: Record<string, unknown>): Promise<void>;
+    // (undocumented)
+    protected readonly execFn: ExecFunction;
+    protected getTunnelForEnvironment(environmentId: string): TunnelState | undefined;
+    healthCheck(connection: PowerLineConnection): Promise<boolean>;
+    // (undocumented)
+    protected readonly isGitHubProviderEnabled: () => boolean;
+    protected openWithFreePort<T>(action: (port: number) => Promise<T>): Promise<T>;
+    protected preBootstrap(_executor: RemoteExecutor, _config: TConfig): Promise<{
+        workingDirectory?: string;
+    }>;
+    reconnect(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
+    protected reconnectBootstrapOptions(_config: TConfig): Record<string, unknown>;
+    protected registerTunnelForEnvironment(environmentId: string, state: TunnelState): void;
+    protected abstract resolveConfig(config: Record<string, unknown>): {
+        config: TConfig;
+        meta: RemoteTunnelMeta;
+    };
+    // (undocumented)
+    protected readonly resolveGitHubToken: (accountId?: string) => string | undefined;
+    protected runBootstrap(executor: RemoteExecutor, powerlineToken: string, options: BootstrapOptions): AsyncGenerator<ProvisionEvent>;
+    protected runHealthCheck(connection: PowerLineConnection): Promise<boolean>;
+    protected runRemoteDestroy(environmentId: string, executor: RemoteExecutor): Promise<void>;
+    protected runRemoteStop(environmentId: string, executor: RemoteExecutor): Promise<void>;
+    protected runStartPowerLine(executor: RemoteExecutor, powerlineToken: string, options: StartRemotePowerLineOptions): Promise<{
+        alreadyRunning: boolean;
+    }>;
+    // (undocumented)
+    protected readonly sleepFn: (ms: number) => Promise<void>;
+}
+
+// @public
+export interface RemoteTunnelConfig extends BaseEnvironmentConfig {
+    env?: Record<string, string>;
+    localPort?: number;
+}
+
+// @public
+export interface RemoteTunnelMeta {
+    displayTarget: string;
+}
+
 export { ResourceChange }
 
 export { ResourceChangeType }
@@ -379,6 +443,9 @@ export interface ResourceWatchSubscription {
     channel: string;
     close(): Promise<void>;
 }
+
+// @public
+export const REVERSE_TUNNEL_SETTLE_MS: number;
 
 // @public
 export interface ServerActionEnvelope {

--- a/common/api/adapter-ssh.public.api.md
+++ b/common/api/adapter-ssh.public.api.md
@@ -4,32 +4,29 @@
 
 ```ts
 
-import type { AdapterDependencies } from '@grackle-ai/adapter-sdk';
-import { BaseAdapter } from '@grackle-ai/adapter-sdk';
-import type { BaseEnvironmentConfig } from '@grackle-ai/adapter-sdk';
-import type { PowerLineConnection } from '@grackle-ai/adapter-sdk';
-import type { ProvisionEvent } from '@grackle-ai/adapter-sdk';
+import { ProcessTunnel } from '@grackle-ai/adapter-sdk';
+import { RemoteExecutor } from '@grackle-ai/adapter-sdk';
+import { RemoteTunnelAdapter } from '@grackle-ai/adapter-sdk';
+import type { RemoteTunnelConfig } from '@grackle-ai/adapter-sdk';
+import type { RemoteTunnelMeta } from '@grackle-ai/adapter-sdk';
 
 // @public
-export class SshAdapter extends BaseAdapter {
-    constructor(deps?: AdapterDependencies);
-    protected doConnect(environmentId: string, _config: Record<string, unknown>, powerlineToken: string): Promise<PowerLineConnection>;
-    protected doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void>;
-    protected doDisconnect(environmentId: string): Promise<void>;
-    protected doProvision(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
-    protected doStop(environmentId: string, config: Record<string, unknown>): Promise<void>;
-    healthCheck(connection: PowerLineConnection): Promise<boolean>;
-    reconnect(environmentId: string, config: Record<string, unknown>, powerlineToken: string): AsyncGenerator<ProvisionEvent>;
+export class SshAdapter extends RemoteTunnelAdapter<SshEnvironmentConfig> {
+    protected createExecutor(cfg: SshEnvironmentConfig): RemoteExecutor;
+    protected createForwardTunnel(localPort: number, cfg: SshEnvironmentConfig): ProcessTunnel;
+    protected createReverseTunnel(localPort: number, remotePort: number, cfg: SshEnvironmentConfig): ProcessTunnel;
+    protected resolveConfig(config: Record<string, unknown>): {
+        config: SshEnvironmentConfig;
+        meta: RemoteTunnelMeta;
+    };
     // (undocumented)
     type: string;
 }
 
 // @public
-export interface SshEnvironmentConfig extends BaseEnvironmentConfig {
-    env?: Record<string, string>;
+export interface SshEnvironmentConfig extends RemoteTunnelConfig {
     host: string;
     identityFile?: string;
-    localPort?: number;
     sshOptions?: Record<string, string>;
     sshPort?: number;
     user?: string;

--- a/common/changes/@grackle-ai/cli/nick-pape-1473-remote-tunnel-adapter_2026-06-05-01-11.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1473-remote-tunnel-adapter_2026-06-05-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Extract RemoteTunnelAdapter base class from SSH/Codespace adapters, eliminating ~95% code duplication",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/adapter-codespace/src/codespace.test.ts
+++ b/packages/adapter-codespace/src/codespace.test.ts
@@ -10,46 +10,50 @@ interface MockTunnelInstance {
   close: ReturnType<typeof vi.fn>;
 }
 
-const mocks = vi.hoisted(() => ({
-  closeTunnel: vi.fn().mockResolvedValue(undefined),
-  registerTunnel: vi.fn(),
-  findFreePort: vi.fn().mockResolvedValue(9999),
-  withFreePort: vi.fn(),
-  startRemotePowerLine: vi.fn().mockResolvedValue({ alreadyRunning: true }),
-  bootstrapPowerLine: vi.fn(),
-  tunnelInstances: [] as MockTunnelInstance[],
-  tunnelOpenCallCount: 0,
-  tunnelOpenFailOnCall: -1,
-}));
+const mocks: {
+  tunnelInstances: MockTunnelInstance[];
+  tunnelOpenCallCount: number;
+  tunnelOpenFailOnCall: number;
+  MockTunnelClass: new (localPort: number) => unknown;
+} = vi.hoisted(() => {
+  // Use a single object so the class closures and the test both mutate the same reference.
+  const m: {
+    tunnelInstances: MockTunnelInstance[];
+    tunnelOpenCallCount: number;
+    tunnelOpenFailOnCall: number;
+    MockTunnelClass: new (localPort: number) => unknown;
+  } = {
+    tunnelInstances: [],
+    tunnelOpenCallCount: 0,
+    tunnelOpenFailOnCall: -1,
+    MockTunnelClass: undefined!,
+  };
+
+  m.MockTunnelClass = class {
+    public localPort: number;
+    public close = vi.fn();
+    public open = vi.fn().mockImplementation(async () => {
+      m.tunnelOpenCallCount++;
+      if (m.tunnelOpenCallCount === m.tunnelOpenFailOnCall) {
+        throw new Error("tunnel open failed");
+      }
+    });
+    public isAlive = vi.fn().mockReturnValue(true);
+    public constructor(localPort: number) {
+      this.localPort = localPort;
+      m.tunnelInstances.push(this as unknown as MockTunnelInstance);
+    }
+  };
+
+  return m;
+});
 
 vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => {
   const original = await importOriginal<typeof import("@grackle-ai/adapter-sdk")>();
   return {
     ...original,
-    closeTunnel: mocks.closeTunnel,
-    registerTunnel: mocks.registerTunnel,
-    findFreePort: mocks.findFreePort,
-    withFreePort: mocks.withFreePort,
-    startRemotePowerLine: mocks.startRemotePowerLine,
-    bootstrapPowerLine: async function* () {
-      yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
-    },
-    // Stub ProcessTunnel so CodespaceTunnel doesn't spawn real processes (tested in tunnel.test.ts)
-    ProcessTunnel: class {
-      public localPort: number;
-      public close = vi.fn();
-      public open = vi.fn().mockImplementation(async () => {
-        mocks.tunnelOpenCallCount++;
-        if (mocks.tunnelOpenCallCount === mocks.tunnelOpenFailOnCall) {
-          throw new Error("tunnel open failed");
-        }
-      });
-      public isAlive = vi.fn().mockReturnValue(true);
-      public constructor(localPort: number) {
-        this.localPort = localPort;
-        mocks.tunnelInstances.push(this as unknown as MockTunnelInstance);
-      }
-    },
+    ProcessTunnel: mocks.MockTunnelClass,
+    ProcessReverseTunnel: mocks.MockTunnelClass,
   };
 });
 
@@ -69,10 +73,48 @@ async function collectEvents(gen: AsyncGenerator<ProvisionEvent>): Promise<Provi
   return events;
 }
 
+/** Set up standard spies on the adapter's SDK wrapper methods. */
+function setupAdapterSpies(adapter: CodespaceAdapter): {
+  runBootstrap: ReturnType<typeof vi.fn>;
+  runStartPowerLine: ReturnType<typeof vi.fn>;
+  openWithFreePort: ReturnType<typeof vi.fn>;
+  closeTunnelForEnvironment: ReturnType<typeof vi.fn>;
+  registerTunnelForEnvironment: ReturnType<typeof vi.fn>;
+} {
+  const obj = adapter as unknown as Record<string, unknown>;
+  const runBootstrap = vi
+    .spyOn(obj, "runBootstrap")
+    .mockImplementation(async function* (): AsyncGenerator<ProvisionEvent> {
+      yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
+    });
+  const runStartPowerLine = vi
+    .spyOn(obj, "runStartPowerLine")
+    .mockResolvedValue({ alreadyRunning: true });
+  const openWithFreePort = vi
+    .spyOn(obj, "openWithFreePort")
+    .mockImplementation(async (action: (port: number) => Promise<unknown>) => action(9999));
+  const closeTunnelForEnvironment = vi
+    .spyOn(obj, "closeTunnelForEnvironment")
+    .mockResolvedValue(undefined);
+  const registerTunnelForEnvironment = vi
+    .spyOn(obj, "registerTunnelForEnvironment")
+    .mockImplementation(() => {});
+  return {
+    runBootstrap: runBootstrap as unknown as ReturnType<typeof vi.fn>,
+    runStartPowerLine: runStartPowerLine as unknown as ReturnType<typeof vi.fn>,
+    openWithFreePort: openWithFreePort as unknown as ReturnType<typeof vi.fn>,
+    closeTunnelForEnvironment: closeTunnelForEnvironment as unknown as ReturnType<typeof vi.fn>,
+    registerTunnelForEnvironment: registerTunnelForEnvironment as unknown as ReturnType<
+      typeof vi.fn
+    >,
+  };
+}
+
 // ── Tests ───────────────────────────────────────────────────
 
 describe("CodespaceAdapter.reconnect()", () => {
   let adapter: CodespaceAdapter;
+  let spies: ReturnType<typeof setupAdapterSpies>;
   const config = { codespaceName: "test-cs" };
   const token = "test-token";
   const envId = "env-1";
@@ -82,14 +124,11 @@ describe("CodespaceAdapter.reconnect()", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
-    mocks.startRemotePowerLine.mockResolvedValue({ alreadyRunning: true });
-    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
-      action(9999),
-    );
     adapter = new CodespaceAdapter({
       exec: mockExec,
       sleep: mockSleep,
     });
+    spies = setupAdapterSpies(adapter);
   });
 
   it("yields reconnecting progress events on happy path", async () => {
@@ -99,18 +138,18 @@ describe("CodespaceAdapter.reconnect()", () => {
 
     expect(events.length).toBeGreaterThanOrEqual(3);
     expect(events.every((e) => e.stage === "reconnecting")).toBe(true);
-    expect(events[events.length - 1].message).toContain("Reconnected");
+    expect(events[events.length - 1]!.message).toContain("Reconnected");
   });
 
-  it("closes stale tunnel, calls startRemotePowerLine with probeFirst, and opens new tunnel", async () => {
+  it("closes stale tunnel, calls startRemotePowerLine with probeFirst and autoDetectWorkspace, and opens new tunnel", async () => {
     await collectEvents(adapter.reconnect!(envId, config as Record<string, unknown>, token));
 
-    expect(mocks.closeTunnel).toHaveBeenCalledWith(envId);
-    expect(mocks.startRemotePowerLine).toHaveBeenCalledOnce();
-    // Verify probeFirst and autoDetectWorkspace options
-    const options = mocks.startRemotePowerLine.mock.calls[0][2];
+    expect(spies.closeTunnelForEnvironment).toHaveBeenCalledWith(envId);
+    expect(spies.runStartPowerLine).toHaveBeenCalledOnce();
+    // Verify probeFirst and autoDetectWorkspace options (Codespace-specific)
+    const options = spies.runStartPowerLine.mock.calls[0]![2];
     expect(options).toMatchObject({ probeFirst: true, autoDetectWorkspace: true });
-    expect(mocks.registerTunnel).toHaveBeenCalledWith(
+    expect(spies.registerTunnelForEnvironment).toHaveBeenCalledWith(
       envId,
       expect.objectContaining({
         tunnel: expect.objectContaining({ localPort: 9999 }),
@@ -119,18 +158,18 @@ describe("CodespaceAdapter.reconnect()", () => {
   });
 
   it("yields 'restarted' event when PowerLine was not already running", async () => {
-    mocks.startRemotePowerLine.mockResolvedValueOnce({ alreadyRunning: false });
+    spies.runStartPowerLine.mockResolvedValueOnce({ alreadyRunning: false });
 
     const events = await collectEvents(
       adapter.reconnect!(envId, config as Record<string, unknown>, token),
     );
 
     expect(events.some((e) => e.message.includes("restarted"))).toBe(true);
-    expect(events[events.length - 1].message).toContain("Reconnected");
+    expect(events[events.length - 1]!.message).toContain("Reconnected");
   });
 
   it("does not yield 'restarted' event when PowerLine was already running", async () => {
-    mocks.startRemotePowerLine.mockResolvedValueOnce({ alreadyRunning: true });
+    spies.runStartPowerLine.mockResolvedValueOnce({ alreadyRunning: true });
 
     const events = await collectEvents(
       adapter.reconnect!(envId, config as Record<string, unknown>, token),
@@ -140,7 +179,7 @@ describe("CodespaceAdapter.reconnect()", () => {
   });
 
   it("propagates error when startRemotePowerLine fails", async () => {
-    mocks.startRemotePowerLine.mockRejectedValueOnce(
+    spies.runStartPowerLine.mockRejectedValueOnce(
       new Error("PowerLine process died immediately after starting"),
     );
 
@@ -150,7 +189,7 @@ describe("CodespaceAdapter.reconnect()", () => {
   });
 
   it("propagates error when SSH is unreachable", async () => {
-    mocks.startRemotePowerLine.mockRejectedValueOnce(new Error("ssh connection refused"));
+    spies.runStartPowerLine.mockRejectedValueOnce(new Error("ssh connection refused"));
 
     await expect(
       collectEvents(adapter.reconnect!(envId, config as Record<string, unknown>, token)),
@@ -172,13 +211,13 @@ describe("CodespaceAdapter.reconnect()", () => {
 
     expect(mocks.tunnelInstances).toHaveLength(2);
     expect(mocks.tunnelInstances[0]!.close).toHaveBeenCalledOnce();
-    expect(mocks.registerTunnel).not.toHaveBeenCalled();
+    expect(spies.registerTunnelForEnvironment).not.toHaveBeenCalled();
   });
 });
 
 // ── CodespaceNotFoundError detection ────────────────────────
-// These tests go through provision() because that calls executor.exec() directly
-// (startRemotePowerLine is mocked in reconnect() tests above, bypassing the executor).
+// These tests go through provision() with the connectivity test exec mock only.
+// The runBootstrap spy prevents real I/O after the connectivity test.
 
 describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()", () => {
   let adapter: CodespaceAdapter;
@@ -188,10 +227,12 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
-      action(9999),
-    );
+    mocks.tunnelInstances.length = 0;
+    mocks.tunnelOpenCallCount = 0;
+    mocks.tunnelOpenFailOnCall = -1;
     adapter = new CodespaceAdapter({ exec: mockExec, sleep: mockSleep });
+    // Set up spies so provision doesn't try real bootstrap/tunnel work after the connectivity test
+    setupAdapterSpies(adapter);
   });
 
   it("throws CodespaceNotFoundError (FatalAdapterError) when gh stderr contains 'Not Found'", async () => {
@@ -250,8 +291,6 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
   });
 
   it("throws CodespaceNotFoundError for real gh HTTP 404 response (getting full codespace details)", async () => {
-    // This is the actual error gh codespace ssh emits when the codespace doesn't exist:
-    // "getting full codespace details: HTTP 404: Not Found"
     const ghErr = Object.assign(new Error("Command failed: gh codespace ssh"), {
       stderr:
         "getting full codespace details: HTTP 404: Not Found (https://api.github.com/user/codespaces/fake-cs)",
@@ -285,6 +324,7 @@ describe("CodespaceAdapter — CodespaceNotFoundError detection via provision()"
 
 describe("CodespaceAdapter.provision() — tunnel cleanup", () => {
   let adapter: CodespaceAdapter;
+  let spies: ReturnType<typeof setupAdapterSpies>;
   const config = { codespaceName: "test-cs" };
   const token = "test-token";
   const envId = "env-1";
@@ -294,10 +334,8 @@ describe("CodespaceAdapter.provision() — tunnel cleanup", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
-    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
-      action(9999),
-    );
     adapter = new CodespaceAdapter({ exec: mockExec, sleep: mockSleep });
+    spies = setupAdapterSpies(adapter);
   });
 
   it("closes forward tunnel when reverse tunnel open() fails", async () => {
@@ -309,6 +347,6 @@ describe("CodespaceAdapter.provision() — tunnel cleanup", () => {
 
     expect(mocks.tunnelInstances).toHaveLength(2);
     expect(mocks.tunnelInstances[0]!.close).toHaveBeenCalledOnce();
-    expect(mocks.registerTunnel).not.toHaveBeenCalled();
+    expect(spies.registerTunnelForEnvironment).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -1,38 +1,18 @@
-import type {
-  BaseEnvironmentConfig,
-  PowerLineConnection,
-  ProvisionEvent,
-  AdapterDependencies,
-  ExecFunction,
-} from "@grackle-ai/adapter-sdk";
+import type { RemoteTunnelConfig, RemoteTunnelMeta, ExecFunction } from "@grackle-ai/adapter-sdk";
 import { FatalAdapterError } from "@grackle-ai/adapter-sdk";
-import { DEFAULT_POWERLINE_PORT, DEFAULT_MCP_PORT } from "@grackle-ai/common";
 import {
-  BaseAdapter,
+  RemoteTunnelAdapter,
   type RemoteExecutor,
   type TunnelProcessFactory,
   type TunnelPortProbe,
   ProcessTunnel,
-  bootstrapPowerLine,
-  connectThroughTunnel,
-  registerTunnel,
-  getTunnel,
-  closeTunnel,
-  withFreePort,
-  remoteStop,
-  remoteDestroy,
-  remoteHealthCheck,
-  startRemotePowerLine,
-  exec as defaultExec,
-  sleep as defaultSleep,
-  SSH_CONNECTIVITY_TIMEOUT_MS,
+  ProcessReverseTunnel,
   REMOTE_EXEC_DEFAULT_TIMEOUT_MS,
+  SSH_CONNECTIVITY_TIMEOUT_MS,
 } from "@grackle-ai/adapter-sdk";
+import { DEFAULT_POWERLINE_PORT } from "@grackle-ai/common";
 
 const REMOTE_COPY_TIMEOUT_MS: number = 120_000;
-
-/** Delay for reverse tunnels to wait for SSH to establish. */
-const REVERSE_TUNNEL_SETTLE_MS: number = 3_000;
 
 /**
  * Thrown when the codespace no longer exists on GitHub.
@@ -53,13 +33,9 @@ const CODESPACE_NOT_FOUND_PATTERNS: RegExp =
 // ─── Config ─────────────────────────────────────────────────
 
 /** GitHub Codespaces-specific environment configuration. */
-export interface CodespaceEnvironmentConfig extends BaseEnvironmentConfig {
+export interface CodespaceEnvironmentConfig extends RemoteTunnelConfig {
   /** The codespace name from `gh codespace list` (required). */
   codespaceName: string;
-  /** Override the local tunnel port (otherwise a free port is chosen). */
-  localPort?: number;
-  /** Additional environment variables forwarded to the remote PowerLine. */
-  env?: Record<string, string>;
   /**
    * ID of the GitHub account to use for `gh` CLI operations on this environment.
    * When set, the account's token is injected as `GH_TOKEN` into all `gh` calls.
@@ -172,10 +148,8 @@ class CodespaceTunnel extends ProcessTunnel {
  * Reverse SSH tunnel: binds a port inside the codespace that tunnels back to a local port.
  * Used so agents (running in the codespace) can reach the Grackle MCP server (on the host).
  */
-class CodespaceReverseTunnel extends ProcessTunnel {
+class CodespaceReverseTunnel extends ProcessReverseTunnel {
   private readonly codespaceName: string;
-  private readonly remotePort: number;
-  private readonly sleepFn: (ms: number) => Promise<void>;
 
   public constructor(
     localPort: number,
@@ -186,10 +160,8 @@ class CodespaceReverseTunnel extends ProcessTunnel {
     portProbe?: TunnelPortProbe,
     ghToken?: string,
   ) {
-    super(localPort, undefined, processFactory, portProbe);
-    this.remotePort = remotePort;
+    super(localPort, remotePort, sleepFn, processFactory, portProbe);
     this.codespaceName = codespaceName;
-    this.sleepFn = sleepFn;
     if (ghToken) {
       this.spawnEnv = { GH_TOKEN: ghToken };
     }
@@ -209,70 +181,61 @@ class CodespaceReverseTunnel extends ProcessTunnel {
     ];
     return { command: "gh", args };
   }
-
-  /**
-   * Reverse tunnels bind on the remote side, not locally.
-   * We can't probe the remote port, so wait a fixed delay for SSH to establish.
-   */
-  protected async waitForReady(): Promise<void> {
-    await this.sleepFn(REVERSE_TUNNEL_SETTLE_MS);
-    if (this.process?.exitCode !== null) {
-      throw new Error(`Reverse tunnel exited immediately with code ${this.process?.exitCode}`);
-    }
-  }
 }
 
 // ─── Adapter ────────────────────────────────────────────────
 
 /** Environment adapter that provisions and manages GitHub Codespaces running the PowerLine. */
-export class CodespaceAdapter extends BaseAdapter {
+export class CodespaceAdapter extends RemoteTunnelAdapter<CodespaceEnvironmentConfig> {
   public type: string = "codespace";
-  private readonly execFn: ExecFunction;
-  private readonly sleepFn: (ms: number) => Promise<void>;
-  private readonly isGitHubProviderEnabled: () => boolean;
-  private readonly resolveGitHubToken: (accountId?: string) => string | undefined;
 
-  public constructor(deps: AdapterDependencies = {}) {
-    super();
-    this.execFn = deps.exec ?? defaultExec;
-    this.sleepFn = deps.sleep ?? defaultSleep;
-    this.isGitHubProviderEnabled = deps.isGitHubProviderEnabled ?? (() => false);
-    this.resolveGitHubToken = deps.resolveGitHubToken ?? (() => undefined);
-  }
-
-  /** Provision the codespace: verify connectivity, bootstrap PowerLine, open port-forward. */
-  protected async *doProvision(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
+  /** Validate and parse the raw config into typed Codespace configuration. */
+  protected resolveConfig(config: Record<string, unknown>): {
+    config: CodespaceEnvironmentConfig;
+    meta: RemoteTunnelMeta;
+  } {
     const cfg = config as unknown as CodespaceEnvironmentConfig;
     if (!cfg.codespaceName) {
       throw new Error("Codespace adapter requires a 'codespaceName' in the configuration");
     }
+    return { config: cfg, meta: { displayTarget: `codespace ${cfg.codespaceName}` } };
+  }
 
+  /** Create a Codespace executor with optional GitHub token injection. */
+  protected createExecutor(cfg: CodespaceEnvironmentConfig): RemoteExecutor {
     const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
-    const executor = new CodespaceExecutor(cfg.codespaceName, this.execFn, ghToken);
+    return new CodespaceExecutor(cfg.codespaceName, this.execFn, ghToken);
+  }
 
-    // Test codespace connectivity
-    yield {
-      stage: "connecting",
-      message: `Connecting to codespace ${cfg.codespaceName}...`,
-      progress: 0.05,
-    };
-    try {
-      await executor.exec("echo ok", { timeout: SSH_CONNECTIVITY_TIMEOUT_MS });
-    } catch (err) {
-      if (err instanceof FatalAdapterError) {
-        throw err;
-      }
-      throw new Error(
-        `Cannot reach codespace '${cfg.codespaceName}' via gh CLI: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+  /** Create a port-forward tunnel via `gh codespace ports forward`. */
+  protected createForwardTunnel(localPort: number, cfg: CodespaceEnvironmentConfig): ProcessTunnel {
+    const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
+    return new CodespaceTunnel(localPort, cfg.codespaceName, undefined, undefined, ghToken);
+  }
 
-    // Detect the repo working directory (codespaces clone to /workspaces/<name>)
-    let workingDirectory: string | undefined;
+  /** Create a reverse SSH tunnel via `gh codespace ssh -- -R`. */
+  protected createReverseTunnel(
+    localPort: number,
+    remotePort: number,
+    cfg: CodespaceEnvironmentConfig,
+  ): ProcessTunnel {
+    const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
+    return new CodespaceReverseTunnel(
+      localPort,
+      remotePort,
+      cfg.codespaceName,
+      this.sleepFn,
+      undefined,
+      undefined,
+      ghToken,
+    );
+  }
+
+  /** Detect the repo working directory (codespaces clone to /workspaces/<name>). */
+  protected async preBootstrap(
+    executor: RemoteExecutor,
+    _config: CodespaceEnvironmentConfig,
+  ): Promise<{ workingDirectory?: string }> {
     try {
       const workspaceDir = (
         await executor.exec("ls -d /workspaces/*/ 2>/dev/null | head -1", {
@@ -282,190 +245,18 @@ export class CodespaceAdapter extends BaseAdapter {
         .trim()
         .replace(/\/$/, "");
       if (workspaceDir) {
-        workingDirectory = workspaceDir;
+        return { workingDirectory: workspaceDir };
       }
     } catch {
       // Non-fatal — fall back to PowerLine directory
     }
-
-    // Bootstrap PowerLine on the codespace
-    yield* bootstrapPowerLine(executor, powerlineToken, {
-      extraEnv: cfg.env,
-      workingDirectory,
-      isGitHubProviderEnabled: this.isGitHubProviderEnabled,
-      defaultRuntime: (config.defaultRuntime as string) || undefined,
-    });
-
-    // Open port-forward tunnel (retry on port conflict, #1486)
-    const openTunnel = async (port: number): Promise<{ port: number; tunnel: CodespaceTunnel }> => {
-      const t = new CodespaceTunnel(port, cfg.codespaceName, undefined, undefined, ghToken);
-      await t.open();
-      return { port, tunnel: t };
-    };
-
-    const { port: localPort, tunnel } = cfg.localPort
-      ? await openTunnel(cfg.localPort)
-      : await withFreePort(openTunnel);
-
-    yield {
-      stage: "tunneling",
-      message: `Forwarding local port ${localPort} to codespace...`,
-      progress: 0.8,
-    };
-
-    // Open reverse tunnel (codespace → host MCP server) for agent tool calls.
-    // Wrap in try/catch so the forward tunnel is cleaned up if the reverse fails.
-    try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
-      const reverseTunnel = new CodespaceReverseTunnel(
-        mcpPort,
-        mcpPort,
-        cfg.codespaceName,
-        this.sleepFn,
-        undefined,
-        undefined,
-        ghToken,
-      );
-      await reverseTunnel.open();
-
-      registerTunnel(environmentId, { tunnel, reverseTunnel });
-    } catch (err) {
-      await tunnel.close();
-      throw err;
-    }
-
-    yield {
-      stage: "connecting",
-      message: `Tunnel open, connecting on port ${localPort}...`,
-      progress: 0.9,
-    };
+    return {};
   }
 
-  /**
-   * Attempt fast reconnect: probe PowerLine, restart if needed, re-open tunnel.
-   */
-  public async *reconnect(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
-    yield* this.withProvisionLock(
-      environmentId,
-      this.doReconnect(environmentId, config, powerlineToken),
-    );
-  }
-
-  private async *doReconnect(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
-    const cfg = config as unknown as CodespaceEnvironmentConfig;
-    if (!cfg.codespaceName) {
-      throw new Error("Codespace adapter requires a 'codespaceName' in the configuration");
-    }
-
-    const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
-    const executor = new CodespaceExecutor(cfg.codespaceName, this.execFn, ghToken);
-
-    // 1. Close any stale tunnel
-    yield { stage: "reconnecting", message: "Closing stale tunnel...", progress: 0.1 };
-    await closeTunnel(environmentId);
-
-    // 2. Probe + conditional restart in a single SSH call.
-    yield {
-      stage: "reconnecting",
-      message: `Checking PowerLine on ${cfg.codespaceName}...`,
-      progress: 0.3,
-    };
-    const { alreadyRunning } = await startRemotePowerLine(executor, powerlineToken, {
-      extraEnv: cfg.env,
-      autoDetectWorkspace: true,
-      probeFirst: true,
-    });
-    if (!alreadyRunning) {
-      yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };
-    }
-
-    // 3. Open new port-forward tunnel + reverse tunnel for MCP (retry on port conflict, #1486)
-    const openTunnel = async (port: number): Promise<{ port: number; tunnel: CodespaceTunnel }> => {
-      const t = new CodespaceTunnel(port, cfg.codespaceName, undefined, undefined, ghToken);
-      await t.open();
-      return { port, tunnel: t };
-    };
-
-    const { port: localPort, tunnel } = cfg.localPort
-      ? await openTunnel(cfg.localPort)
-      : await withFreePort(openTunnel);
-
-    yield {
-      stage: "reconnecting",
-      message: `Forwarding local port ${localPort} to codespace...`,
-      progress: 0.7,
-    };
-
-    try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
-      const reverseTunnel = new CodespaceReverseTunnel(
-        mcpPort,
-        mcpPort,
-        cfg.codespaceName,
-        this.sleepFn,
-        undefined,
-        undefined,
-        ghToken,
-      );
-      await reverseTunnel.open();
-
-      registerTunnel(environmentId, { tunnel, reverseTunnel });
-    } catch (err) {
-      await tunnel.close();
-      throw err;
-    }
-
-    yield { stage: "reconnecting", message: "Reconnected to codespace", progress: 0.9 };
-  }
-
-  /** Connect to the PowerLine through the port-forward tunnel. */
-  protected async doConnect(
-    environmentId: string,
-    _config: Record<string, unknown>,
-    powerlineToken: string,
-  ): Promise<PowerLineConnection> {
-    const state = getTunnel(environmentId);
-    if (!state) {
-      throw new Error(`No tunnel registered for environment ${environmentId}`);
-    }
-    return connectThroughTunnel(environmentId, state.tunnel.localPort, powerlineToken);
-  }
-
-  /** Close the port-forward tunnel without stopping the remote PowerLine. */
-  protected async doDisconnect(environmentId: string): Promise<void> {
-    await closeTunnel(environmentId);
-  }
-
-  /** Stop the remote PowerLine process and close the tunnel. */
-  protected async doStop(environmentId: string, config: Record<string, unknown>): Promise<void> {
-    const cfg = config as unknown as CodespaceEnvironmentConfig;
-    const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
-    await remoteStop(environmentId, new CodespaceExecutor(cfg.codespaceName, this.execFn, ghToken));
-  }
-
-  /**
-   * Stop the remote PowerLine and remove artifacts from the codespace.
-   * This does NOT delete the codespace itself.
-   */
-  protected async doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void> {
-    const cfg = config as unknown as CodespaceEnvironmentConfig;
-    const ghToken = this.resolveGitHubToken(cfg.githubAccountId || undefined);
-    await remoteDestroy(
-      environmentId,
-      new CodespaceExecutor(cfg.codespaceName, this.execFn, ghToken),
-    );
-  }
-
-  /** Check that the tunnel is alive and the PowerLine responds to a ping. */
-  public async healthCheck(connection: PowerLineConnection): Promise<boolean> {
-    return remoteHealthCheck(connection);
+  /** On reconnect, auto-detect the workspace directory. */
+  protected reconnectBootstrapOptions(
+    _config: CodespaceEnvironmentConfig,
+  ): Record<string, unknown> {
+    return { autoDetectWorkspace: true };
   }
 }

--- a/packages/adapter-codespace/src/codespace.ts
+++ b/packages/adapter-codespace/src/codespace.ts
@@ -1,4 +1,9 @@
-import type { RemoteTunnelConfig, RemoteTunnelMeta, ExecFunction } from "@grackle-ai/adapter-sdk";
+import type {
+  RemoteTunnelConfig,
+  RemoteTunnelMeta,
+  ExecFunction,
+  StartRemotePowerLineOptions,
+} from "@grackle-ai/adapter-sdk";
 import { FatalAdapterError } from "@grackle-ai/adapter-sdk";
 import {
   RemoteTunnelAdapter,
@@ -256,7 +261,7 @@ export class CodespaceAdapter extends RemoteTunnelAdapter<CodespaceEnvironmentCo
   /** On reconnect, auto-detect the workspace directory. */
   protected reconnectBootstrapOptions(
     _config: CodespaceEnvironmentConfig,
-  ): Record<string, unknown> {
+  ): Partial<StartRemotePowerLineOptions> {
     return { autoDetectWorkspace: true };
   }
 }

--- a/packages/adapter-sdk/src/bootstrap.ts
+++ b/packages/adapter-sdk/src/bootstrap.ts
@@ -408,6 +408,8 @@ export async function* bootstrapPowerLine(
     yield { stage: "bootstrapping", message: "Creating remote directories...", progress: 0.2 };
     await executor.exec(
       `mkdir -p ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/common` +
+        ` ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/ahp` +
+        ` ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/ahp-transport` +
         ` ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/runtime-sdk` +
         ` ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/runtime-claude-code` +
         ` ${REMOTE_POWERLINE_DIRECTORY}/node_modules/@grackle-ai/runtime-copilot` +
@@ -425,6 +427,8 @@ export async function* bootstrapPowerLine(
     /** Workspace packages that PowerLine needs at runtime (besides powerline itself). */
     const workspacePackages: Array<[string, string]> = [
       ["common", resolve(sdkDistDir, "../../common")],
+      ["ahp", resolve(sdkDistDir, "../../ahp")],
+      ["ahp-transport", resolve(sdkDistDir, "../../ahp-transport")],
       ["mcp", resolve(sdkDistDir, "../../mcp")],
       ["auth", resolve(sdkDistDir, "../../auth")],
       ["runtime-sdk", resolve(sdkDistDir, "../../runtime-sdk")],

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -18,12 +18,16 @@ export { reconnectOrProvision } from "./adapter.js";
 export type { AdapterLifecycleState } from "./base-adapter.js";
 export { BaseAdapter } from "./base-adapter.js";
 
+// ─── Remote Tunnel Adapter ─────────────────────────────────
+export type { RemoteTunnelConfig, RemoteTunnelMeta } from "./remote-tunnel-adapter.js";
+export { RemoteTunnelAdapter } from "./remote-tunnel-adapter.js";
+
 // ─── Remote Executor ────────────────────────────────────────
 export type { RemoteExecutor } from "./remote-executor.js";
 
 // ─── Tunnels ────────────────────────────────────────────────
 export type { RemoteTunnel, TunnelProcessFactory, TunnelPortProbe } from "./tunnel.js";
-export { ProcessTunnel } from "./tunnel.js";
+export { ProcessTunnel, ProcessReverseTunnel, REVERSE_TUNNEL_SETTLE_MS } from "./tunnel.js";
 export type { TunnelState } from "./tunnel-registry.js";
 export { registerTunnel, getTunnel, closeTunnel, closeAllTunnels } from "./tunnel-registry.js";
 

--- a/packages/adapter-sdk/src/remote-tunnel-adapter.test.ts
+++ b/packages/adapter-sdk/src/remote-tunnel-adapter.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ProvisionEvent } from "./adapter.js";
+import type { RemoteExecutor } from "./remote-executor.js";
+import type { ProcessTunnel } from "./tunnel.js";
+import type { PowerLineConnection } from "./adapter.js";
+import type { RemoteTunnelConfig, RemoteTunnelMeta } from "./remote-tunnel-adapter.js";
+import { RemoteTunnelAdapter } from "./remote-tunnel-adapter.js";
+import { FatalAdapterError } from "./fatal-error.js";
+
+// ── Test Config ─────────────────────────────────────────────
+
+interface TestConfig extends RemoteTunnelConfig {
+  target: string;
+}
+
+// ── Mock Tunnel ─────────────────────────────────────────────
+
+interface MockTunnelInstance {
+  localPort: number;
+  open: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+let tunnelInstances: MockTunnelInstance[] = [];
+let tunnelOpenCallCount: number = 0;
+let tunnelOpenFailOnCall: number = -1;
+
+function createMockTunnel(localPort: number): MockTunnelInstance {
+  const instance: MockTunnelInstance = {
+    localPort,
+    open: vi.fn().mockImplementation(async () => {
+      tunnelOpenCallCount++;
+      if (tunnelOpenCallCount === tunnelOpenFailOnCall) {
+        throw new Error("tunnel open failed");
+      }
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  tunnelInstances.push(instance);
+  return instance;
+}
+
+// ── Test Adapter ────────────────────────────────────────────
+
+class TestAdapter extends RemoteTunnelAdapter<TestConfig> {
+  public type: string = "test";
+
+  protected resolveConfig(config: Record<string, unknown>): {
+    config: TestConfig;
+    meta: RemoteTunnelMeta;
+  } {
+    const cfg = config as unknown as TestConfig;
+    if (!cfg.target) {
+      throw new Error("Test adapter requires a 'target'");
+    }
+    return { config: cfg, meta: { displayTarget: cfg.target } };
+  }
+
+  protected createExecutor(_cfg: TestConfig): RemoteExecutor {
+    return {
+      exec: mockExec,
+      copyTo: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  protected createForwardTunnel(localPort: number, _cfg: TestConfig): ProcessTunnel {
+    return createMockTunnel(localPort) as unknown as ProcessTunnel;
+  }
+
+  protected createReverseTunnel(
+    localPort: number,
+    _remotePort: number,
+    _cfg: TestConfig,
+  ): ProcessTunnel {
+    return createMockTunnel(localPort) as unknown as ProcessTunnel;
+  }
+}
+
+// ── Mocks ───────────────────────────────────────────────────
+
+const mockExec = vi.fn().mockResolvedValue("");
+const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+/** Collect all events from an async generator. */
+async function collectEvents(gen: AsyncGenerator<ProvisionEvent>): Promise<ProvisionEvent[]> {
+  const events: ProvisionEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe("RemoteTunnelAdapter", () => {
+  let adapter: TestAdapter;
+  const config: Record<string, unknown> = { target: "test-host" };
+  const token: string = "test-token";
+  const envId: string = "env-test-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tunnelInstances = [];
+    tunnelOpenCallCount = 0;
+    tunnelOpenFailOnCall = -1;
+    mockExec.mockResolvedValue("");
+
+    adapter = new TestAdapter({
+      exec: mockExec,
+      sleep: mockSleep,
+    });
+
+    // Mock the SDK wrapper methods to avoid real I/O
+    vi.spyOn(adapter as unknown as Record<string, unknown>, "runBootstrap").mockImplementation(
+      async function* (): AsyncGenerator<ProvisionEvent> {
+        yield { stage: "bootstrapping", message: "mock bootstrap", progress: 0.5 };
+      },
+    );
+    vi.spyOn(adapter as unknown as Record<string, unknown>, "runStartPowerLine").mockResolvedValue({
+      alreadyRunning: true,
+    });
+    vi.spyOn(adapter as unknown as Record<string, unknown>, "openWithFreePort").mockImplementation(
+      async (action: (port: number) => Promise<unknown>) => action(9999),
+    );
+    vi.spyOn(
+      adapter as unknown as Record<string, unknown>,
+      "closeTunnelForEnvironment",
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      adapter as unknown as Record<string, unknown>,
+      "registerTunnelForEnvironment",
+    ).mockImplementation(() => {});
+  });
+
+  // ── Provision ──────────────────────────────────────────────
+
+  describe("provision()", () => {
+    it("yields progress events through the full lifecycle", async () => {
+      const events = await collectEvents(adapter.provision(envId, config, token));
+
+      expect(events.length).toBeGreaterThanOrEqual(4);
+      expect(events[0]!.stage).toBe("connecting");
+      expect(events[0]!.message).toContain("test-host");
+    });
+
+    it("calls runBootstrap with correct options", async () => {
+      const cfgWithEnv: Record<string, unknown> = {
+        target: "test-host",
+        env: { MY_VAR: "val" },
+        defaultRuntime: "claude-code",
+      };
+      await collectEvents(adapter.provision(envId, cfgWithEnv, token));
+
+      const bootstrapSpy = adapter["runBootstrap"] as unknown as ReturnType<typeof vi.fn>;
+      expect(bootstrapSpy).toHaveBeenCalledOnce();
+      const options = bootstrapSpy.mock.calls[0]![2];
+      expect(options.extraEnv).toEqual({ MY_VAR: "val" });
+      expect(options.defaultRuntime).toBe("claude-code");
+    });
+
+    it("opens forward and reverse tunnels and registers them", async () => {
+      await collectEvents(adapter.provision(envId, config, token));
+
+      expect(tunnelInstances).toHaveLength(2);
+      expect(tunnelInstances[0]!.open).toHaveBeenCalledOnce();
+      expect(tunnelInstances[1]!.open).toHaveBeenCalledOnce();
+      const registerSpy = adapter["registerTunnelForEnvironment"] as unknown as ReturnType<
+        typeof vi.fn
+      >;
+      expect(registerSpy).toHaveBeenCalledWith(
+        envId,
+        expect.objectContaining({
+          tunnel: expect.objectContaining({ localPort: 9999 }),
+        }),
+      );
+    });
+
+    it("throws if config validation fails", async () => {
+      await expect(collectEvents(adapter.provision(envId, {}, token))).rejects.toThrow("target");
+    });
+
+    it("passes through FatalAdapterError from connectivity test", async () => {
+      mockExec.mockRejectedValueOnce(new FatalAdapterError("codespace deleted"));
+
+      await expect(collectEvents(adapter.provision(envId, config, token))).rejects.toThrow(
+        FatalAdapterError,
+      );
+    });
+
+    it("wraps non-fatal connectivity errors with displayTarget", async () => {
+      mockExec.mockRejectedValueOnce(new Error("connection refused"));
+
+      await expect(collectEvents(adapter.provision(envId, config, token))).rejects.toThrow(
+        "Cannot reach test-host",
+      );
+    });
+
+    it("closes forward tunnel when reverse tunnel open() fails", async () => {
+      tunnelOpenFailOnCall = 2;
+
+      await expect(collectEvents(adapter.provision(envId, config, token))).rejects.toThrow(
+        "tunnel open failed",
+      );
+
+      expect(tunnelInstances).toHaveLength(2);
+      expect(tunnelInstances[0]!.close).toHaveBeenCalledOnce();
+      const registerSpy = adapter["registerTunnelForEnvironment"] as unknown as ReturnType<
+        typeof vi.fn
+      >;
+      expect(registerSpy).not.toHaveBeenCalled();
+    });
+
+    it("uses configured localPort when specified", async () => {
+      const cfgWithPort: Record<string, unknown> = { target: "test-host", localPort: 12345 };
+      await collectEvents(adapter.provision(envId, cfgWithPort, token));
+
+      const freePortSpy = adapter["openWithFreePort"] as unknown as ReturnType<typeof vi.fn>;
+      expect(freePortSpy).not.toHaveBeenCalled();
+      expect(tunnelInstances[0]!.localPort).toBe(12345);
+    });
+
+    it("calls preBootstrap hook before bootstrap", async () => {
+      const preBootstrapSpy = vi
+        .spyOn(adapter as unknown as Record<string, unknown>, "preBootstrap")
+        .mockResolvedValue({ workingDirectory: "/workspaces/test" });
+
+      await collectEvents(adapter.provision(envId, config, token));
+
+      expect(preBootstrapSpy).toHaveBeenCalledOnce();
+      const bootstrapSpy = adapter["runBootstrap"] as unknown as ReturnType<typeof vi.fn>;
+      const options = bootstrapSpy.mock.calls[0]![2];
+      expect(options.workingDirectory).toBe("/workspaces/test");
+    });
+  });
+
+  // ── Reconnect ──────────────────────────────────────────────
+
+  describe("reconnect()", () => {
+    it("yields reconnecting progress events on happy path", async () => {
+      const events = await collectEvents(adapter.reconnect!(envId, config, token));
+
+      expect(events.length).toBeGreaterThanOrEqual(3);
+      expect(events.every((e) => e.stage === "reconnecting")).toBe(true);
+      expect(events[events.length - 1]!.message).toContain("Reconnected");
+    });
+
+    it("closes stale tunnel and calls runStartPowerLine with probeFirst", async () => {
+      await collectEvents(adapter.reconnect!(envId, config, token));
+
+      const closeSpy = adapter["closeTunnelForEnvironment"] as unknown as ReturnType<typeof vi.fn>;
+      expect(closeSpy).toHaveBeenCalledWith(envId);
+
+      const startSpy = adapter["runStartPowerLine"] as unknown as ReturnType<typeof vi.fn>;
+      expect(startSpy).toHaveBeenCalledOnce();
+      const options = startSpy.mock.calls[0]![2];
+      expect(options).toMatchObject({ probeFirst: true });
+    });
+
+    it("yields 'restarted' event when PowerLine was not already running", async () => {
+      (adapter["runStartPowerLine"] as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        alreadyRunning: false,
+      });
+
+      const events = await collectEvents(adapter.reconnect!(envId, config, token));
+
+      expect(events.some((e) => e.message.includes("restarted"))).toBe(true);
+    });
+
+    it("does not yield 'restarted' event when PowerLine was already running", async () => {
+      const events = await collectEvents(adapter.reconnect!(envId, config, token));
+
+      expect(events.some((e) => e.message.includes("restarted"))).toBe(false);
+    });
+
+    it("propagates error when runStartPowerLine fails", async () => {
+      (adapter["runStartPowerLine"] as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("PowerLine process died"),
+      );
+
+      await expect(collectEvents(adapter.reconnect!(envId, config, token))).rejects.toThrow(
+        "PowerLine process died",
+      );
+    });
+
+    it("throws if config validation fails", async () => {
+      await expect(collectEvents(adapter.reconnect!(envId, {}, token))).rejects.toThrow("target");
+    });
+
+    it("forwards extraEnv from config", async () => {
+      const cfgWithEnv: Record<string, unknown> = {
+        target: "test-host",
+        env: { MY_VAR: "value" },
+      };
+      await collectEvents(adapter.reconnect!(envId, cfgWithEnv, token));
+
+      const startSpy = adapter["runStartPowerLine"] as unknown as ReturnType<typeof vi.fn>;
+      const options = startSpy.mock.calls[0]![2];
+      expect(options.extraEnv).toEqual({ MY_VAR: "value" });
+    });
+
+    it("merges reconnectBootstrapOptions into startPowerLine call", async () => {
+      vi.spyOn(
+        adapter as unknown as Record<string, unknown>,
+        "reconnectBootstrapOptions",
+      ).mockReturnValue({
+        autoDetectWorkspace: true,
+      });
+
+      await collectEvents(adapter.reconnect!(envId, config, token));
+
+      const startSpy = adapter["runStartPowerLine"] as unknown as ReturnType<typeof vi.fn>;
+      const options = startSpy.mock.calls[0]![2];
+      expect(options.autoDetectWorkspace).toBe(true);
+      expect(options.probeFirst).toBe(true);
+    });
+
+    it("closes forward tunnel when reverse tunnel open() fails", async () => {
+      tunnelOpenFailOnCall = 2;
+
+      await expect(collectEvents(adapter.reconnect!(envId, config, token))).rejects.toThrow(
+        "tunnel open failed",
+      );
+
+      expect(tunnelInstances).toHaveLength(2);
+      expect(tunnelInstances[0]!.close).toHaveBeenCalledOnce();
+      const registerSpy = adapter["registerTunnelForEnvironment"] as unknown as ReturnType<
+        typeof vi.fn
+      >;
+      expect(registerSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/adapter-sdk/src/remote-tunnel-adapter.ts
+++ b/packages/adapter-sdk/src/remote-tunnel-adapter.ts
@@ -1,0 +1,361 @@
+import type { PowerLineConnection, ProvisionEvent } from "./adapter.js";
+import type { AdapterDependencies, ExecFunction } from "./adapter-dependencies.js";
+import type { BootstrapOptions, StartRemotePowerLineOptions } from "./bootstrap.js";
+import type { RemoteExecutor } from "./remote-executor.js";
+import type { ProcessTunnel } from "./tunnel.js";
+import type { TunnelState } from "./tunnel-registry.js";
+import type { BaseEnvironmentConfig } from "./adapter.js";
+import { BaseAdapter } from "./base-adapter.js";
+import { FatalAdapterError } from "./fatal-error.js";
+import { DEFAULT_MCP_PORT } from "@grackle-ai/common";
+import { bootstrapPowerLine, startRemotePowerLine } from "./bootstrap.js";
+import { connectThroughTunnel } from "./connect.js";
+import { registerTunnel, getTunnel, closeTunnel } from "./tunnel-registry.js";
+import { remoteStop, remoteDestroy, remoteHealthCheck } from "./shared-operations.js";
+import { sleep as defaultSleep, withFreePort, SSH_CONNECTIVITY_TIMEOUT_MS } from "./utils.js";
+import { exec as defaultExec } from "./exec.js";
+
+// ─── Types ──────────────────────────────────────────────────
+
+/** Configuration fields shared by all remote-tunnel-based adapters. */
+export interface RemoteTunnelConfig extends BaseEnvironmentConfig {
+  /** Override the local tunnel port (otherwise a free port is chosen). */
+  localPort?: number;
+  /** Additional environment variables forwarded to the remote PowerLine. */
+  env?: Record<string, string>;
+}
+
+/** Display metadata returned by {@link RemoteTunnelAdapter.resolveConfig}. */
+export interface RemoteTunnelMeta {
+  /** Human-readable target name for progress messages (e.g. "my-host", "codespace 'abc'"). */
+  displayTarget: string;
+}
+
+// ─── Base Class ─────────────────────────────────────────────
+
+/**
+ * Abstract base for adapters that connect to a remote host via a process-backed
+ * tunnel (SSH, gh codespace ports forward, etc.).
+ *
+ * Implements the full provision/reconnect/connect/disconnect/stop/destroy/healthCheck
+ * lifecycle once. Subclasses provide four factory methods that encapsulate the
+ * transport-specific differences (executor commands, tunnel arguments).
+ *
+ * @typeParam TConfig - Adapter-specific configuration extending {@link RemoteTunnelConfig}.
+ */
+export abstract class RemoteTunnelAdapter<
+  TConfig extends RemoteTunnelConfig = RemoteTunnelConfig,
+> extends BaseAdapter {
+  protected readonly execFn: ExecFunction;
+  protected readonly sleepFn: (ms: number) => Promise<void>;
+  protected readonly isGitHubProviderEnabled: () => boolean;
+  protected readonly resolveGitHubToken: (accountId?: string) => string | undefined;
+
+  public constructor(deps: AdapterDependencies = {}) {
+    super();
+    this.execFn = deps.exec ?? defaultExec;
+    this.sleepFn = deps.sleep ?? defaultSleep;
+    this.isGitHubProviderEnabled = deps.isGitHubProviderEnabled ?? (() => false);
+    this.resolveGitHubToken = deps.resolveGitHubToken ?? (() => undefined);
+  }
+
+  // ─── Abstract factories (subclasses MUST implement) ────────
+
+  /**
+   * Validate raw config and return typed config + display metadata.
+   * Throw if required fields are missing.
+   */
+  protected abstract resolveConfig(config: Record<string, unknown>): {
+    config: TConfig;
+    meta: RemoteTunnelMeta;
+  };
+
+  /** Create a {@link RemoteExecutor} for running commands on the remote host. */
+  protected abstract createExecutor(config: TConfig): RemoteExecutor;
+
+  /** Create a forward tunnel (local port → remote PowerLine port). */
+  protected abstract createForwardTunnel(localPort: number, config: TConfig): ProcessTunnel;
+
+  /** Create a reverse tunnel (remote port → local MCP port). */
+  protected abstract createReverseTunnel(
+    localPort: number,
+    remotePort: number,
+    config: TConfig,
+  ): ProcessTunnel;
+
+  // ─── Optional hooks ────────────────────────────────────────
+
+  /**
+   * Post-connectivity hook called before bootstrap.
+   * Override to detect the remote working directory (e.g. `/workspaces/*` on codespaces).
+   * Default returns no working directory.
+   */
+  protected async preBootstrap(
+    _executor: RemoteExecutor,
+    _config: TConfig,
+  ): Promise<{ workingDirectory?: string }> {
+    return {};
+  }
+
+  /**
+   * Additional options merged into {@link startRemotePowerLine} during reconnect.
+   * Override to supply adapter-specific options (e.g. `{ autoDetectWorkspace: true }`).
+   */
+  protected reconnectBootstrapOptions(_config: TConfig): Record<string, unknown> {
+    return {};
+  }
+
+  // ─── SDK operation wrappers ────────────────────────────────
+  // Protected methods wrapping adapter-sdk functions. These provide a clean test
+  // seam for subclass tests that mock via vi.spyOn, since the SDK functions
+  // imported here are internal to adapter-sdk and not reachable through barrel mocks.
+
+  /** Run the PowerLine bootstrap sequence on the remote host. */
+  protected async *runBootstrap(
+    executor: RemoteExecutor,
+    powerlineToken: string,
+    options: BootstrapOptions,
+  ): AsyncGenerator<ProvisionEvent> {
+    yield* bootstrapPowerLine(executor, powerlineToken, options);
+  }
+
+  /** Probe and optionally restart the remote PowerLine. */
+  protected async runStartPowerLine(
+    executor: RemoteExecutor,
+    powerlineToken: string,
+    options: StartRemotePowerLineOptions,
+  ): Promise<{ alreadyRunning: boolean }> {
+    return startRemotePowerLine(executor, powerlineToken, options);
+  }
+
+  /** Open a tunnel with automatic free-port discovery. */
+  protected async openWithFreePort<T>(action: (port: number) => Promise<T>): Promise<T> {
+    return withFreePort(action);
+  }
+
+  /** Connect to the PowerLine via the tunnel. */
+  protected async connectToTunnel(
+    environmentId: string,
+    localPort: number,
+    powerlineToken: string,
+  ): Promise<PowerLineConnection> {
+    return connectThroughTunnel(environmentId, localPort, powerlineToken);
+  }
+
+  /** Close and unregister the tunnel(s) for an environment. */
+  protected async closeTunnelForEnvironment(environmentId: string): Promise<void> {
+    await closeTunnel(environmentId);
+  }
+
+  /** Register an active tunnel pair for an environment. */
+  protected registerTunnelForEnvironment(environmentId: string, state: TunnelState): void {
+    registerTunnel(environmentId, state);
+  }
+
+  /** Get the tunnel state for an environment. */
+  protected getTunnelForEnvironment(environmentId: string): TunnelState | undefined {
+    return getTunnel(environmentId);
+  }
+
+  /** Stop the remote PowerLine and close the tunnel. */
+  protected async runRemoteStop(environmentId: string, executor: RemoteExecutor): Promise<void> {
+    await remoteStop(environmentId, executor);
+  }
+
+  /** Destroy remote PowerLine artifacts and close the tunnel. */
+  protected async runRemoteDestroy(environmentId: string, executor: RemoteExecutor): Promise<void> {
+    await remoteDestroy(environmentId, executor);
+  }
+
+  /** Ping the PowerLine to check liveness. */
+  protected async runHealthCheck(connection: PowerLineConnection): Promise<boolean> {
+    return remoteHealthCheck(connection);
+  }
+
+  // ─── Shared lifecycle ──────────────────────────────────────
+
+  /** Provision the remote host: test connectivity, bootstrap PowerLine, open tunnels. */
+  protected async *doProvision(
+    environmentId: string,
+    config: Record<string, unknown>,
+    powerlineToken: string,
+  ): AsyncGenerator<ProvisionEvent> {
+    const { config: cfg, meta } = this.resolveConfig(config);
+    const executor = this.createExecutor(cfg);
+
+    yield {
+      stage: "connecting",
+      message: `Connecting to ${meta.displayTarget}...`,
+      progress: 0.05,
+    };
+    try {
+      await executor.exec("echo ok", { timeout: SSH_CONNECTIVITY_TIMEOUT_MS });
+    } catch (err) {
+      if (err instanceof FatalAdapterError) {
+        throw err;
+      }
+      throw new Error(
+        `Cannot reach ${meta.displayTarget}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const { workingDirectory } = await this.preBootstrap(executor, cfg);
+
+    yield* this.runBootstrap(executor, powerlineToken, {
+      extraEnv: cfg.env,
+      workingDirectory,
+      isGitHubProviderEnabled: this.isGitHubProviderEnabled,
+      defaultRuntime: (config.defaultRuntime as string) || undefined,
+    });
+
+    // Open forward tunnel (retry with a fresh port on TOCTOU conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: ProcessTunnel }> => {
+      const t = this.createForwardTunnel(port, cfg);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await this.openWithFreePort(openTunnel);
+
+    yield {
+      stage: "tunneling",
+      message: `Opening tunnel on local port ${localPort}...`,
+      progress: 0.8,
+    };
+
+    // Open reverse tunnel (remote → host MCP server) for agent tool calls.
+    // Clean up the forward tunnel if the reverse tunnel fails to open.
+    try {
+      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
+      const reverseTunnel = this.createReverseTunnel(mcpPort, mcpPort, cfg);
+      await reverseTunnel.open();
+
+      this.registerTunnelForEnvironment(environmentId, { tunnel, reverseTunnel });
+    } catch (err) {
+      await tunnel.close();
+      throw err;
+    }
+
+    yield {
+      stage: "connecting",
+      message: `Tunnel open, connecting on port ${localPort}...`,
+      progress: 0.9,
+    };
+  }
+
+  /**
+   * Attempt fast reconnect: probe PowerLine, restart if needed, re-open tunnels.
+   *
+   * Any failure throws and falls through to the caller, which should trigger
+   * a full provision via {@link reconnectOrProvision}.
+   */
+  public async *reconnect(
+    environmentId: string,
+    config: Record<string, unknown>,
+    powerlineToken: string,
+  ): AsyncGenerator<ProvisionEvent> {
+    yield* this.withProvisionLock(
+      environmentId,
+      this.doReconnect(environmentId, config, powerlineToken),
+    );
+  }
+
+  private async *doReconnect(
+    environmentId: string,
+    config: Record<string, unknown>,
+    powerlineToken: string,
+  ): AsyncGenerator<ProvisionEvent> {
+    const { config: cfg, meta } = this.resolveConfig(config);
+    const executor = this.createExecutor(cfg);
+
+    // 1. Close any stale tunnel
+    yield { stage: "reconnecting", message: "Closing stale tunnel...", progress: 0.1 };
+    await this.closeTunnelForEnvironment(environmentId);
+
+    // 2. Probe + conditional restart in a single call.
+    yield {
+      stage: "reconnecting",
+      message: `Checking PowerLine on ${meta.displayTarget}...`,
+      progress: 0.3,
+    };
+    const { alreadyRunning } = await this.runStartPowerLine(executor, powerlineToken, {
+      extraEnv: cfg.env,
+      probeFirst: true,
+      ...this.reconnectBootstrapOptions(cfg),
+    });
+    if (!alreadyRunning) {
+      yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };
+    }
+
+    // 3. Open new tunnels (retry on port conflict, #1486)
+    const openTunnel = async (port: number): Promise<{ port: number; tunnel: ProcessTunnel }> => {
+      const t = this.createForwardTunnel(port, cfg);
+      await t.open();
+      return { port, tunnel: t };
+    };
+
+    const { port: localPort, tunnel } = cfg.localPort
+      ? await openTunnel(cfg.localPort)
+      : await this.openWithFreePort(openTunnel);
+
+    yield {
+      stage: "reconnecting",
+      message: `Opening tunnel on local port ${localPort}...`,
+      progress: 0.7,
+    };
+
+    try {
+      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
+      const reverseTunnel = this.createReverseTunnel(mcpPort, mcpPort, cfg);
+      await reverseTunnel.open();
+
+      this.registerTunnelForEnvironment(environmentId, { tunnel, reverseTunnel });
+    } catch (err) {
+      await tunnel.close();
+      throw err;
+    }
+
+    yield {
+      stage: "reconnecting",
+      message: `Reconnected to ${meta.displayTarget}`,
+      progress: 0.9,
+    };
+  }
+
+  /** Connect to the PowerLine through the tunnel. */
+  protected async doConnect(
+    environmentId: string,
+    _config: Record<string, unknown>,
+    powerlineToken: string,
+  ): Promise<PowerLineConnection> {
+    const state = this.getTunnelForEnvironment(environmentId);
+    if (!state) {
+      throw new Error(`No tunnel registered for environment ${environmentId}`);
+    }
+    return this.connectToTunnel(environmentId, state.tunnel.localPort, powerlineToken);
+  }
+
+  /** Close the tunnel without stopping the remote PowerLine. */
+  protected async doDisconnect(environmentId: string): Promise<void> {
+    await this.closeTunnelForEnvironment(environmentId);
+  }
+
+  /** Stop the remote PowerLine process and close the tunnel. */
+  protected async doStop(environmentId: string, config: Record<string, unknown>): Promise<void> {
+    const { config: cfg } = this.resolveConfig(config);
+    await this.runRemoteStop(environmentId, this.createExecutor(cfg));
+  }
+
+  /** Stop the remote PowerLine, remove artifacts, and close the tunnel. */
+  protected async doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void> {
+    const { config: cfg } = this.resolveConfig(config);
+    await this.runRemoteDestroy(environmentId, this.createExecutor(cfg));
+  }
+
+  /** Check that the tunnel is alive and the PowerLine responds to a ping. */
+  public async healthCheck(connection: PowerLineConnection): Promise<boolean> {
+    return this.runHealthCheck(connection);
+  }
+}

--- a/packages/adapter-sdk/src/remote-tunnel-adapter.ts
+++ b/packages/adapter-sdk/src/remote-tunnel-adapter.ts
@@ -15,6 +15,18 @@ import { remoteStop, remoteDestroy, remoteHealthCheck } from "./shared-operation
 import { sleep as defaultSleep, withFreePort, SSH_CONNECTIVITY_TIMEOUT_MS } from "./utils.js";
 import { exec as defaultExec } from "./exec.js";
 
+/** Parse `GRACKLE_MCP_PORT` env var, falling back to {@link DEFAULT_MCP_PORT} on missing or non-numeric values. */
+function parseMcpPort(): number {
+  const raw = process.env.GRACKLE_MCP_PORT;
+  if (raw) {
+    const parsed = parseInt(raw, 10);
+    if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return DEFAULT_MCP_PORT;
+}
+
 // ─── Types ──────────────────────────────────────────────────
 
 /** Configuration fields shared by all remote-tunnel-based adapters. */
@@ -228,7 +240,7 @@ export abstract class RemoteTunnelAdapter<
     // Open reverse tunnel (remote → host MCP server) for agent tool calls.
     // Clean up the forward tunnel if the reverse tunnel fails to open.
     try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
+      const mcpPort = parseMcpPort();
       const reverseTunnel = this.createReverseTunnel(mcpPort, mcpPort, cfg);
       await reverseTunnel.open();
 
@@ -307,7 +319,7 @@ export abstract class RemoteTunnelAdapter<
     };
 
     try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
+      const mcpPort = parseMcpPort();
       const reverseTunnel = this.createReverseTunnel(mcpPort, mcpPort, cfg);
       await reverseTunnel.open();
 

--- a/packages/adapter-sdk/src/remote-tunnel-adapter.ts
+++ b/packages/adapter-sdk/src/remote-tunnel-adapter.ts
@@ -113,7 +113,7 @@ export abstract class RemoteTunnelAdapter<
    * Additional options merged into {@link startRemotePowerLine} during reconnect.
    * Override to supply adapter-specific options (e.g. `{ autoDetectWorkspace: true }`).
    */
-  protected reconnectBootstrapOptions(_config: TConfig): Record<string, unknown> {
+  protected reconnectBootstrapOptions(_config: TConfig): Partial<StartRemotePowerLineOptions> {
     return {};
   }
 
@@ -294,8 +294,8 @@ export abstract class RemoteTunnelAdapter<
     };
     const { alreadyRunning } = await this.runStartPowerLine(executor, powerlineToken, {
       extraEnv: cfg.env,
-      probeFirst: true,
       ...this.reconnectBootstrapOptions(cfg),
+      probeFirst: true,
     });
     if (!alreadyRunning) {
       yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };

--- a/packages/adapter-sdk/src/tunnel.ts
+++ b/packages/adapter-sdk/src/tunnel.ts
@@ -143,3 +143,40 @@ export abstract class ProcessTunnel implements RemoteTunnel {
     return this.process?.exitCode === null;
   }
 }
+
+// ─── Reverse Tunnel ──────────────────────────────────────────
+
+/** Delay for reverse tunnels to settle before checking readiness. */
+export const REVERSE_TUNNEL_SETTLE_MS: number = 3_000;
+
+/**
+ * Base class for reverse tunnels that bind a remote port to a local port.
+ *
+ * Reverse tunnels bind on the remote side, so local port probing doesn't work.
+ * Readiness is determined by a fixed delay followed by an exit-code check.
+ * Subclasses override `spawnArgs()` for the specific transport (SSH, gh CLI).
+ */
+export abstract class ProcessReverseTunnel extends ProcessTunnel {
+  protected readonly remotePort: number;
+  protected readonly sleepFn: (ms: number) => Promise<void>;
+
+  public constructor(
+    localPort: number,
+    remotePort: number,
+    sleepFn: (ms: number) => Promise<void>,
+    processFactory?: TunnelProcessFactory,
+    portProbe?: TunnelPortProbe,
+  ) {
+    super(localPort, undefined, processFactory, portProbe);
+    this.remotePort = remotePort;
+    this.sleepFn = sleepFn;
+  }
+
+  /** Wait for the reverse tunnel to establish by sleeping, then check for early exit. */
+  protected async waitForReady(): Promise<void> {
+    await this.sleepFn(REVERSE_TUNNEL_SETTLE_MS);
+    if (this.process?.exitCode !== null) {
+      throw new Error(`Reverse tunnel exited immediately with code ${this.process?.exitCode}`);
+    }
+  }
+}

--- a/packages/adapter-ssh/src/ssh.test.ts
+++ b/packages/adapter-ssh/src/ssh.test.ts
@@ -8,46 +8,50 @@ interface MockTunnelInstance {
   close: ReturnType<typeof vi.fn>;
 }
 
-const mocks = vi.hoisted(() => ({
-  closeTunnel: vi.fn().mockResolvedValue(undefined),
-  registerTunnel: vi.fn(),
-  findFreePort: vi.fn().mockResolvedValue(9999),
-  withFreePort: vi.fn(),
-  startRemotePowerLine: vi.fn().mockResolvedValue({ alreadyRunning: true }),
-  bootstrapPowerLine: vi.fn(),
-  tunnelInstances: [] as MockTunnelInstance[],
-  tunnelOpenCallCount: 0,
-  tunnelOpenFailOnCall: -1,
-}));
+const mocks: {
+  tunnelInstances: MockTunnelInstance[];
+  tunnelOpenCallCount: number;
+  tunnelOpenFailOnCall: number;
+  MockTunnelClass: new (localPort: number) => unknown;
+} = vi.hoisted(() => {
+  // Use a single object so the class closures and the test both mutate the same reference.
+  const m: {
+    tunnelInstances: MockTunnelInstance[];
+    tunnelOpenCallCount: number;
+    tunnelOpenFailOnCall: number;
+    MockTunnelClass: new (localPort: number) => unknown;
+  } = {
+    tunnelInstances: [],
+    tunnelOpenCallCount: 0,
+    tunnelOpenFailOnCall: -1,
+    MockTunnelClass: undefined!,
+  };
+
+  m.MockTunnelClass = class {
+    public localPort: number;
+    public close = vi.fn();
+    public open = vi.fn().mockImplementation(async () => {
+      m.tunnelOpenCallCount++;
+      if (m.tunnelOpenCallCount === m.tunnelOpenFailOnCall) {
+        throw new Error("tunnel open failed");
+      }
+    });
+    public isAlive = vi.fn().mockReturnValue(true);
+    public constructor(localPort: number) {
+      this.localPort = localPort;
+      m.tunnelInstances.push(this as unknown as MockTunnelInstance);
+    }
+  };
+
+  return m;
+});
 
 vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => {
   const original = await importOriginal<typeof import("@grackle-ai/adapter-sdk")>();
   return {
     ...original,
-    closeTunnel: mocks.closeTunnel,
-    registerTunnel: mocks.registerTunnel,
-    findFreePort: mocks.findFreePort,
-    withFreePort: mocks.withFreePort,
-    startRemotePowerLine: mocks.startRemotePowerLine,
-    bootstrapPowerLine: async function* () {
-      yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
-    },
-    // Stub ProcessTunnel so SshTunnel doesn't spawn real processes (tested in tunnel.test.ts)
-    ProcessTunnel: class {
-      public localPort: number;
-      public close = vi.fn();
-      public open = vi.fn().mockImplementation(async () => {
-        mocks.tunnelOpenCallCount++;
-        if (mocks.tunnelOpenCallCount === mocks.tunnelOpenFailOnCall) {
-          throw new Error("tunnel open failed");
-        }
-      });
-      public isAlive = vi.fn().mockReturnValue(true);
-      public constructor(localPort: number) {
-        this.localPort = localPort;
-        mocks.tunnelInstances.push(this as unknown as MockTunnelInstance);
-      }
-    },
+    ProcessTunnel: mocks.MockTunnelClass,
+    ProcessReverseTunnel: mocks.MockTunnelClass,
   };
 });
 
@@ -67,10 +71,48 @@ async function collectEvents(gen: AsyncGenerator<ProvisionEvent>): Promise<Provi
   return events;
 }
 
+/** Set up standard spies on the adapter's SDK wrapper methods. */
+function setupAdapterSpies(adapter: SshAdapter): {
+  runBootstrap: ReturnType<typeof vi.fn>;
+  runStartPowerLine: ReturnType<typeof vi.fn>;
+  openWithFreePort: ReturnType<typeof vi.fn>;
+  closeTunnelForEnvironment: ReturnType<typeof vi.fn>;
+  registerTunnelForEnvironment: ReturnType<typeof vi.fn>;
+} {
+  const obj = adapter as unknown as Record<string, unknown>;
+  const runBootstrap = vi
+    .spyOn(obj, "runBootstrap")
+    .mockImplementation(async function* (): AsyncGenerator<ProvisionEvent> {
+      yield { stage: "bootstrapping", message: "mock", progress: 0.5 };
+    });
+  const runStartPowerLine = vi
+    .spyOn(obj, "runStartPowerLine")
+    .mockResolvedValue({ alreadyRunning: true });
+  const openWithFreePort = vi
+    .spyOn(obj, "openWithFreePort")
+    .mockImplementation(async (action: (port: number) => Promise<unknown>) => action(9999));
+  const closeTunnelForEnvironment = vi
+    .spyOn(obj, "closeTunnelForEnvironment")
+    .mockResolvedValue(undefined);
+  const registerTunnelForEnvironment = vi
+    .spyOn(obj, "registerTunnelForEnvironment")
+    .mockImplementation(() => {});
+  return {
+    runBootstrap: runBootstrap as unknown as ReturnType<typeof vi.fn>,
+    runStartPowerLine: runStartPowerLine as unknown as ReturnType<typeof vi.fn>,
+    openWithFreePort: openWithFreePort as unknown as ReturnType<typeof vi.fn>,
+    closeTunnelForEnvironment: closeTunnelForEnvironment as unknown as ReturnType<typeof vi.fn>,
+    registerTunnelForEnvironment: registerTunnelForEnvironment as unknown as ReturnType<
+      typeof vi.fn
+    >,
+  };
+}
+
 // ── Tests ───────────────────────────────────────────────────
 
 describe("SshAdapter.reconnect()", () => {
   let adapter: SshAdapter;
+  let spies: ReturnType<typeof setupAdapterSpies>;
   const config = { host: "example.com" };
   const token = "test-token";
   const envId = "env-ssh-1";
@@ -80,14 +122,11 @@ describe("SshAdapter.reconnect()", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
-    mocks.startRemotePowerLine.mockResolvedValue({ alreadyRunning: true });
-    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
-      action(9999),
-    );
     adapter = new SshAdapter({
       exec: mockExec,
       sleep: mockSleep,
     });
+    spies = setupAdapterSpies(adapter);
   });
 
   it("yields reconnecting progress events on happy path", async () => {
@@ -97,19 +136,19 @@ describe("SshAdapter.reconnect()", () => {
 
     expect(events.length).toBeGreaterThanOrEqual(3);
     expect(events.every((e) => e.stage === "reconnecting")).toBe(true);
-    expect(events[events.length - 1].message).toContain("Reconnected");
+    expect(events[events.length - 1]!.message).toContain("Reconnected");
   });
 
   it("closes stale tunnel, calls startRemotePowerLine with probeFirst, and opens new tunnel", async () => {
     await collectEvents(adapter.reconnect!(envId, config as Record<string, unknown>, token));
 
-    expect(mocks.closeTunnel).toHaveBeenCalledWith(envId);
-    expect(mocks.startRemotePowerLine).toHaveBeenCalledOnce();
+    expect(spies.closeTunnelForEnvironment).toHaveBeenCalledWith(envId);
+    expect(spies.runStartPowerLine).toHaveBeenCalledOnce();
     // Verify probeFirst option (SSH adapter does NOT set autoDetectWorkspace)
-    const options = mocks.startRemotePowerLine.mock.calls[0][2];
+    const options = spies.runStartPowerLine.mock.calls[0]![2];
     expect(options).toMatchObject({ probeFirst: true });
     expect(options.autoDetectWorkspace).toBeUndefined();
-    expect(mocks.registerTunnel).toHaveBeenCalledWith(
+    expect(spies.registerTunnelForEnvironment).toHaveBeenCalledWith(
       envId,
       expect.objectContaining({
         tunnel: expect.objectContaining({ localPort: 9999 }),
@@ -118,18 +157,18 @@ describe("SshAdapter.reconnect()", () => {
   });
 
   it("yields 'restarted' event when PowerLine was not already running", async () => {
-    mocks.startRemotePowerLine.mockResolvedValueOnce({ alreadyRunning: false });
+    spies.runStartPowerLine.mockResolvedValueOnce({ alreadyRunning: false });
 
     const events = await collectEvents(
       adapter.reconnect!(envId, config as Record<string, unknown>, token),
     );
 
     expect(events.some((e) => e.message.includes("restarted"))).toBe(true);
-    expect(events[events.length - 1].message).toContain("Reconnected");
+    expect(events[events.length - 1]!.message).toContain("Reconnected");
   });
 
   it("does not yield 'restarted' event when PowerLine was already running", async () => {
-    mocks.startRemotePowerLine.mockResolvedValueOnce({ alreadyRunning: true });
+    spies.runStartPowerLine.mockResolvedValueOnce({ alreadyRunning: true });
 
     const events = await collectEvents(
       adapter.reconnect!(envId, config as Record<string, unknown>, token),
@@ -139,7 +178,7 @@ describe("SshAdapter.reconnect()", () => {
   });
 
   it("propagates error when startRemotePowerLine fails", async () => {
-    mocks.startRemotePowerLine.mockRejectedValueOnce(
+    spies.runStartPowerLine.mockRejectedValueOnce(
       new Error("PowerLine process died immediately after starting"),
     );
 
@@ -149,7 +188,7 @@ describe("SshAdapter.reconnect()", () => {
   });
 
   it("propagates error when SSH is unreachable", async () => {
-    mocks.startRemotePowerLine.mockRejectedValueOnce(new Error("ssh connection refused"));
+    spies.runStartPowerLine.mockRejectedValueOnce(new Error("ssh connection refused"));
 
     await expect(
       collectEvents(adapter.reconnect!(envId, config as Record<string, unknown>, token)),
@@ -166,7 +205,7 @@ describe("SshAdapter.reconnect()", () => {
     const cfgWithEnv = { host: "example.com", env: { MY_VAR: "value" } };
     await collectEvents(adapter.reconnect!(envId, cfgWithEnv as Record<string, unknown>, token));
 
-    const options = mocks.startRemotePowerLine.mock.calls[0][2];
+    const options = spies.runStartPowerLine.mock.calls[0]![2];
     expect(options.extraEnv).toEqual({ MY_VAR: "value" });
   });
 
@@ -179,7 +218,7 @@ describe("SshAdapter.reconnect()", () => {
 
     expect(mocks.tunnelInstances).toHaveLength(2);
     expect(mocks.tunnelInstances[0]!.close).toHaveBeenCalledOnce();
-    expect(mocks.registerTunnel).not.toHaveBeenCalled();
+    expect(spies.registerTunnelForEnvironment).not.toHaveBeenCalled();
   });
 });
 
@@ -187,6 +226,7 @@ describe("SshAdapter.reconnect()", () => {
 
 describe("SshAdapter.provision() — tunnel cleanup", () => {
   let adapter: SshAdapter;
+  let spies: ReturnType<typeof setupAdapterSpies>;
   const config = { host: "example.com" };
   const token = "test-token";
   const envId = "env-ssh-1";
@@ -196,13 +236,11 @@ describe("SshAdapter.provision() — tunnel cleanup", () => {
     mocks.tunnelInstances.length = 0;
     mocks.tunnelOpenCallCount = 0;
     mocks.tunnelOpenFailOnCall = -1;
-    mocks.withFreePort.mockImplementation(async (action: (port: number) => Promise<unknown>) =>
-      action(9999),
-    );
     adapter = new SshAdapter({
       exec: mockExec,
       sleep: mockSleep,
     });
+    spies = setupAdapterSpies(adapter);
   });
 
   it("closes forward tunnel when reverse tunnel open() fails", async () => {
@@ -214,6 +252,6 @@ describe("SshAdapter.provision() — tunnel cleanup", () => {
 
     expect(mocks.tunnelInstances).toHaveLength(2);
     expect(mocks.tunnelInstances[0]!.close).toHaveBeenCalledOnce();
-    expect(mocks.registerTunnel).not.toHaveBeenCalled();
+    expect(spies.registerTunnelForEnvironment).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapter-ssh/src/ssh.ts
+++ b/packages/adapter-ssh/src/ssh.ts
@@ -1,42 +1,21 @@
-import type {
-  BaseEnvironmentConfig,
-  PowerLineConnection,
-  ProvisionEvent,
-  AdapterDependencies,
-  ExecFunction,
-} from "@grackle-ai/adapter-sdk";
-import { DEFAULT_POWERLINE_PORT, DEFAULT_MCP_PORT } from "@grackle-ai/common";
+import type { RemoteTunnelConfig, RemoteTunnelMeta, ExecFunction } from "@grackle-ai/adapter-sdk";
+import { DEFAULT_POWERLINE_PORT } from "@grackle-ai/common";
 import {
-  BaseAdapter,
+  RemoteTunnelAdapter,
   type RemoteExecutor,
   type TunnelProcessFactory,
   type TunnelPortProbe,
   ProcessTunnel,
-  bootstrapPowerLine,
-  connectThroughTunnel,
-  registerTunnel,
-  getTunnel,
-  closeTunnel,
-  withFreePort,
-  remoteStop,
-  remoteDestroy,
-  remoteHealthCheck,
-  startRemotePowerLine,
-  exec as defaultExec,
-  sleep as defaultSleep,
-  SSH_CONNECTIVITY_TIMEOUT_MS,
+  ProcessReverseTunnel,
   REMOTE_EXEC_DEFAULT_TIMEOUT_MS,
 } from "@grackle-ai/adapter-sdk";
 
 const REMOTE_COPY_TIMEOUT_MS: number = 120_000;
 
-/** Delay for reverse tunnels to wait for SSH to establish. */
-const REVERSE_TUNNEL_SETTLE_MS: number = 3_000;
-
 // ─── Config ─────────────────────────────────────────────────
 
 /** SSH-specific environment configuration. */
-export interface SshEnvironmentConfig extends BaseEnvironmentConfig {
+export interface SshEnvironmentConfig extends RemoteTunnelConfig {
   /** Remote hostname or IP address (required). */
   host: string;
   /** SSH username (defaults to the current OS user). */
@@ -47,10 +26,6 @@ export interface SshEnvironmentConfig extends BaseEnvironmentConfig {
   identityFile?: string;
   /** Extra SSH options passed as `-o Key=Value`. */
   sshOptions?: Record<string, string>;
-  /** Override the local tunnel port (otherwise a free port is chosen). */
-  localPort?: number;
-  /** Additional environment variables forwarded to the remote PowerLine. */
-  env?: Record<string, string>;
 }
 
 // ─── SSH Helpers ────────────────────────────────────────────
@@ -148,10 +123,8 @@ class SshTunnel extends ProcessTunnel {
  * Reverse SSH tunnel: binds a port on the remote host that tunnels back to a local port.
  * Used so agents (running on the remote host) can reach the Grackle MCP server (on the host).
  */
-class SshReverseTunnel extends ProcessTunnel {
+class SshReverseTunnel extends ProcessReverseTunnel {
   private readonly cfg: SshEnvironmentConfig;
-  private readonly remotePort: number;
-  private readonly sleepFn: (ms: number) => Promise<void>;
 
   public constructor(
     localPort: number,
@@ -161,10 +134,8 @@ class SshReverseTunnel extends ProcessTunnel {
     processFactory?: TunnelProcessFactory,
     portProbe?: TunnelPortProbe,
   ) {
-    super(localPort, undefined, processFactory, portProbe);
+    super(localPort, remotePort, sleepFn, processFactory, portProbe);
     this.cfg = cfg;
-    this.remotePort = remotePort;
-    this.sleepFn = sleepFn;
   }
 
   /** Return the ssh command with -R for reverse port forwarding. */
@@ -185,215 +156,42 @@ class SshReverseTunnel extends ProcessTunnel {
     ];
     return { command: "ssh", args };
   }
-
-  /**
-   * Reverse tunnels bind on the remote side, not locally.
-   * We can't probe the remote port, so wait a fixed delay for SSH to establish.
-   */
-  protected async waitForReady(): Promise<void> {
-    await this.sleepFn(REVERSE_TUNNEL_SETTLE_MS);
-    if (this.process?.exitCode !== null) {
-      throw new Error(`Reverse tunnel exited immediately with code ${this.process?.exitCode}`);
-    }
-  }
 }
 
 // ─── Adapter ────────────────────────────────────────────────
 
 /** Environment adapter that provisions and manages remote environments via SSH. */
-export class SshAdapter extends BaseAdapter {
+export class SshAdapter extends RemoteTunnelAdapter<SshEnvironmentConfig> {
   public type: string = "ssh";
-  private readonly execFn: ExecFunction;
-  private readonly sleepFn: (ms: number) => Promise<void>;
-  private readonly isGitHubProviderEnabled: () => boolean;
 
-  public constructor(deps: AdapterDependencies = {}) {
-    super();
-    this.execFn = deps.exec ?? defaultExec;
-    this.sleepFn = deps.sleep ?? defaultSleep;
-    this.isGitHubProviderEnabled = deps.isGitHubProviderEnabled ?? (() => false);
-  }
-
-  /** Provision the remote host: test connectivity, bootstrap PowerLine, open tunnel. */
-  protected async *doProvision(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
+  /** Validate and parse the raw config into typed SSH configuration. */
+  protected resolveConfig(config: Record<string, unknown>): {
+    config: SshEnvironmentConfig;
+    meta: RemoteTunnelMeta;
+  } {
     const cfg = config as unknown as SshEnvironmentConfig;
     if (!cfg.host) {
       throw new Error("SSH adapter requires a 'host' in the configuration");
     }
-
-    const executor = new SshExecutor(cfg, this.execFn);
-
-    // Test SSH connectivity
-    yield {
-      stage: "connecting",
-      message: `Testing SSH connectivity to ${cfg.host}...`,
-      progress: 0.05,
-    };
-    try {
-      await executor.exec("echo ok", { timeout: SSH_CONNECTIVITY_TIMEOUT_MS });
-    } catch (err) {
-      throw new Error(
-        `Cannot reach ${cfg.host} via SSH: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-
-    // Bootstrap PowerLine on the remote host
-    yield* bootstrapPowerLine(executor, powerlineToken, {
-      extraEnv: cfg.env,
-      isGitHubProviderEnabled: this.isGitHubProviderEnabled,
-      defaultRuntime: (config.defaultRuntime as string) || undefined,
-    });
-
-    // Open SSH tunnel (retry with a fresh port on TOCTOU conflict, #1486)
-    const openTunnel = async (port: number): Promise<{ port: number; tunnel: SshTunnel }> => {
-      const t = new SshTunnel(port, cfg);
-      await t.open();
-      return { port, tunnel: t };
-    };
-
-    const { port: localPort, tunnel } = cfg.localPort
-      ? await openTunnel(cfg.localPort)
-      : await withFreePort(openTunnel);
-
-    yield {
-      stage: "tunneling",
-      message: `Opening SSH tunnel on local port ${localPort}...`,
-      progress: 0.8,
-    };
-
-    // Open reverse tunnel (remote → host MCP server) for agent tool calls.
-    // Wrap in try/catch so the forward tunnel is cleaned up if the reverse fails.
-    try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
-      const reverseTunnel = new SshReverseTunnel(mcpPort, mcpPort, cfg, this.sleepFn);
-      await reverseTunnel.open();
-
-      registerTunnel(environmentId, { tunnel, reverseTunnel });
-    } catch (err) {
-      await tunnel.close();
-      throw err;
-    }
-
-    yield {
-      stage: "connecting",
-      message: `Tunnel open, connecting on port ${localPort}...`,
-      progress: 0.9,
-    };
+    return { config: cfg, meta: { displayTarget: cfg.host } };
   }
 
-  /**
-   * Attempt fast reconnect: probe PowerLine, restart if needed, re-open tunnel.
-   *
-   * Any failure (SSH unreachable, PowerLine won't start, tunnel error) throws
-   * and falls through to the caller, which should trigger a full provision.
-   *
-   * Minimizes SSH round trips — probe and conditional restart run in a single
-   * SSH call via `startRemotePowerLine({ probeFirst: true })`.
-   */
-  public async *reconnect(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
-    yield* this.withProvisionLock(
-      environmentId,
-      this.doReconnect(environmentId, config, powerlineToken),
-    );
+  /** Create an SSH executor for remote command execution. */
+  protected createExecutor(cfg: SshEnvironmentConfig): RemoteExecutor {
+    return new SshExecutor(cfg, this.execFn);
   }
 
-  private async *doReconnect(
-    environmentId: string,
-    config: Record<string, unknown>,
-    powerlineToken: string,
-  ): AsyncGenerator<ProvisionEvent> {
-    const cfg = config as unknown as SshEnvironmentConfig;
-    if (!cfg.host) {
-      throw new Error("SSH adapter requires a 'host' in the configuration");
-    }
-
-    const executor = new SshExecutor(cfg, this.execFn);
-
-    // 1. Close any stale tunnel
-    yield { stage: "reconnecting", message: "Closing stale tunnel...", progress: 0.1 };
-    await closeTunnel(environmentId);
-
-    // 2. Probe + conditional restart in a single SSH call.
-    yield { stage: "reconnecting", message: `Checking PowerLine on ${cfg.host}...`, progress: 0.3 };
-    const { alreadyRunning } = await startRemotePowerLine(executor, powerlineToken, {
-      extraEnv: cfg.env,
-      probeFirst: true,
-    });
-    if (!alreadyRunning) {
-      yield { stage: "reconnecting", message: "PowerLine restarted", progress: 0.5 };
-    }
-
-    // 3. Open new SSH tunnel + reverse tunnel for MCP (retry on port conflict, #1486)
-    const openTunnel = async (port: number): Promise<{ port: number; tunnel: SshTunnel }> => {
-      const t = new SshTunnel(port, cfg);
-      await t.open();
-      return { port, tunnel: t };
-    };
-
-    const { port: localPort, tunnel } = cfg.localPort
-      ? await openTunnel(cfg.localPort)
-      : await withFreePort(openTunnel);
-
-    yield {
-      stage: "reconnecting",
-      message: `Opening SSH tunnel on local port ${localPort}...`,
-      progress: 0.7,
-    };
-
-    try {
-      const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
-      const reverseTunnel = new SshReverseTunnel(mcpPort, mcpPort, cfg, this.sleepFn);
-      await reverseTunnel.open();
-
-      registerTunnel(environmentId, { tunnel, reverseTunnel });
-    } catch (err) {
-      await tunnel.close();
-      throw err;
-    }
-
-    yield { stage: "reconnecting", message: "Reconnected via SSH", progress: 0.9 };
+  /** Create an SSH forward tunnel (local port → remote PowerLine). */
+  protected createForwardTunnel(localPort: number, cfg: SshEnvironmentConfig): ProcessTunnel {
+    return new SshTunnel(localPort, cfg);
   }
 
-  /** Connect to the PowerLine through the SSH tunnel. */
-  protected async doConnect(
-    environmentId: string,
-    _config: Record<string, unknown>,
-    powerlineToken: string,
-  ): Promise<PowerLineConnection> {
-    const state = getTunnel(environmentId);
-    if (!state) {
-      throw new Error(`No tunnel registered for environment ${environmentId}`);
-    }
-    return connectThroughTunnel(environmentId, state.tunnel.localPort, powerlineToken);
-  }
-
-  /** Close the SSH tunnel without stopping the remote PowerLine. */
-  protected async doDisconnect(environmentId: string): Promise<void> {
-    await closeTunnel(environmentId);
-  }
-
-  /** Stop the remote PowerLine process and close the tunnel. */
-  protected async doStop(environmentId: string, config: Record<string, unknown>): Promise<void> {
-    const cfg = config as unknown as SshEnvironmentConfig;
-    await remoteStop(environmentId, new SshExecutor(cfg, this.execFn));
-  }
-
-  /** Stop the remote PowerLine, remove artifacts, and close the tunnel. */
-  protected async doDestroy(environmentId: string, config: Record<string, unknown>): Promise<void> {
-    const cfg = config as unknown as SshEnvironmentConfig;
-    await remoteDestroy(environmentId, new SshExecutor(cfg, this.execFn));
-  }
-
-  /** Check that the tunnel is alive and the PowerLine responds to a ping. */
-  public async healthCheck(connection: PowerLineConnection): Promise<boolean> {
-    return remoteHealthCheck(connection);
+  /** Create an SSH reverse tunnel (remote → local MCP). */
+  protected createReverseTunnel(
+    localPort: number,
+    remotePort: number,
+    cfg: SshEnvironmentConfig,
+  ): ProcessTunnel {
+    return new SshReverseTunnel(localPort, remotePort, cfg, this.sleepFn);
   }
 }


### PR DESCRIPTION
## Summary
- Extract `RemoteTunnelAdapter<TConfig>` base class in `adapter-sdk` that implements the full provision/reconnect/connect/disconnect/stop/destroy/healthCheck lifecycle once — eliminating ~95% code duplication between SSH and Codespace adapters
- Extract `ProcessReverseTunnel` base class for the shared reverse tunnel pattern (identical `waitForReady()` + `remotePort` + `sleepFn`)
- SSH adapter shrinks from 399 → 200 lines, Codespace from 471 → 268 lines; both become thin subclasses providing only 4 transport-specific factory methods

## Test plan
- [x] New `remote-tunnel-adapter.test.ts` covers shared lifecycle (provision, reconnect, error handling, tunnel cleanup, hooks)
- [x] Existing SSH adapter tests pass with updated mock pattern
- [x] Existing Codespace adapter tests pass (including CodespaceNotFoundError detection)
- [x] Full `rush build` succeeds with no warnings
- [x] API extractor reports regenerated (public API change — new exports)

Closes #1473