### PR TITLE
Centralize env config with shared utilities and typed GrackleConfig (#1476)

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -635,6 +635,13 @@ export function detectDelegation(tool: string, args: unknown): DelegationInfo | 
 export type Disposition = "mapped" | "carried" | "dropped";
 
 // @public
+export interface DockerConfig {
+    dockerHost?: string;
+    dockerNetwork?: string;
+    dockerSocatImage: string;
+}
+
+// @public
 type DockerContainerInfo = Message<"grackle.DockerContainerInfo"> & {
     id: string;
     name: string;
@@ -707,6 +714,19 @@ export const END_REASON: {
 export type EndReason = (typeof END_REASON)[keyof typeof END_REASON];
 
 // @public
+export function envBool(name: string, fallback: boolean, env?: EnvSource): boolean;
+
+// @public
+export function envFlag(name: string, env?: EnvSource): boolean;
+
+// @public
+export function envInt(name: string, fallback: number, opts?: {
+    min?: number;
+    max?: number;
+    env?: EnvSource;
+}): number;
+
+// @public
 type Environment = Message<"grackle.Environment"> & {
     id: string;
     displayName: string;
@@ -753,6 +773,21 @@ const EnvironmentSchema: GenMessage<Environment>;
 
 // @public
 export type EnvironmentStatus = "disconnected" | "connecting" | "connected" | "sleeping" | "error";
+
+// @public
+export function envNum(name: string, fallback: number, env?: EnvSource): number;
+
+// @public
+export function envOptionalString(name: string, env?: EnvSource): string | undefined;
+
+// @public
+export function envPort(name: string, fallback: number, env?: EnvSource): number;
+
+// @public
+export type EnvSource = Record<string, string | undefined>;
+
+// @public
+export function envString(name: string, fallback: string, env?: EnvSource): string;
 
 // @public
 type Escalation = Message<"grackle.Escalation"> & {
@@ -877,6 +912,15 @@ type FdInfo = Message<"grackle.FdInfo"> & {
 
 // @public
 const FdInfoSchema: GenMessage<FdInfo>;
+
+// @public
+export interface FeatureConfig {
+    knowledgeEnabled: boolean;
+    skipLocalPowerline: boolean;
+    skipOrchestration: boolean;
+    skipRootAutostart: boolean;
+    skipScheduling: boolean;
+}
 
 // @public
 const file_grackle_grackle_core: GenFile;
@@ -1376,6 +1420,16 @@ declare namespace grackle {
 
 // @public
 export const GRACKLE_DIR: string;
+
+// @public
+export interface GrackleConfig {
+    docker: DockerConfig;
+    features: FeatureConfig;
+    log: LogConfig;
+    network: NetworkConfig;
+    paths: PathConfig;
+    tuning: TuningConfig;
+}
 
 // @public
 const GrackleCore: GenService<{
@@ -2229,6 +2283,15 @@ type ListWorkspacesRequest = Message<"grackle.ListWorkspacesRequest"> & {
 const ListWorkspacesRequestSchema: GenMessage<ListWorkspacesRequest>;
 
 // @public
+export interface LogConfig {
+    isProduction: boolean;
+    level: LogLevel;
+}
+
+// @public
+export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent";
+
+// @public
 export const LOGS_DIR: string;
 
 // @public
@@ -2316,6 +2379,19 @@ type ModelSelection = Message<"grackle.ModelSelection"> & {
 
 // @public
 const ModelSelectionSchema: GenMessage<ModelSelection>;
+
+// @public
+export interface NetworkConfig {
+    grpcPort: number;
+    host: string;
+    mcpOrigin?: string;
+    mcpPort: number;
+    powerlinePort: number;
+    publicUrl?: string;
+    sandboxOrigin?: string;
+    sandboxPort: number;
+    webPort: number;
+}
 
 // @public
 export function newReverseMapperContext(): ReverseMapperContext;
@@ -2407,6 +2483,15 @@ export function parseDelegationArgs(tool: string, args: unknown): DelegationInfo
 
 // @public
 export function parseDuration(expr: string): number;
+
+// @public
+export interface PathConfig {
+    grackleHome?: string;
+    mcpConfig?: string;
+    webDir?: string;
+    workingDirectory?: string;
+    worktreeBase?: string;
+}
 
 // @public
 export interface PendingToolCall {
@@ -2651,6 +2736,29 @@ type ResolveComponentGraphResponse = Message<"grackle.ResolveComponentGraphRespo
 
 // @public
 const ResolveComponentGraphResponseSchema: GenMessage<ResolveComponentGraphResponse>;
+
+// @public
+export function resolveDockerConfig(env?: EnvSource): Readonly<DockerConfig>;
+
+// @public
+export function resolveFeatureConfig(env?: EnvSource): Readonly<FeatureConfig>;
+
+// @public
+export function resolveGrackleConfig(opts?: {
+    env?: EnvSource;
+}): Readonly<GrackleConfig>;
+
+// @public
+export function resolveLogConfig(env?: EnvSource): Readonly<LogConfig>;
+
+// @public
+export function resolveNetworkConfig(env?: EnvSource): Readonly<NetworkConfig>;
+
+// @public
+export function resolvePathConfig(env?: EnvSource): Readonly<PathConfig>;
+
+// @public
+export function resolveTuningConfig(env?: EnvSource): Readonly<TuningConfig>;
 
 // @public
 type ResourceContent = Message<"grackle.ResourceContent"> & {
@@ -3601,6 +3709,12 @@ export const tooltipPropsSchema: z.ZodObject<{
     }>>;
     delayMs: z.ZodOptional<z.ZodInt>;
 }, z.core.$strip>;
+
+// @public
+export interface TuningConfig {
+    kgSpawnContextTimeoutMs: number;
+    reconciliationTickMs: number;
+}
 
 // @public
 type UnlinkEnvironmentRequest = Message<"grackle.UnlinkEnvironmentRequest"> & {

--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { ActionEnvelope } from '@grackle-ai/ahp';
+import { Code } from '@connectrpc/connect';
 import type { GenEnum } from '@bufbuild/protobuf/codegenv2';
 import type { GenFile } from '@bufbuild/protobuf/codegenv2';
 import type { GenMessage } from '@bufbuild/protobuf/codegenv2';
@@ -20,6 +21,19 @@ type AcknowledgeEscalationRequest = Message<"grackle.AcknowledgeEscalationReques
 
 // @public
 const AcknowledgeEscalationRequestSchema: GenMessage<AcknowledgeEscalationRequest>;
+
+// @public
+export interface AcpRuntimeFactory {
+    config: AcpRuntimeFactoryConfig;
+    type: "acp";
+}
+
+// @public
+export interface AcpRuntimeFactoryConfig {
+    args: string[];
+    command: string;
+    isolateClaudeConfig?: boolean;
+}
 
 // @public
 export type AdapterType = "docker" | "local" | "codespace" | "ssh";
@@ -156,6 +170,11 @@ type AuthenticateRequest = Message<"grackle.powerline.AuthenticateRequest"> & {
 
 // @public
 const AuthenticateRequestSchema: GenMessage<AuthenticateRequest>;
+
+// @public
+export class AuthError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
+}
 
 // @public
 export const BUILTIN_COMPONENT_JSON_SCHEMAS: Readonly<Record<BuiltinComponentName, object>>;
@@ -381,6 +400,8 @@ type CloseFdResponse = Message<"grackle.CloseFdResponse"> & {
 // @public
 const CloseFdResponseSchema: GenMessage<CloseFdResponse>;
 
+export { Code }
+
 // @public
 type CodespaceInfo = Message<"grackle.CodespaceInfo"> & {
     name: string;
@@ -434,6 +455,11 @@ const ComponentSchema: GenMessage<Component>;
 
 // @public
 export function computeNextRunAt(expr: string, lastRunAt?: string): string;
+
+// @public
+export class ConflictError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
+}
 
 // @public
 export type CopyButtonBuiltinProps = z.infer<typeof copyButtonPropsSchema>;
@@ -1776,6 +1802,13 @@ const GrackleCore: GenService<{
 }>;
 
 // @public
+export class GrackleError extends Error {
+    constructor(message: string, code?: Code, context?: Record<string, unknown>);
+    readonly code: Code;
+    readonly context: Readonly<Record<string, unknown>>;
+}
+
+// @public
 const GrackleKnowledge: GenService<{
     searchKnowledge: {
         methodKind: "unary";
@@ -2079,7 +2112,7 @@ const InputMessageSchema: GenMessage<InputMessage>;
 const InputMessageSchema_2: GenMessage<InputMessage_2>;
 
 // @public
-export class InvalidSessionTransitionError extends Error {
+export class InvalidSessionTransitionError extends PreconditionError {
     constructor(from: SessionStatus, to: SessionStatus);
     // (undocumented)
     readonly from: SessionStatus;
@@ -2397,6 +2430,11 @@ export interface NetworkConfig {
 export function newReverseMapperContext(): ReverseMapperContext;
 
 // @public
+export class NotFoundError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
+}
+
+// @public
 type OperatorAttachTaskRequest = Message<"grackle.OperatorAttachTaskRequest"> & {
     taskId: string;
     streamId: string;
@@ -2608,6 +2646,11 @@ declare namespace powerline {
         DrainRequestSchema,
         GracklePowerLine
     }
+}
+
+// @public
+export class PreconditionError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
 }
 
 // @public
@@ -2848,9 +2891,13 @@ export const RUNTIME_CATALOG: Readonly<Record<string, RuntimeCatalogEntry>>;
 export interface RuntimeCatalogEntry {
     description: string;
     displayName: string;
+    factory?: RuntimeFactoryDescriptor;
     install?: RuntimePackageManifest;
     models: RuntimeModelInfo[];
 }
+
+// @public
+export type RuntimeFactoryDescriptor = SdkRuntimeFactory | AcpRuntimeFactory;
 
 // @public
 type RuntimeInfo = Message<"grackle.RuntimeInfo"> & {
@@ -2937,6 +2984,13 @@ export function scheduleRowToProto(row: ScheduleRowShape): Schedule;
 
 // @public
 const ScheduleSchema: GenMessage<Schedule>;
+
+// @public
+export interface SdkRuntimeFactory {
+    exportName: string;
+    package: string;
+    type: "sdk";
+}
 
 // @public
 type SearchComponentResult = Message<"grackle.SearchComponentResult"> & {
@@ -3717,6 +3771,11 @@ export interface TuningConfig {
 }
 
 // @public
+export class UnavailableError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
+}
+
+// @public
 type UnlinkEnvironmentRequest = Message<"grackle.UnlinkEnvironmentRequest"> & {
     workspaceId: string;
     environmentId: string;
@@ -3857,6 +3916,11 @@ const UsageStatsSchema: GenMessage<UsageStats>;
 
 // @public
 export function validateExpression(expr: string): void;
+
+// @public
+export class ValidationError extends GrackleError {
+    constructor(message: string, context?: Record<string, unknown>);
+}
 
 // @public
 type VersionStatus = Message<"grackle.VersionStatus"> & {

--- a/common/changes/@grackle-ai/cli/nick-pape-1476-centralized-config_2026-06-05-04-17.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1476-centralized-config_2026-06-05-04-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add centralized env config utilities (envPort, envFlag, envString, etc.) and typed GrackleConfig to @grackle-ai/common; refactor core and server to use shared parsing instead of scattered process.env reads",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "nickpape@outlook.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@rushstack/heft':
         specifier: 1.2.7
         version: 1.2.7(@types/node@22.19.15)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.8(vitest@4.1.8)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,6 +48,7 @@
     "@grackle-ai/heft-buf-plugin": "workspace:*",
     "@grackle-ai/heft-rig": "workspace:*",
     "@rushstack/heft": "1.2.7",
+    "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.0",
     "vitest": "^4.1.0",
     "@vitest/spy": "^4.1.0"

--- a/packages/common/src/config.test.ts
+++ b/packages/common/src/config.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveGrackleConfig,
+  resolveLogConfig,
+  resolveNetworkConfig,
+  resolvePathConfig,
+  resolveDockerConfig,
+  resolveFeatureConfig,
+  resolveTuningConfig,
+} from "./config.js";
+
+describe("resolveLogConfig", () => {
+  it("returns defaults when env is empty", () => {
+    const cfg = resolveLogConfig({});
+    expect(cfg.level).toBe("info");
+    expect(cfg.isProduction).toBe(false);
+  });
+
+  it("reads LOG_LEVEL", () => {
+    expect(resolveLogConfig({ LOG_LEVEL: "debug" }).level).toBe("debug");
+  });
+
+  it("detects production", () => {
+    expect(resolveLogConfig({ NODE_ENV: "production" }).isProduction).toBe(true);
+  });
+
+  it("result is frozen", () => {
+    const cfg = resolveLogConfig({});
+    expect(Object.isFrozen(cfg)).toBe(true);
+  });
+});
+
+describe("resolveNetworkConfig", () => {
+  it("returns port defaults", () => {
+    const cfg = resolveNetworkConfig({});
+    expect(cfg.grpcPort).toBe(7434);
+    expect(cfg.webPort).toBe(3000);
+    expect(cfg.mcpPort).toBe(7435);
+    expect(cfg.sandboxPort).toBe(7436);
+    expect(cfg.powerlinePort).toBe(7433);
+    expect(cfg.host).toBe("127.0.0.1");
+  });
+
+  it("reads port overrides", () => {
+    const cfg = resolveNetworkConfig({ GRACKLE_PORT: "9000", GRACKLE_HOST: "0.0.0.0" });
+    expect(cfg.grpcPort).toBe(9000);
+    expect(cfg.host).toBe("0.0.0.0");
+  });
+
+  it("reads optional origin fields", () => {
+    const cfg = resolveNetworkConfig({
+      GRACKLE_PUBLIC_URL: "https://grackle.home",
+      GRACKLE_MCP_ORIGIN: "https://mcp.home",
+      GRACKLE_SANDBOX_ORIGIN: "https://sandbox.home",
+    });
+    expect(cfg.publicUrl).toBe("https://grackle.home");
+    expect(cfg.mcpOrigin).toBe("https://mcp.home");
+    expect(cfg.sandboxOrigin).toBe("https://sandbox.home");
+  });
+
+  it("omits optional fields when unset", () => {
+    const cfg = resolveNetworkConfig({});
+    expect(cfg.publicUrl).toBeUndefined();
+    expect(cfg.mcpOrigin).toBeUndefined();
+    expect(cfg.sandboxOrigin).toBeUndefined();
+  });
+});
+
+describe("resolvePathConfig", () => {
+  it("returns all undefined when env is empty", () => {
+    const cfg = resolvePathConfig({});
+    expect(cfg.grackleHome).toBeUndefined();
+    expect(cfg.workingDirectory).toBeUndefined();
+    expect(cfg.worktreeBase).toBeUndefined();
+    expect(cfg.webDir).toBeUndefined();
+    expect(cfg.mcpConfig).toBeUndefined();
+  });
+
+  it("reads all path overrides", () => {
+    const cfg = resolvePathConfig({
+      GRACKLE_HOME: "/custom/home",
+      GRACKLE_WORKING_DIRECTORY: "/work",
+      GRACKLE_WORKTREE_BASE: "/trees",
+      GRACKLE_WEB_DIR: "/web",
+      GRACKLE_MCP_CONFIG: "/mcp.json",
+    });
+    expect(cfg.grackleHome).toBe("/custom/home");
+    expect(cfg.workingDirectory).toBe("/work");
+    expect(cfg.worktreeBase).toBe("/trees");
+    expect(cfg.webDir).toBe("/web");
+    expect(cfg.mcpConfig).toBe("/mcp.json");
+  });
+});
+
+describe("resolveDockerConfig", () => {
+  it("returns defaults", () => {
+    const cfg = resolveDockerConfig({});
+    expect(cfg.dockerHost).toBeUndefined();
+    expect(cfg.dockerSocatImage).toBe("alpine/socat");
+    expect(cfg.dockerNetwork).toBeUndefined();
+  });
+
+  it("reads overrides", () => {
+    const cfg = resolveDockerConfig({
+      GRACKLE_DOCKER_HOST: "grackle-server",
+      GRACKLE_DOCKER_SOCAT_IMAGE: "custom/socat:v2",
+      GRACKLE_DOCKER_NETWORK: "my-net",
+    });
+    expect(cfg.dockerHost).toBe("grackle-server");
+    expect(cfg.dockerSocatImage).toBe("custom/socat:v2");
+    expect(cfg.dockerNetwork).toBe("my-net");
+  });
+});
+
+describe("resolveFeatureConfig", () => {
+  it("returns defaults (all skips false, knowledge enabled)", () => {
+    const cfg = resolveFeatureConfig({});
+    expect(cfg.skipLocalPowerline).toBe(false);
+    expect(cfg.skipRootAutostart).toBe(false);
+    expect(cfg.skipOrchestration).toBe(false);
+    expect(cfg.skipScheduling).toBe(false);
+    expect(cfg.knowledgeEnabled).toBe(true);
+  });
+
+  it("reads flag overrides", () => {
+    const cfg = resolveFeatureConfig({
+      GRACKLE_SKIP_LOCAL_POWERLINE: "1",
+      GRACKLE_SKIP_ORCHESTRATION: "1",
+      GRACKLE_KNOWLEDGE_ENABLED: "false",
+    });
+    expect(cfg.skipLocalPowerline).toBe(true);
+    expect(cfg.skipOrchestration).toBe(true);
+    expect(cfg.knowledgeEnabled).toBe(false);
+  });
+});
+
+describe("resolveTuningConfig", () => {
+  it("returns defaults", () => {
+    const cfg = resolveTuningConfig({});
+    expect(cfg.reconciliationTickMs).toBe(10_000);
+    expect(cfg.kgSpawnContextTimeoutMs).toBe(1_500);
+  });
+
+  it("reads overrides", () => {
+    const cfg = resolveTuningConfig({
+      GRACKLE_RECONCILIATION_TICK_MS: "5000",
+      GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS: "3000",
+    });
+    expect(cfg.reconciliationTickMs).toBe(5000);
+    expect(cfg.kgSpawnContextTimeoutMs).toBe(3000);
+  });
+
+  it("clamps to min 1", () => {
+    const cfg = resolveTuningConfig({
+      GRACKLE_RECONCILIATION_TICK_MS: "0",
+      GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS: "-5",
+    });
+    expect(cfg.reconciliationTickMs).toBe(1);
+    expect(cfg.kgSpawnContextTimeoutMs).toBe(1);
+  });
+});
+
+describe("resolveGrackleConfig", () => {
+  it("composes all sub-configs", () => {
+    const cfg = resolveGrackleConfig({ env: {} });
+    expect(cfg.network.grpcPort).toBe(7434);
+    expect(cfg.log.level).toBe("info");
+    expect(cfg.features.knowledgeEnabled).toBe(true);
+    expect(cfg.tuning.reconciliationTickMs).toBe(10_000);
+  });
+
+  it("result is frozen (top-level and nested)", () => {
+    const cfg = resolveGrackleConfig({ env: {} });
+    expect(Object.isFrozen(cfg)).toBe(true);
+    expect(Object.isFrozen(cfg.network)).toBe(true);
+    expect(Object.isFrozen(cfg.log)).toBe(true);
+  });
+
+  it("passes env through to all sub-resolvers", () => {
+    const cfg = resolveGrackleConfig({
+      env: {
+        GRACKLE_PORT: "9000",
+        LOG_LEVEL: "debug",
+        GRACKLE_HOME: "/custom",
+        GRACKLE_DOCKER_HOST: "myhost",
+        GRACKLE_SKIP_ORCHESTRATION: "1",
+        GRACKLE_RECONCILIATION_TICK_MS: "2000",
+      },
+    });
+    expect(cfg.network.grpcPort).toBe(9000);
+    expect(cfg.log.level).toBe("debug");
+    expect(cfg.paths.grackleHome).toBe("/custom");
+    expect(cfg.docker.dockerHost).toBe("myhost");
+    expect(cfg.features.skipOrchestration).toBe(true);
+    expect(cfg.tuning.reconciliationTickMs).toBe(2000);
+  });
+});

--- a/packages/common/src/config.test.ts
+++ b/packages/common/src/config.test.ts
@@ -20,6 +20,10 @@ describe("resolveLogConfig", () => {
     expect(resolveLogConfig({ LOG_LEVEL: "debug" }).level).toBe("debug");
   });
 
+  it("falls back to 'info' for invalid LOG_LEVEL", () => {
+    expect(resolveLogConfig({ LOG_LEVEL: "verbose" }).level).toBe("info");
+  });
+
   it("detects production", () => {
     expect(resolveLogConfig({ NODE_ENV: "production" }).isProduction).toBe(true);
   });
@@ -150,13 +154,13 @@ describe("resolveTuningConfig", () => {
     expect(cfg.kgSpawnContextTimeoutMs).toBe(3000);
   });
 
-  it("clamps to min 1", () => {
+  it("returns defaults for non-positive values", () => {
     const cfg = resolveTuningConfig({
       GRACKLE_RECONCILIATION_TICK_MS: "0",
       GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS: "-5",
     });
-    expect(cfg.reconciliationTickMs).toBe(1);
-    expect(cfg.kgSpawnContextTimeoutMs).toBe(1);
+    expect(cfg.reconciliationTickMs).toBe(10_000);
+    expect(cfg.kgSpawnContextTimeoutMs).toBe(1_500);
   });
 });
 

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -1,0 +1,221 @@
+/**
+ * Centralized Grackle configuration resolved from environment variables.
+ *
+ * Call {@link resolveGrackleConfig} once at startup and pass the result to
+ * consumers. Partial resolvers ({@link resolveLogConfig},
+ * {@link resolveNetworkConfig}) serve leaf packages that only need a slice.
+ *
+ * @module
+ */
+
+import {
+  envPort,
+  envString,
+  envOptionalString,
+  envInt,
+  envFlag,
+  envBool,
+  type EnvSource,
+} from "./env.js";
+import {
+  DEFAULT_SERVER_PORT,
+  DEFAULT_WEB_PORT,
+  DEFAULT_MCP_PORT,
+  DEFAULT_POWERLINE_PORT,
+  DEFAULT_SANDBOX_PORT,
+} from "./types.js";
+
+// ─── Tuning defaults (mirrored from core, canonical values) ────
+
+/** Default reconciliation tick interval (10 seconds). */
+const DEFAULT_RECONCILIATION_TICK_MS: number = 10_000;
+
+/** Default per-provider timeout for spawn-context resolution (1.5 seconds). */
+const DEFAULT_SPAWN_CONTEXT_TIMEOUT_MS: number = 1_500;
+
+// ─── Sub-config interfaces ─────────────────────────────────────
+
+/** Pino-compatible log levels. */
+export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent";
+
+/** Logging configuration shared across all packages. */
+export interface LogConfig {
+  /** Pino log level. */
+  level: LogLevel;
+  /** Whether `NODE_ENV` is `"production"`. */
+  isProduction: boolean;
+}
+
+/** Network and port configuration. */
+export interface NetworkConfig {
+  /** gRPC server port (`GRACKLE_PORT`). */
+  grpcPort: number;
+  /** Web UI + WebSocket port (`GRACKLE_WEB_PORT`). */
+  webPort: number;
+  /** MCP server port (`GRACKLE_MCP_PORT`). */
+  mcpPort: number;
+  /** MCP Apps widget sandbox port (`GRACKLE_SANDBOX_PORT`). */
+  sandboxPort: number;
+  /** PowerLine gRPC port (`GRACKLE_POWERLINE_PORT`). */
+  powerlinePort: number;
+  /** Bind address (`GRACKLE_HOST`). */
+  host: string;
+  /** Canonical browser-facing origin (`GRACKLE_PUBLIC_URL`). */
+  publicUrl?: string;
+  /** Explicit MCP origin for broker-captured widgets (`GRACKLE_MCP_ORIGIN`). */
+  mcpOrigin?: string;
+  /** Explicit sandbox origin (`GRACKLE_SANDBOX_ORIGIN`). */
+  sandboxOrigin?: string;
+}
+
+/** Filesystem path overrides. */
+export interface PathConfig {
+  /** Raw `GRACKLE_HOME` override (before joining with `.grackle`). */
+  grackleHome?: string;
+  /** Override agent working directory (`GRACKLE_WORKING_DIRECTORY`). */
+  workingDirectory?: string;
+  /** Worktree base path (`GRACKLE_WORKTREE_BASE`). */
+  worktreeBase?: string;
+  /** Override web asset directory (`GRACKLE_WEB_DIR`). */
+  webDir?: string;
+  /** MCP config file path (`GRACKLE_MCP_CONFIG`). */
+  mcpConfig?: string;
+}
+
+/** Docker-related configuration. */
+export interface DockerConfig {
+  /** Container hostname for DooD mode (`GRACKLE_DOCKER_HOST`). */
+  dockerHost?: string;
+  /** Socat helper image (`GRACKLE_DOCKER_SOCAT_IMAGE`). */
+  dockerSocatImage: string;
+  /** Docker network name (`GRACKLE_DOCKER_NETWORK`). */
+  dockerNetwork?: string;
+}
+
+/** Feature flags. */
+export interface FeatureConfig {
+  /** Skip auto-starting local PowerLine (`GRACKLE_SKIP_LOCAL_POWERLINE=1`). */
+  skipLocalPowerline: boolean;
+  /** Skip auto-starting root task on connect (`GRACKLE_SKIP_ROOT_AUTOSTART=1`). */
+  skipRootAutostart: boolean;
+  /** Skip task orchestration (`GRACKLE_SKIP_ORCHESTRATION=1`). */
+  skipOrchestration: boolean;
+  /** Skip task scheduling (`GRACKLE_SKIP_SCHEDULING=1`). */
+  skipScheduling: boolean;
+  /** Enable knowledge graph features (`GRACKLE_KNOWLEDGE_ENABLED`). */
+  knowledgeEnabled: boolean;
+}
+
+/** Operational tuning knobs (resolve once at startup). */
+export interface TuningConfig {
+  /** Reconciliation loop interval in ms (`GRACKLE_RECONCILIATION_TICK_MS`). */
+  reconciliationTickMs: number;
+  /** Per-provider timeout for spawn-context resolution in ms (`GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS`). */
+  kgSpawnContextTimeoutMs: number;
+}
+
+/** Complete Grackle configuration resolved from environment variables. */
+export interface GrackleConfig {
+  /** Network ports and bind address. */
+  network: NetworkConfig;
+  /** Filesystem path overrides. */
+  paths: PathConfig;
+  /** Docker-related configuration. */
+  docker: DockerConfig;
+  /** Feature flags. */
+  features: FeatureConfig;
+  /** Operational tuning. */
+  tuning: TuningConfig;
+  /** Logging. */
+  log: LogConfig;
+}
+
+// ─── Resolvers ─────────────────────────────────────────────────
+
+/** Resolve logging configuration from env vars. */
+export function resolveLogConfig(env?: EnvSource): Readonly<LogConfig> {
+  return Object.freeze({
+    level: envString("LOG_LEVEL", "info", env) as LogLevel,
+    isProduction: envString("NODE_ENV", "", env) === "production",
+  });
+}
+
+/** Resolve network/port configuration from env vars. */
+export function resolveNetworkConfig(env?: EnvSource): Readonly<NetworkConfig> {
+  return Object.freeze({
+    grpcPort: envPort("GRACKLE_PORT", DEFAULT_SERVER_PORT, env),
+    webPort: envPort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT, env),
+    mcpPort: envPort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT, env),
+    sandboxPort: envPort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT, env),
+    powerlinePort: envPort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT, env),
+    host: envString("GRACKLE_HOST", "127.0.0.1", env),
+    publicUrl: envOptionalString("GRACKLE_PUBLIC_URL", env),
+    mcpOrigin: envOptionalString("GRACKLE_MCP_ORIGIN", env),
+    sandboxOrigin: envOptionalString("GRACKLE_SANDBOX_ORIGIN", env),
+  });
+}
+
+/** Resolve path configuration from env vars. */
+export function resolvePathConfig(env?: EnvSource): Readonly<PathConfig> {
+  return Object.freeze({
+    grackleHome: envOptionalString("GRACKLE_HOME", env),
+    workingDirectory: envOptionalString("GRACKLE_WORKING_DIRECTORY", env),
+    worktreeBase: envOptionalString("GRACKLE_WORKTREE_BASE", env),
+    webDir: envOptionalString("GRACKLE_WEB_DIR", env),
+    mcpConfig: envOptionalString("GRACKLE_MCP_CONFIG", env),
+  });
+}
+
+/** Resolve Docker configuration from env vars. */
+export function resolveDockerConfig(env?: EnvSource): Readonly<DockerConfig> {
+  return Object.freeze({
+    dockerHost: envOptionalString("GRACKLE_DOCKER_HOST", env),
+    dockerSocatImage: envString("GRACKLE_DOCKER_SOCAT_IMAGE", "alpine/socat", env),
+    dockerNetwork: envOptionalString("GRACKLE_DOCKER_NETWORK", env),
+  });
+}
+
+/** Resolve feature flags from env vars. */
+export function resolveFeatureConfig(env?: EnvSource): Readonly<FeatureConfig> {
+  return Object.freeze({
+    skipLocalPowerline: envFlag("GRACKLE_SKIP_LOCAL_POWERLINE", env),
+    skipRootAutostart: envFlag("GRACKLE_SKIP_ROOT_AUTOSTART", env),
+    skipOrchestration: envFlag("GRACKLE_SKIP_ORCHESTRATION", env),
+    skipScheduling: envFlag("GRACKLE_SKIP_SCHEDULING", env),
+    knowledgeEnabled: envBool("GRACKLE_KNOWLEDGE_ENABLED", true, env),
+  });
+}
+
+/** Resolve tuning configuration from env vars. */
+export function resolveTuningConfig(env?: EnvSource): Readonly<TuningConfig> {
+  return Object.freeze({
+    reconciliationTickMs: envInt("GRACKLE_RECONCILIATION_TICK_MS", DEFAULT_RECONCILIATION_TICK_MS, {
+      min: 1,
+      env,
+    }),
+    kgSpawnContextTimeoutMs: envInt(
+      "GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS",
+      DEFAULT_SPAWN_CONTEXT_TIMEOUT_MS,
+      { min: 1, env },
+    ),
+  });
+}
+
+/**
+ * Resolve and validate all Grackle configuration from environment variables.
+ * Returns a frozen config object. Call once at startup, pass to consumers.
+ *
+ * Does NOT include TLS or network-exposure validation — those are
+ * server-specific concerns in `@grackle-ai/server`.
+ */
+export function resolveGrackleConfig(opts?: { env?: EnvSource }): Readonly<GrackleConfig> {
+  const env = opts?.env;
+  return Object.freeze({
+    network: resolveNetworkConfig(env),
+    paths: resolvePathConfig(env),
+    docker: resolveDockerConfig(env),
+    features: resolveFeatureConfig(env),
+    tuning: resolveTuningConfig(env),
+    log: resolveLogConfig(env),
+  });
+}

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -132,10 +132,22 @@ export interface GrackleConfig {
 
 // ─── Resolvers ─────────────────────────────────────────────────
 
+const VALID_LOG_LEVELS: ReadonlySet<string> = new Set([
+  "fatal",
+  "error",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+  "silent",
+]);
+
 /** Resolve logging configuration from env vars. */
 export function resolveLogConfig(env?: EnvSource): Readonly<LogConfig> {
+  const raw = envString("LOG_LEVEL", "info", env);
+  const level: LogLevel = VALID_LOG_LEVELS.has(raw) ? (raw as LogLevel) : "info";
   return Object.freeze({
-    level: envString("LOG_LEVEL", "info", env) as LogLevel,
+    level,
     isProduction: envString("NODE_ENV", "", env) === "production",
   });
 }

--- a/packages/common/src/env.test.ts
+++ b/packages/common/src/env.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { envString, envOptionalString, envPort, envInt, envNum, envFlag, envBool } from "./env.js";
+
+describe("envString", () => {
+  it("returns the env value when set", () => {
+    expect(envString("X", "default", { X: "hello" })).toBe("hello");
+  });
+
+  it("returns fallback when unset", () => {
+    expect(envString("X", "default", {})).toBe("default");
+  });
+
+  it("returns fallback when empty", () => {
+    expect(envString("X", "default", { X: "" })).toBe("default");
+  });
+});
+
+describe("envOptionalString", () => {
+  it("returns the value when set", () => {
+    expect(envOptionalString("X", { X: "val" })).toBe("val");
+  });
+
+  it("returns undefined when unset", () => {
+    expect(envOptionalString("X", {})).toBeUndefined();
+  });
+
+  it("returns undefined when empty", () => {
+    expect(envOptionalString("X", { X: "" })).toBeUndefined();
+  });
+});
+
+describe("envPort", () => {
+  it("returns fallback when unset", () => {
+    expect(envPort("PORT", 3000, {})).toBe(3000);
+  });
+
+  it("parses a valid port", () => {
+    expect(envPort("PORT", 3000, { PORT: "8080" })).toBe(8080);
+  });
+
+  it("accepts port 1", () => {
+    expect(envPort("PORT", 3000, { PORT: "1" })).toBe(1);
+  });
+
+  it("accepts port 65535", () => {
+    expect(envPort("PORT", 3000, { PORT: "65535" })).toBe(65535);
+  });
+
+  it("throws on port 0", () => {
+    expect(() => envPort("PORT", 3000, { PORT: "0" })).toThrow('Invalid port for PORT: "0"');
+  });
+
+  it("throws on port 65536", () => {
+    expect(() => envPort("PORT", 3000, { PORT: "65536" })).toThrow(
+      'Invalid port for PORT: "65536"',
+    );
+  });
+
+  it("throws on non-integer", () => {
+    expect(() => envPort("PORT", 3000, { PORT: "3.14" })).toThrow("Invalid port");
+  });
+
+  it("throws on non-numeric", () => {
+    expect(() => envPort("PORT", 3000, { PORT: "abc" })).toThrow("Invalid port");
+  });
+
+  it("returns fallback when empty", () => {
+    expect(envPort("PORT", 3000, { PORT: "" })).toBe(3000);
+  });
+});
+
+describe("envInt", () => {
+  it("returns fallback when unset", () => {
+    expect(envInt("X", 10, {})).toBe(10);
+  });
+
+  it("parses a valid integer", () => {
+    expect(envInt("X", 10, { env: { X: "42" } })).toBe(42);
+  });
+
+  it("floors a float", () => {
+    expect(envInt("X", 10, { env: { X: "3.9" } })).toBe(3);
+  });
+
+  it("clamps to min", () => {
+    expect(envInt("X", 10, { min: 5, env: { X: "2" } })).toBe(5);
+  });
+
+  it("clamps to max", () => {
+    expect(envInt("X", 10, { max: 100, env: { X: "200" } })).toBe(100);
+  });
+
+  it("returns fallback on NaN", () => {
+    expect(envInt("X", 10, { env: { X: "abc" } })).toBe(10);
+  });
+
+  it("returns fallback on empty", () => {
+    expect(envInt("X", 10, { env: { X: "" } })).toBe(10);
+  });
+
+  it("parses negative integers", () => {
+    expect(envInt("X", 0, { env: { X: "-5" } })).toBe(-5);
+  });
+});
+
+describe("envNum", () => {
+  it("returns fallback when unset", () => {
+    expect(envNum("X", 0.5, {})).toBe(0.5);
+  });
+
+  it("parses a float", () => {
+    expect(envNum("X", 0.5, { X: "0.35" })).toBe(0.35);
+  });
+
+  it("parses zero", () => {
+    expect(envNum("X", 0.5, { X: "0" })).toBe(0);
+  });
+
+  it("returns fallback on negative", () => {
+    expect(envNum("X", 0.5, { X: "-1" })).toBe(0.5);
+  });
+
+  it("returns fallback on NaN", () => {
+    expect(envNum("X", 0.5, { X: "nope" })).toBe(0.5);
+  });
+
+  it("returns fallback on Infinity", () => {
+    expect(envNum("X", 0.5, { X: "Infinity" })).toBe(0.5);
+  });
+});
+
+describe("envFlag", () => {
+  it("returns true for '1'", () => {
+    expect(envFlag("X", { X: "1" })).toBe(true);
+  });
+
+  it("returns false for '0'", () => {
+    expect(envFlag("X", { X: "0" })).toBe(false);
+  });
+
+  it("returns false for 'true'", () => {
+    expect(envFlag("X", { X: "true" })).toBe(false);
+  });
+
+  it("returns false when unset", () => {
+    expect(envFlag("X", {})).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(envFlag("X", { X: "" })).toBe(false);
+  });
+});
+
+describe("envBool", () => {
+  it("returns true for '1'", () => {
+    expect(envBool("X", false, { X: "1" })).toBe(true);
+  });
+
+  it("returns true for 'true'", () => {
+    expect(envBool("X", false, { X: "true" })).toBe(true);
+  });
+
+  it("returns true for 'TRUE'", () => {
+    expect(envBool("X", false, { X: "TRUE" })).toBe(true);
+  });
+
+  it("returns false for '0'", () => {
+    expect(envBool("X", true, { X: "0" })).toBe(false);
+  });
+
+  it("returns false for 'false'", () => {
+    expect(envBool("X", true, { X: "false" })).toBe(false);
+  });
+
+  it("returns fallback when unset", () => {
+    expect(envBool("X", true, {})).toBe(true);
+    expect(envBool("X", false, {})).toBe(false);
+  });
+
+  it("returns fallback when empty", () => {
+    expect(envBool("X", true, { X: "" })).toBe(true);
+  });
+});

--- a/packages/common/src/env.test.ts
+++ b/packages/common/src/env.test.ts
@@ -78,16 +78,20 @@ describe("envInt", () => {
     expect(envInt("X", 10, { env: { X: "42" } })).toBe(42);
   });
 
-  it("floors a float", () => {
+  it("truncates a positive float toward zero", () => {
     expect(envInt("X", 10, { env: { X: "3.9" } })).toBe(3);
   });
 
-  it("clamps to min", () => {
-    expect(envInt("X", 10, { min: 5, env: { X: "2" } })).toBe(5);
+  it("truncates a negative float toward zero", () => {
+    expect(envInt("X", 10, { env: { X: "-1.2" } })).toBe(-1);
   });
 
-  it("clamps to max", () => {
-    expect(envInt("X", 10, { max: 100, env: { X: "200" } })).toBe(100);
+  it("returns fallback when below min", () => {
+    expect(envInt("X", 10, { min: 5, env: { X: "2" } })).toBe(10);
+  });
+
+  it("returns fallback when above max", () => {
+    expect(envInt("X", 10, { max: 100, env: { X: "200" } })).toBe(10);
   });
 
   it("returns fallback on NaN", () => {
@@ -179,5 +183,10 @@ describe("envBool", () => {
 
   it("returns fallback when empty", () => {
     expect(envBool("X", true, { X: "" })).toBe(true);
+  });
+
+  it("returns fallback for unrecognized values", () => {
+    expect(envBool("X", true, { X: "nope" })).toBe(true);
+    expect(envBool("X", false, { X: "yes" })).toBe(false);
   });
 });

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared environment-variable parsing utilities.
+ *
+ * Every function accepts an optional {@link EnvSource} so tests can inject
+ * values without mutating `process.env`.
+ *
+ * @module
+ */
+
+/** A bag of environment variables — defaults to `process.env`. */
+export type EnvSource = Record<string, string | undefined>;
+
+function resolve(name: string, env?: EnvSource): string | undefined {
+  return (env ?? process.env)[name];
+}
+
+/** Read a string env var, returning `fallback` when unset or empty. */
+export function envString(name: string, fallback: string, env?: EnvSource): string {
+  const raw = resolve(name, env);
+  return raw !== undefined && raw !== "" ? raw : fallback;
+}
+
+/** Read an optional string env var; returns `undefined` when unset or empty. */
+export function envOptionalString(name: string, env?: EnvSource): string | undefined {
+  const raw = resolve(name, env);
+  return raw !== undefined && raw !== "" ? raw : undefined;
+}
+
+/**
+ * Parse a port number (integer 1–65535) from an env var.
+ * Returns `fallback` when unset. Throws on invalid values.
+ */
+export function envPort(name: string, fallback: number, env?: EnvSource): number {
+  const raw = resolve(name, env);
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(`Invalid port for ${name}: "${raw}". Must be an integer between 1 and 65535.`);
+  }
+  return parsed;
+}
+
+/**
+ * Parse an integer env var with optional min/max bounds.
+ * Returns `fallback` when unset or non-finite. Throws when outside bounds.
+ */
+export function envInt(
+  name: string,
+  fallback: number,
+  opts?: { min?: number; max?: number; env?: EnvSource },
+): number {
+  const raw = resolve(name, opts?.env);
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const value = Math.floor(parsed);
+  if (opts?.min !== undefined && value < opts.min) {
+    return opts.min;
+  }
+  if (opts?.max !== undefined && value > opts.max) {
+    return opts.max;
+  }
+  return value;
+}
+
+/**
+ * Parse a non-negative float env var.
+ * Returns `fallback` when unset, non-finite, or negative.
+ */
+export function envNum(name: string, fallback: number, env?: EnvSource): number {
+  const raw = resolve(name, env);
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Parse a strict boolean flag: `"1"` → `true`, anything else → `false`.
+ * Matches the `GRACKLE_SKIP_*` / `GRACKLE_ALLOW_*` convention.
+ */
+export function envFlag(name: string, env?: EnvSource): boolean {
+  return resolve(name, env) === "1";
+}
+
+/**
+ * Parse a broad boolean: `"1"` / `"true"` → `true`, `"0"` / `"false"` → `false`,
+ * unset/empty → `fallback`. Matches the `GRACKLE_KNOWLEDGE_ENABLED` convention.
+ */
+export function envBool(name: string, fallback: boolean, env?: EnvSource): boolean {
+  const raw = resolve(name, env);
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  return raw === "1" || raw.toLowerCase() === "true";
+}

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -44,7 +44,8 @@ export function envPort(name: string, fallback: number, env?: EnvSource): number
 
 /**
  * Parse an integer env var with optional min/max bounds.
- * Returns `fallback` when unset or non-finite. Throws when outside bounds.
+ * Returns `fallback` when unset, non-finite, or outside bounds.
+ * Truncates toward zero (matching `parseInt` semantics).
  */
 export function envInt(
   name: string,
@@ -59,12 +60,12 @@ export function envInt(
   if (!Number.isFinite(parsed)) {
     return fallback;
   }
-  const value = Math.floor(parsed);
+  const value = Math.trunc(parsed);
   if (opts?.min !== undefined && value < opts.min) {
-    return opts.min;
+    return fallback;
   }
   if (opts?.max !== undefined && value > opts.max) {
-    return opts.max;
+    return fallback;
   }
   return value;
 }
@@ -92,12 +93,21 @@ export function envFlag(name: string, env?: EnvSource): boolean {
 
 /**
  * Parse a broad boolean: `"1"` / `"true"` → `true`, `"0"` / `"false"` → `false`,
- * unset/empty → `fallback`. Matches the `GRACKLE_KNOWLEDGE_ENABLED` convention.
+ * unset/empty/unrecognized → `fallback`. Matches the `GRACKLE_KNOWLEDGE_ENABLED`
+ * convention. Unrecognized values preserve the fallback so a typo doesn't
+ * silently flip a feature flag.
  */
 export function envBool(name: string, fallback: boolean, env?: EnvSource): boolean {
   const raw = resolve(name, env);
   if (raw === undefined || raw === "") {
     return fallback;
   }
-  return raw === "1" || raw.toLowerCase() === "true";
+  const lower = raw.toLowerCase();
+  if (lower === "1" || lower === "true") {
+    return true;
+  }
+  if (lower === "0" || lower === "false") {
+    return false;
+  }
+  return fallback;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,8 @@
 export * as grackle from "./grackle-barrel.js";
 export * as powerline from "./gen/grackle/powerline/powerline_pb.js";
 export * from "./types.js";
+export * from "./env.js";
+export * from "./config.js";
 export * from "./session-state-machine.js";
 export * from "./mcp-tool-presets.js";
 export * from "./enum-converters.js";

--- a/packages/core/src/grpc-shared-utils.ts
+++ b/packages/core/src/grpc-shared-utils.ts
@@ -25,17 +25,20 @@ export function validatePipeInputs(pipe: string, parentSessionId: string): void 
 
 /**
  * Map a bind host to a dialable URL host. Wildcard addresses become loopback,
- * unless GRACKLE_DOCKER_HOST is set (DooD mode) — in that case, use that value
+ * unless `dockerHost` is provided (DooD mode) — in that case, use that value
  * so sibling containers can reach the server by container name.
+ *
+ * Falls back to `GRACKLE_DOCKER_HOST` env var when `dockerHost` is not
+ * explicitly passed (backward compat during config migration).
  */
-export function toDialableHost(bindHost: string): string {
+export function toDialableHost(bindHost: string, dockerHost?: string): string {
   if (bindHost === "0.0.0.0" || bindHost === "::") {
-    const dockerHost = process.env.GRACKLE_DOCKER_HOST;
-    if (dockerHost) {
-      if (dockerHost.startsWith("[") && dockerHost.endsWith("]")) {
-        return dockerHost;
+    const resolved = dockerHost ?? process.env.GRACKLE_DOCKER_HOST;
+    if (resolved) {
+      if (resolved.startsWith("[") && resolved.endsWith("]")) {
+        return resolved;
       }
-      return dockerHost.includes(":") ? `[${dockerHost}]` : dockerHost;
+      return resolved.includes(":") ? `[${resolved}]` : resolved;
     }
     return bindHost === "::" ? "[::1]" : "127.0.0.1";
   }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,4 +1,5 @@
 import pino, { type Logger } from "pino";
+import { resolveLogConfig, type LogConfig } from "@grackle-ai/common";
 import { getTraceId } from "./trace-context.js";
 
 /** Pino mixin that auto-injects the active traceId into every log line. */
@@ -7,13 +8,14 @@ export function createLoggerMixin(): object {
   return traceId ? { traceId } : {};
 }
 
+const logConfig: Readonly<LogConfig> = resolveLogConfig();
+
 /** Application logger for the Grackle server. */
 export const logger: Logger = pino({
   name: "grackle-server",
-  level: process.env.LOG_LEVEL || "info",
+  level: logConfig.level,
   mixin: createLoggerMixin,
-  transport:
-    process.env.NODE_ENV !== "production"
-      ? { target: "pino/file", options: { destination: 1 } }
-      : undefined,
+  transport: !logConfig.isProduction
+    ? { target: "pino/file", options: { destination: 1 } }
+    : undefined,
 });

--- a/packages/core/src/reconciliation-manager.ts
+++ b/packages/core/src/reconciliation-manager.ts
@@ -5,6 +5,7 @@
  * stall detection, etc.) in a single background loop.
  */
 
+import { envInt } from "@grackle-ai/common";
 import { logger } from "./logger.js";
 
 /** Default tick interval in milliseconds. */
@@ -34,26 +35,9 @@ export class ReconciliationManager {
    */
   public constructor(phases: ReconciliationPhase[], tickIntervalMs?: number) {
     this.phases = phases;
-
-    if (tickIntervalMs !== undefined) {
-      this.tickIntervalMs = tickIntervalMs;
-    } else {
-      const envRaw = process.env.GRACKLE_RECONCILIATION_TICK_MS;
-      if (envRaw !== undefined && envRaw !== "") {
-        const parsed = parseInt(envRaw, 10);
-        if (Number.isFinite(parsed) && parsed > 0) {
-          this.tickIntervalMs = parsed;
-        } else {
-          logger.warn(
-            { envValue: envRaw, default: DEFAULT_TICK_INTERVAL_MS },
-            "Invalid GRACKLE_RECONCILIATION_TICK_MS; falling back to default",
-          );
-          this.tickIntervalMs = DEFAULT_TICK_INTERVAL_MS;
-        }
-      } else {
-        this.tickIntervalMs = DEFAULT_TICK_INTERVAL_MS;
-      }
-    }
+    this.tickIntervalMs =
+      tickIntervalMs ??
+      envInt("GRACKLE_RECONCILIATION_TICK_MS", DEFAULT_TICK_INTERVAL_MS, { min: 1 });
   }
 
   /** Start the periodic ticker. */

--- a/packages/core/src/resolve-spawn-spec.ts
+++ b/packages/core/src/resolve-spawn-spec.ts
@@ -23,6 +23,7 @@
  * @module
  */
 
+import { envOptionalString } from "@grackle-ai/common";
 import type { ToolConfigSpec, McpServerSpec } from "@grackle-ai/common";
 
 /**
@@ -322,6 +323,8 @@ export function spawnRequestToLayer(src: SpawnRequestSource): SpawnConfigLayer {
 export function hostDefaults(): SpawnConfigLayer {
   return {
     workingDirectory:
-      process.env.GRACKLE_WORKING_DIRECTORY || process.env.GRACKLE_WORKTREE_BASE || "/workspace",
+      envOptionalString("GRACKLE_WORKING_DIRECTORY") ??
+      envOptionalString("GRACKLE_WORKTREE_BASE") ??
+      "/workspace",
   };
 }

--- a/packages/core/src/spawn-context-registry.ts
+++ b/packages/core/src/spawn-context-registry.ts
@@ -17,6 +17,7 @@
  */
 
 import type { SpawnContextInput, SystemPromptContributor } from "@grackle-ai/plugin-sdk";
+import { envInt } from "@grackle-ai/common";
 import { logger } from "./logger.js";
 
 /** Default per-provider timeout (ms); override with `GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS`. */
@@ -49,8 +50,9 @@ function resolveTimeoutMs(override?: number): number {
   if (override !== undefined) {
     return override;
   }
-  const env: number = Number(process.env.GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS);
-  return Number.isFinite(env) && env > 0 ? env : DEFAULT_SPAWN_CONTEXT_TIMEOUT_MS;
+  return envInt("GRACKLE_KG_SPAWN_CONTEXT_TIMEOUT_MS", DEFAULT_SPAWN_CONTEXT_TIMEOUT_MS, {
+    min: 1,
+  });
 }
 
 /**

--- a/packages/core/src/task-session.ts
+++ b/packages/core/src/task-session.ts
@@ -23,7 +23,7 @@ import * as adapterManager from "./adapter-manager.js";
 import * as tokenPush from "./token-push.js";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
-import { LOGS_DIR, DEFAULT_MCP_PORT, ROOT_TASK_ID } from "@grackle-ai/common";
+import { LOGS_DIR, DEFAULT_MCP_PORT, ROOT_TASK_ID, envPort, envString } from "@grackle-ai/common";
 import {
   resolvePersona,
   buildOrchestratorContext,
@@ -218,8 +218,8 @@ export async function startTaskSession(
     resolved.mcpServers.length > 0 ? buildMcpServersJson(resolved.mcpServers) : "";
 
   // Build MCP broker URL + scoped token so runtimes can call the MCP server.
-  const mcpPort = parseInt(process.env.GRACKLE_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
-  const mcpDialHost = toDialableHost(process.env.GRACKLE_HOST || "127.0.0.1");
+  const mcpPort = envPort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT);
+  const mcpDialHost = toDialableHost(envString("GRACKLE_HOST", "127.0.0.1"));
   const mcpUrl = `http://${mcpDialHost}:${mcpPort}/mcp`;
   const mcpToken = createScopedToken(
     {

--- a/packages/core/src/to-dialable-host.test.ts
+++ b/packages/core/src/to-dialable-host.test.ts
@@ -14,39 +14,42 @@ describe("toDialableHost()", () => {
     expect(toDialableHost("::")).toBe("[::1]");
   });
 
-  it("returns GRACKLE_DOCKER_HOST when set and bindHost is 0.0.0.0", () => {
-    process.env.GRACKLE_DOCKER_HOST = "grackle";
-    expect(toDialableHost("0.0.0.0")).toBe("grackle");
+  it("uses explicit dockerHost parameter when bindHost is 0.0.0.0", () => {
+    expect(toDialableHost("0.0.0.0", "grackle")).toBe("grackle");
   });
 
-  it("returns GRACKLE_DOCKER_HOST when set and bindHost is ::", () => {
-    process.env.GRACKLE_DOCKER_HOST = "grackle";
-    expect(toDialableHost("::")).toBe("grackle");
+  it("uses explicit dockerHost parameter when bindHost is ::", () => {
+    expect(toDialableHost("::", "grackle")).toBe("grackle");
   });
 
-  it("wraps IPv6 GRACKLE_DOCKER_HOST in brackets when bindHost is 0.0.0.0", () => {
-    process.env.GRACKLE_DOCKER_HOST = "fd12::1";
-    expect(toDialableHost("0.0.0.0")).toBe("[fd12::1]");
+  it("falls back to GRACKLE_DOCKER_HOST env when dockerHost not passed", () => {
+    process.env.GRACKLE_DOCKER_HOST = "grackle-env";
+    expect(toDialableHost("0.0.0.0")).toBe("grackle-env");
   });
 
-  it("wraps IPv6 GRACKLE_DOCKER_HOST in brackets when bindHost is ::", () => {
-    process.env.GRACKLE_DOCKER_HOST = "fd12::1";
-    expect(toDialableHost("::")).toBe("[fd12::1]");
+  it("explicit dockerHost takes precedence over env var", () => {
+    process.env.GRACKLE_DOCKER_HOST = "from-env";
+    expect(toDialableHost("0.0.0.0", "from-param")).toBe("from-param");
   });
 
-  it("returns non-IPv6 GRACKLE_DOCKER_HOST unchanged", () => {
-    process.env.GRACKLE_DOCKER_HOST = "grackle.local";
-    expect(toDialableHost("0.0.0.0")).toBe("grackle.local");
+  it("wraps IPv6 dockerHost in brackets", () => {
+    expect(toDialableHost("0.0.0.0", "fd12::1")).toBe("[fd12::1]");
   });
 
-  it("does not double-wrap already-bracketed IPv6 GRACKLE_DOCKER_HOST", () => {
-    process.env.GRACKLE_DOCKER_HOST = "[fd12::1]";
-    expect(toDialableHost("0.0.0.0")).toBe("[fd12::1]");
+  it("wraps IPv6 dockerHost in brackets when bindHost is ::", () => {
+    expect(toDialableHost("::", "fd12::1")).toBe("[fd12::1]");
   });
 
-  it("does not use GRACKLE_DOCKER_HOST for explicit bind addresses", () => {
-    process.env.GRACKLE_DOCKER_HOST = "grackle";
-    expect(toDialableHost("127.0.0.1")).toBe("127.0.0.1");
+  it("returns non-IPv6 dockerHost unchanged", () => {
+    expect(toDialableHost("0.0.0.0", "grackle.local")).toBe("grackle.local");
+  });
+
+  it("does not double-wrap already-bracketed IPv6 dockerHost", () => {
+    expect(toDialableHost("0.0.0.0", "[fd12::1]")).toBe("[fd12::1]");
+  });
+
+  it("does not use dockerHost for explicit bind addresses", () => {
+    expect(toDialableHost("127.0.0.1", "grackle")).toBe("127.0.0.1");
   });
 
   it("wraps IPv6 addresses in brackets", () => {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,6 +5,10 @@ import {
   DEFAULT_MCP_PORT,
   DEFAULT_POWERLINE_PORT,
   DEFAULT_SANDBOX_PORT,
+  envPort,
+  envFlag,
+  envString,
+  envOptionalString,
 } from "@grackle-ai/common";
 import { parsePublicOrigin } from "@grackle-ai/auth";
 
@@ -100,30 +104,6 @@ export interface ServerConfig {
    * for `docker run` ergonomics — clear it when adding TLS.
    */
   allowInsecure: boolean;
-}
-
-/**
- * Parse and validate a port number from an environment variable.
- * Returns the default if the variable is not set.
- * Throws if the value is not a valid port (integer 1-65535).
- */
-function parsePort(envName: string, defaultValue: number): number {
-  const raw = process.env[envName];
-  if (!raw) {
-    return defaultValue;
-  }
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
-    throw new Error(
-      `Invalid port for ${envName}: "${raw}". Must be an integer between 1 and 65535.`,
-    );
-  }
-  return parsed;
-}
-
-/** Parse a boolean flag from an environment variable ("1" = true, anything else = false). */
-function parseFlag(envName: string): boolean {
-  return process.env[envName] === "1";
 }
 
 /**
@@ -259,30 +239,29 @@ function validateNetworkExposure(args: {
  */
 export function resolveServerConfig(): ServerConfig {
   const tls = parseTlsConfig();
-  const host = process.env.GRACKLE_HOST || "127.0.0.1";
+  const host = envString("GRACKLE_HOST", "127.0.0.1");
   const publicUrl = parsePublicUrl("GRACKLE_PUBLIC_URL");
-  const allowInsecure = parseFlag("GRACKLE_ALLOW_INSECURE");
-  // Run the network-exposure gate (#1374) before we finish building the config
-  // so the throw fires before any caller can spin up a listener with insecure
-  // defaults. Loopback binds are always allowed (today's casual local default).
+  const allowInsecure = envFlag("GRACKLE_ALLOW_INSECURE");
   validateNetworkExposure({ host, hasTls: !!tls, publicUrl, allowInsecure });
+
+  const mcpOrigin = envOptionalString("GRACKLE_MCP_ORIGIN");
+  const sandboxOrigin = envOptionalString("GRACKLE_SANDBOX_ORIGIN");
+
   return Object.freeze({
-    grpcPort: parsePort("GRACKLE_PORT", DEFAULT_SERVER_PORT),
-    webPort: parsePort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
-    mcpPort: parsePort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
+    grpcPort: envPort("GRACKLE_PORT", DEFAULT_SERVER_PORT),
+    webPort: envPort("GRACKLE_WEB_PORT", DEFAULT_WEB_PORT),
+    mcpPort: envPort("GRACKLE_MCP_PORT", DEFAULT_MCP_PORT),
     ...(publicUrl ? { publicUrl } : {}),
-    ...(process.env.GRACKLE_MCP_ORIGIN ? { mcpOrigin: process.env.GRACKLE_MCP_ORIGIN } : {}),
-    sandboxPort: parsePort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
-    ...(process.env.GRACKLE_SANDBOX_ORIGIN
-      ? { sandboxOrigin: process.env.GRACKLE_SANDBOX_ORIGIN }
-      : {}),
-    powerlinePort: parsePort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT),
+    ...(mcpOrigin ? { mcpOrigin } : {}),
+    sandboxPort: envPort("GRACKLE_SANDBOX_PORT", DEFAULT_SANDBOX_PORT),
+    ...(sandboxOrigin ? { sandboxOrigin } : {}),
+    powerlinePort: envPort("GRACKLE_POWERLINE_PORT", DEFAULT_POWERLINE_PORT),
     host,
-    skipLocalPowerline: parseFlag("GRACKLE_SKIP_LOCAL_POWERLINE"),
-    skipRootAutostart: parseFlag("GRACKLE_SKIP_ROOT_AUTOSTART"),
-    workingDirectory: process.env.GRACKLE_WORKING_DIRECTORY || undefined,
-    worktreeBase: process.env.GRACKLE_WORKTREE_BASE || undefined,
-    dockerHost: process.env.GRACKLE_DOCKER_HOST || undefined,
+    skipLocalPowerline: envFlag("GRACKLE_SKIP_LOCAL_POWERLINE"),
+    skipRootAutostart: envFlag("GRACKLE_SKIP_ROOT_AUTOSTART"),
+    workingDirectory: envOptionalString("GRACKLE_WORKING_DIRECTORY"),
+    worktreeBase: envOptionalString("GRACKLE_WORKTREE_BASE"),
+    dockerHost: envOptionalString("GRACKLE_DOCKER_HOST"),
     ...(tls ? { tls } : {}),
     allowInsecure,
   });


### PR DESCRIPTION
## Summary
- Add `envString`/`envPort`/`envFlag`/`envBool`/`envInt`/`envNum` parsing utilities and typed `GrackleConfig` with per-concern resolvers (`resolveNetworkConfig`, `resolveLogConfig`, etc.) to `@grackle-ai/common`. Every function accepts an optional `EnvSource` parameter for clean test isolation without `process.env` mutation.
- Refactor `packages/server/src/config.ts` to use common's `envPort`/`envFlag`/`envOptionalString` instead of local `parsePort`/`parseFlag` implementations.
- Refactor `packages/core` to eliminate scattered `process.env.GRACKLE_*` reads: `toDialableHost` accepts a `dockerHost` parameter, `task-session` uses `envPort`/`envString`, `reconciliation-manager` and `spawn-context-registry` use `envInt`, `resolve-spawn-spec` uses `envOptionalString`, and `logger` uses `resolveLogConfig()`.

## Test plan
- [x] `rush build` — all 42 packages compile with zero warnings
- [x] `packages/common` — 293 tests pass (including 59 new env/config tests)
- [x] `packages/server` — 152 tests pass (existing config tests unchanged)
- [x] `packages/core` — 581 tests pass (updated `toDialableHost` tests use parameter injection)
- [x] `packages/plugin-core` — 461 tests pass
- [x] `packages/plugin-scheduling` — 76 tests pass

Closes #1476