### PR TITLE
Catalog-driven runtime registration in PowerLine (#1466)

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -22,6 +22,19 @@ type AcknowledgeEscalationRequest = Message<"grackle.AcknowledgeEscalationReques
 const AcknowledgeEscalationRequestSchema: GenMessage<AcknowledgeEscalationRequest>;
 
 // @public
+export interface AcpRuntimeFactory {
+    config: AcpRuntimeFactoryConfig;
+    type: "acp";
+}
+
+// @public
+export interface AcpRuntimeFactoryConfig {
+    args: string[];
+    command: string;
+    isolateClaudeConfig?: boolean;
+}
+
+// @public
 export type AdapterType = "docker" | "local" | "codespace" | "ssh";
 
 // @public
@@ -2731,9 +2744,13 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>>;
 export interface RuntimeCatalogEntry {
     description: string;
     displayName: string;
+    factory?: RuntimeFactoryDescriptor;
     install?: RuntimePackageManifest;
     models: RuntimeModelInfo[];
 }
+
+// @public
+export type RuntimeFactoryDescriptor = SdkRuntimeFactory | AcpRuntimeFactory;
 
 // @public
 type RuntimeInfo = Message<"grackle.RuntimeInfo"> & {
@@ -2820,6 +2837,13 @@ export function scheduleRowToProto(row: ScheduleRowShape): Schedule;
 
 // @public
 const ScheduleSchema: GenMessage<Schedule>;
+
+// @public
+export interface SdkRuntimeFactory {
+    exportName: string;
+    package: string;
+    type: "sdk";
+}
 
 // @public
 type SearchComponentResult = Message<"grackle.SearchComponentResult"> & {

--- a/common/changes/@grackle-ai/cli/nick-pape-1466-dynamic-runtime-registration_2026-06-05-01-37.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1466-dynamic-runtime-registration_2026-06-05-01-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Replace hardcoded runtime registration in PowerLine with catalog-driven dynamic loading",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,9 +12,13 @@ export * from "./component-render-tool.js";
 export * from "./component-refs.js";
 export { RUNTIME_CATALOG } from "./runtime-catalog.js";
 export type {
+  AcpRuntimeFactory,
+  AcpRuntimeFactoryConfig,
   RuntimeCatalogEntry,
+  RuntimeFactoryDescriptor,
   RuntimeModelInfo,
   RuntimePackageManifest,
+  SdkRuntimeFactory,
 } from "./runtime-catalog.js";
 export { SequencedLog } from "./sequenced-log.js";
 export type { Sequenced, LogSink, SequencedLogOptions } from "./sequenced-log.js";

--- a/packages/common/src/runtime-catalog.ts
+++ b/packages/common/src/runtime-catalog.ts
@@ -30,6 +30,47 @@ export interface RuntimeModelInfo {
   provider: string;
 }
 
+// ─── Factory Descriptors ───────────────────────────────────
+// Describe how to instantiate a runtime. PowerLine's runtime-loader reads
+// these to dynamically import and construct each runtime — no hardcoded
+// imports or registration calls.
+
+/** Import a class from a workspace/npm package and call `new Class()`. */
+export interface SdkRuntimeFactory {
+  /** Discriminant. */
+  type: "sdk";
+  /** npm package name to import (e.g. `"@grackle-ai/runtime-claude-code"`). */
+  package: string;
+  /** Named export of the runtime class (e.g. `"ClaudeCodeRuntime"`). */
+  exportName: string;
+}
+
+/** Serializable ACP agent config (no `name` — the catalog key IS the name). */
+export interface AcpRuntimeFactoryConfig {
+  /** CLI command to spawn (e.g. `"goose"`, `"claude-agent-acp"`). */
+  command: string;
+  /** CLI arguments. */
+  args: string[];
+  /** Isolate `~/.claude` config for headless agents. */
+  isolateClaudeConfig?: boolean;
+}
+
+/** Import `AcpRuntime` from `@grackle-ai/runtime-acp` and pass config. */
+export interface AcpRuntimeFactory {
+  /** Discriminant. */
+  type: "acp";
+  /** ACP agent config passed to `new AcpRuntime({ name, ...config })`. */
+  config: AcpRuntimeFactoryConfig;
+}
+
+/**
+ * Discriminated union describing how to instantiate a runtime.
+ *
+ * - `"sdk"` — import a class from a workspace package, call `new Class()`
+ * - `"acp"` — import `AcpRuntime`, pass per-agent config
+ */
+export type RuntimeFactoryDescriptor = SdkRuntimeFactory | AcpRuntimeFactory;
+
 /**
  * A single runtime in the catalog. Mirrors AHP `AgentInfo` (presentation +
  * models); `install` is the lazy-install spec (absent for built-in/test
@@ -44,6 +85,8 @@ export interface RuntimeCatalogEntry {
   models: RuntimeModelInfo[];
   /** npm packages to lazily install for this runtime; omitted for built-ins. */
   install?: RuntimePackageManifest;
+  /** How to instantiate this runtime; absent for local-only runtimes (stubs). */
+  factory?: RuntimeFactoryDescriptor;
 }
 
 /**
@@ -60,6 +103,11 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>> = {
       { id: "haiku", name: "Claude Haiku", provider: "claude-code" },
     ],
     install: { packages: { "@anthropic-ai/claude-agent-sdk": "^0.3.0" } },
+    factory: {
+      type: "sdk",
+      package: "@grackle-ai/runtime-claude-code",
+      exportName: "ClaudeCodeRuntime",
+    },
   },
   copilot: {
     displayName: "GitHub Copilot",
@@ -69,18 +117,21 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>> = {
       packages: { "@github/copilot-sdk": "^1.0.0", "@github/copilot": "^1.0.43" },
       needsJsonRpcHook: true,
     },
+    factory: { type: "sdk", package: "@grackle-ai/runtime-copilot", exportName: "CopilotRuntime" },
   },
   codex: {
     displayName: "Codex",
     description: "OpenAI Codex via the Codex SDK.",
     models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "codex" }],
     install: { packages: { "@openai/codex-sdk": "^0.136.0" } },
+    factory: { type: "sdk", package: "@grackle-ai/runtime-codex", exportName: "CodexRuntime" },
   },
   goose: {
     displayName: "Goose",
     description: "Block Goose via the Agent Client Protocol (experimental).",
     models: [],
     install: { packages: { "@agentclientprotocol/sdk": "^0.24.0" } },
+    factory: { type: "acp", config: { command: "goose", args: ["acp"] } },
   },
   "codex-acp": {
     displayName: "Codex (ACP)",
@@ -89,12 +140,14 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>> = {
     install: {
       packages: { "@agentclientprotocol/sdk": "^0.24.0", "@zed-industries/codex-acp": "^0.15.0" },
     },
+    factory: { type: "acp", config: { command: "codex-acp", args: [] } },
   },
   "copilot-acp": {
     displayName: "Copilot (ACP)",
     description: "GitHub Copilot via the Agent Client Protocol (experimental).",
     models: [],
     install: { packages: { "@agentclientprotocol/sdk": "^0.24.0", "@github/copilot": "^1.0.43" } },
+    factory: { type: "acp", config: { command: "copilot", args: ["--acp", "--stdio"] } },
   },
   "claude-code-acp": {
     displayName: "Claude Code (ACP)",
@@ -106,12 +159,21 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>> = {
         "@zed-industries/claude-agent-acp": "^0.23.0",
       },
     },
+    factory: {
+      type: "acp",
+      config: { command: "claude-agent-acp", args: [], isolateClaudeConfig: true },
+    },
   },
   genaiscript: {
     displayName: "GenAIScript",
     description: "GenAIScript CLI scripting runtime.",
     models: [],
     install: { packages: { genaiscript: "^2.5.1" } },
+    factory: {
+      type: "sdk",
+      package: "@grackle-ai/runtime-genaiscript",
+      exportName: "GenAIScriptRuntime",
+    },
   },
   stub: {
     displayName: "Stub",

--- a/packages/powerline/src/index.ts
+++ b/packages/powerline/src/index.ts
@@ -4,14 +4,10 @@ import { mountAhpServer } from "./ahp-handlers.js";
 import { registerRuntime } from "./runtime-registry.js";
 import { StubRuntime } from "./runtimes/stub.js";
 import { StubMcpRuntime } from "./runtimes/stub-mcp.js";
-import { GenAIScriptRuntime } from "@grackle-ai/runtime-genaiscript";
-import { ClaudeCodeRuntime } from "@grackle-ai/runtime-claude-code";
-import { CopilotRuntime } from "@grackle-ai/runtime-copilot";
-import { CodexRuntime } from "@grackle-ai/runtime-codex";
-import { AcpRuntime } from "@grackle-ai/runtime-acp";
 import { DEFAULT_POWERLINE_PORT } from "@grackle-ai/common";
 import { createRequire } from "node:module";
 import { logger } from "./logger.js";
+import { loadRuntimesFromCatalog } from "./runtime-loader.js";
 
 const esmRequire: NodeRequire = createRequire(import.meta.url);
 const { version } = esmRequire("../package.json") as { version: string };
@@ -22,7 +18,7 @@ const { version } = esmRequire("../package.json") as { version: string };
 // a Claude Code session (e.g. during development or local testing).
 delete process.env.CLAUDECODE;
 
-function main(): void {
+async function main(): Promise<void> {
   const program = new Command();
 
   program
@@ -33,7 +29,7 @@ function main(): void {
     .option("--token <token>", "Authentication token")
     .option("--no-auth", "Run without authentication (development only)")
     .option("--host <host>", "Host to bind to", "127.0.0.1")
-    .action((opts: { port: string; token?: string; auth: boolean; host: string }) => {
+    .action(async (opts: { port: string; token?: string; auth: boolean; host: string }) => {
       const port = parseInt(opts.port, 10);
       const host = opts.host;
       const powerlineToken = opts.auth
@@ -48,28 +44,12 @@ function main(): void {
         return;
       }
 
-      // Register runtimes
+      // Register stubs (PowerLine-internal test runtimes, no catalog factory).
       registerRuntime(new StubRuntime());
       registerRuntime(new StubMcpRuntime());
-      registerRuntime(new GenAIScriptRuntime());
-      registerRuntime(new ClaudeCodeRuntime());
-      registerRuntime(new CopilotRuntime());
-      registerRuntime(new CodexRuntime());
-      registerRuntime(new AcpRuntime({ name: "goose", command: "goose", args: ["acp"] }));
-      registerRuntime(new AcpRuntime({ name: "codex-acp", command: "codex-acp", args: [] }));
-      registerRuntime(
-        new AcpRuntime({ name: "copilot-acp", command: "copilot", args: ["--acp", "--stdio"] }),
-      );
-      registerRuntime(
-        new AcpRuntime({
-          name: "claude-code-acp",
-          command: "claude-agent-acp",
-          args: [],
-          // Isolate from ~/.claude so interactive-only settings (e.g.
-          // permissions.defaultMode "auto") don't crash session/new (#1366).
-          isolateClaudeConfig: true,
-        }),
-      );
+
+      // Register production runtimes from the catalog.
+      await loadRuntimesFromCatalog();
 
       // HR8d: PowerLine speaks AHP JSON-RPC over WebSocket (not gRPC).
       // AhpServerSocket handles the HTTP upgrade and Bearer-token auth.
@@ -132,7 +112,10 @@ function main(): void {
       process.on("SIGTERM", shutdown);
     });
 
-  program.parse();
+  await program.parseAsync();
 }
 
-main();
+main().catch((err: unknown) => {
+  logger.fatal({ err }, "PowerLine failed to start");
+  process.exitCode = 1;
+});

--- a/packages/powerline/src/runtime-loader.test.ts
+++ b/packages/powerline/src/runtime-loader.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import type { AgentRuntime } from "@grackle-ai/runtime-sdk";
+import type { RuntimeCatalogEntry } from "@grackle-ai/common";
+
+function makeMockRuntime(name: string): AgentRuntime {
+  return {
+    name,
+    spawn: () => {
+      throw new Error("not implemented");
+    },
+    resume: () => {
+      throw new Error("not implemented");
+    },
+  };
+}
+
+class FakeSdkRuntime implements AgentRuntime {
+  public name: string = "fake-sdk";
+  public spawn = vi.fn();
+  public resume = vi.fn();
+}
+
+class FakeAcpRuntime implements AgentRuntime {
+  public name: string;
+  public spawn = vi.fn();
+  public resume = vi.fn();
+  public constructor(config: { name: string; command: string; args: string[] }) {
+    this.name = config.name;
+  }
+}
+
+const mockRegisterRuntime = vi.fn();
+const mockListRuntimes = vi.fn<() => string[]>().mockReturnValue([]);
+
+vi.mock("./runtime-registry.js", () => ({
+  registerRuntime: (...args: unknown[]) => mockRegisterRuntime(...args),
+  listRuntimes: () => mockListRuntimes(),
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+let mockCatalog: Record<string, RuntimeCatalogEntry> = {};
+
+vi.mock("@grackle-ai/common", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    get RUNTIME_CATALOG() {
+      return mockCatalog;
+    },
+  };
+});
+
+vi.mock("@grackle-ai/runtime-claude-code", () => ({
+  ClaudeCodeRuntime: FakeSdkRuntime,
+}));
+
+vi.mock("@grackle-ai/runtime-acp", () => ({
+  AcpRuntime: FakeAcpRuntime,
+}));
+
+// Must import AFTER vi.mock declarations
+const { loadRuntimesFromCatalog } = await import("./runtime-loader.js");
+const { logger } = await import("./logger.js");
+
+describe("loadRuntimesFromCatalog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCatalog = {};
+    mockListRuntimes.mockReturnValue([]);
+  });
+
+  it("registers an SDK runtime from catalog", async () => {
+    mockCatalog = {
+      "claude-code": {
+        displayName: "Claude Code",
+        description: "test",
+        models: [],
+        factory: {
+          type: "sdk",
+          package: "@grackle-ai/runtime-claude-code",
+          exportName: "ClaudeCodeRuntime",
+        },
+      },
+    };
+    mockListRuntimes.mockReturnValue(["claude-code"]);
+
+    await loadRuntimesFromCatalog();
+
+    expect(mockRegisterRuntime).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterRuntime.mock.calls[0]![0] as AgentRuntime;
+    expect(registered).toBeInstanceOf(FakeSdkRuntime);
+  });
+
+  it("registers an ACP runtime from catalog with injected name", async () => {
+    mockCatalog = {
+      goose: {
+        displayName: "Goose",
+        description: "test",
+        models: [],
+        factory: {
+          type: "acp",
+          config: { command: "goose", args: ["acp"] },
+        },
+      },
+    };
+    mockListRuntimes.mockReturnValue(["goose"]);
+
+    await loadRuntimesFromCatalog();
+
+    expect(mockRegisterRuntime).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterRuntime.mock.calls[0]![0] as FakeAcpRuntime;
+    expect(registered).toBeInstanceOf(FakeAcpRuntime);
+    expect(registered.name).toBe("goose");
+  });
+
+  it("skips entries without a factory descriptor", async () => {
+    mockCatalog = {
+      stub: {
+        displayName: "Stub",
+        description: "test",
+        models: [],
+      },
+    };
+
+    await loadRuntimesFromCatalog();
+
+    expect(mockRegisterRuntime).not.toHaveBeenCalled();
+  });
+
+  it("skips entries excluded by filter", async () => {
+    mockCatalog = {
+      "claude-code": {
+        displayName: "Claude Code",
+        description: "test",
+        models: [],
+        factory: {
+          type: "sdk",
+          package: "@grackle-ai/runtime-claude-code",
+          exportName: "ClaudeCodeRuntime",
+        },
+      },
+    };
+
+    await loadRuntimesFromCatalog((name) => name !== "claude-code");
+
+    expect(mockRegisterRuntime).not.toHaveBeenCalled();
+  });
+
+  it("continues loading when one runtime fails", async () => {
+    mockCatalog = {
+      "bad-runtime": {
+        displayName: "Bad",
+        description: "test",
+        models: [],
+        factory: {
+          type: "sdk",
+          package: "@grackle-ai/runtime-claude-code",
+          exportName: "NonexistentExport",
+        },
+      },
+      goose: {
+        displayName: "Goose",
+        description: "test",
+        models: [],
+        factory: {
+          type: "acp",
+          config: { command: "goose", args: ["acp"] },
+        },
+      },
+    };
+    mockListRuntimes.mockReturnValue(["goose"]);
+
+    await loadRuntimesFromCatalog();
+
+    expect(logger.error as Mock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: "bad-runtime" }),
+      expect.stringContaining("Failed to load runtime"),
+      "bad-runtime",
+    );
+    expect(mockRegisterRuntime).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterRuntime.mock.calls[0]![0] as AgentRuntime;
+    expect(registered.name).toBe("goose");
+  });
+
+  it("logs a summary after loading", async () => {
+    mockCatalog = {};
+    mockListRuntimes.mockReturnValue(["a", "b"]);
+
+    await loadRuntimesFromCatalog();
+
+    expect(logger.info as Mock).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 2, runtimes: ["a", "b"] }),
+      expect.stringContaining("Loaded"),
+      2,
+    );
+  });
+
+  it("loads only filtered runtimes when filter is provided", async () => {
+    mockCatalog = {
+      "claude-code": {
+        displayName: "Claude Code",
+        description: "test",
+        models: [],
+        factory: {
+          type: "sdk",
+          package: "@grackle-ai/runtime-claude-code",
+          exportName: "ClaudeCodeRuntime",
+        },
+      },
+      goose: {
+        displayName: "Goose",
+        description: "test",
+        models: [],
+        factory: {
+          type: "acp",
+          config: { command: "goose", args: ["acp"] },
+        },
+      },
+    };
+    mockListRuntimes.mockReturnValue(["goose"]);
+
+    await loadRuntimesFromCatalog((name) => name === "goose");
+
+    expect(mockRegisterRuntime).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterRuntime.mock.calls[0]![0] as AgentRuntime;
+    expect(registered.name).toBe("goose");
+  });
+});

--- a/packages/powerline/src/runtime-loader.test.ts
+++ b/packages/powerline/src/runtime-loader.test.ts
@@ -2,18 +2,6 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import type { AgentRuntime } from "@grackle-ai/runtime-sdk";
 import type { RuntimeCatalogEntry } from "@grackle-ai/common";
 
-function makeMockRuntime(name: string): AgentRuntime {
-  return {
-    name,
-    spawn: () => {
-      throw new Error("not implemented");
-    },
-    resume: () => {
-      throw new Error("not implemented");
-    },
-  };
-}
-
 class FakeSdkRuntime implements AgentRuntime {
   public name: string = "fake-sdk";
   public spawn = vi.fn();

--- a/packages/powerline/src/runtime-loader.ts
+++ b/packages/powerline/src/runtime-loader.ts
@@ -48,13 +48,19 @@ async function instantiateRuntime(
   switch (factory.type) {
     case "sdk": {
       const mod = (await import(factory.package)) as Record<string, unknown>;
-      const Constructor = mod[factory.exportName] as new () => AgentRuntime;
+      const Constructor = mod[factory.exportName];
       if (typeof Constructor !== "function") {
         throw new Error(
           `Export "${factory.exportName}" from "${factory.package}" is not a constructor`,
         );
       }
-      return new Constructor();
+      try {
+        return new (Constructor as new () => AgentRuntime)();
+      } catch (err: unknown) {
+        throw new Error(
+          `Failed to construct "${factory.exportName}" from "${factory.package}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     case "acp": {

--- a/packages/powerline/src/runtime-loader.ts
+++ b/packages/powerline/src/runtime-loader.ts
@@ -1,0 +1,82 @@
+/**
+ * Catalog-driven runtime instantiation.
+ *
+ * Iterates {@link RUNTIME_CATALOG}, interprets each entry's factory
+ * descriptor, and registers the resulting {@link AgentRuntime}. This is
+ * the mechanism layer; the catalog is the policy layer.
+ */
+import { RUNTIME_CATALOG } from "@grackle-ai/common";
+import type { RuntimeFactoryDescriptor } from "@grackle-ai/common";
+import type { AgentRuntime } from "@grackle-ai/runtime-sdk";
+import { registerRuntime, listRuntimes } from "./runtime-registry.js";
+import { logger } from "./logger.js";
+
+/**
+ * Load and register all runtimes whose catalog entry has a `factory`
+ * descriptor.
+ *
+ * @param filter - When provided, only runtimes whose name passes the
+ *   predicate are loaded. Enables Code/Claw runtime-set composition.
+ */
+export async function loadRuntimesFromCatalog(filter?: (name: string) => boolean): Promise<void> {
+  for (const [name, entry] of Object.entries(RUNTIME_CATALOG)) {
+    if (entry.factory === undefined) {
+      continue;
+    }
+    if (filter !== undefined && !filter(name)) {
+      logger.debug({ runtime: name }, "Skipping runtime excluded by filter");
+      continue;
+    }
+
+    try {
+      const runtime = await instantiateRuntime(name, entry.factory);
+      registerRuntime(runtime);
+      logger.debug({ runtime: name }, "Registered runtime from catalog");
+    } catch (err: unknown) {
+      logger.error({ err, runtime: name }, "Failed to load runtime %s — skipping", name);
+    }
+  }
+
+  const loaded = listRuntimes();
+  logger.info({ count: loaded.length, runtimes: loaded }, "Loaded %d runtimes", loaded.length);
+}
+
+async function instantiateRuntime(
+  name: string,
+  factory: RuntimeFactoryDescriptor,
+): Promise<AgentRuntime> {
+  switch (factory.type) {
+    case "sdk": {
+      const mod = (await import(factory.package)) as Record<string, unknown>;
+      const Constructor = mod[factory.exportName] as new () => AgentRuntime;
+      if (typeof Constructor !== "function") {
+        throw new Error(
+          `Export "${factory.exportName}" from "${factory.package}" is not a constructor`,
+        );
+      }
+      return new Constructor();
+    }
+
+    case "acp": {
+      const { AcpRuntime } = (await import("@grackle-ai/runtime-acp")) as {
+        AcpRuntime: new (config: {
+          name: string;
+          command: string;
+          args: string[];
+          isolateClaudeConfig?: boolean;
+        }) => AgentRuntime;
+      };
+      return new AcpRuntime({
+        name,
+        command: factory.config.command,
+        args: factory.config.args,
+        isolateClaudeConfig: factory.config.isolateClaudeConfig,
+      });
+    }
+
+    default: {
+      const _exhaustive: never = factory;
+      throw new Error(`Unknown factory type: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `RuntimeFactoryDescriptor` (discriminated union: `sdk` | `acp`) to `RUNTIME_CATALOG` entries in `@grackle-ai/common`, encoding how each runtime is instantiated
- Create `runtime-loader.ts` in PowerLine that iterates the catalog, dynamically imports each runtime package, and registers the result — replacing 8 static imports and 10 hardcoded `registerRuntime()` calls
- Stubs (`stub`, `stub-mcp`) remain directly registered as PowerLine-internal test infrastructure with no catalog factory
- The loader accepts an optional `filter` predicate for Code/Claw runtime-set composition

## Test plan
- [x] New `runtime-loader.test.ts` — SDK registration, ACP registration with injected name, missing factory skip, filter predicate, partial failure resilience, summary logging (7 tests)
- [x] Existing `runtime-registry.test.ts` passes unchanged
- [x] Existing `runtime-handlers.test.ts` in plugin-core passes (catalog backward-compatible)
- [x] Full `rush build` clean (no warnings)
- [ ] E2E tests pass in CI (stub runtime used by E2E exercises the full path)

Closes #1466