### PR TITLE
Scope tunnel registry into instance class

### DIFF
--- a/common/api/adapter-sdk.public.api.md
+++ b/common/api/adapter-sdk.public.api.md
@@ -24,6 +24,7 @@ export interface AdapterDependencies {
     logger?: AdapterLogger;
     resolveGitHubToken?: (accountId?: string) => string | undefined;
     sleep?: (ms: number) => Promise<void>;
+    tunnelRegistry?: TunnelRegistry;
 }
 
 // @public
@@ -138,13 +139,7 @@ export function buildEnvFileContent(powerlineToken: string, extraEnv?: Record<st
 export function buildRemoteKillCommand(): string;
 
 // @public
-export function closeAllTunnels(logger?: AdapterLogger): Promise<void>;
-
-// @public
-export function closeTunnel(environmentId: string): Promise<void>;
-
-// @public
-export function connectThroughTunnel(environmentId: string, localPort: number, powerlineToken: string, logger?: AdapterLogger): Promise<PowerLineConnection>;
+export function connectThroughTunnel(environmentId: string, localPort: number, powerlineToken: string, tunnelRegistry: TunnelRegistry, logger?: AdapterLogger): Promise<PowerLineConnection>;
 
 export { ContentEncoding }
 
@@ -228,9 +223,6 @@ export function findFreePort(): Promise<number>;
 
 // @public
 export function getPackageVersion(): string;
-
-// @public
-export function getTunnel(environmentId: string): TunnelState | undefined;
 
 // @public
 export interface HostSessionInfo {
@@ -334,16 +326,13 @@ export interface ReanimateParams {
 export function reconnectOrProvision(environmentId: string, adapter: EnvironmentAdapter, config: Record<string, unknown>, powerlineToken: string, bootstrapped: boolean, force?: boolean, logger?: AdapterLogger): AsyncGenerator<ProvisionEvent>;
 
 // @public
-export function registerTunnel(environmentId: string, state: TunnelState, logger?: AdapterLogger): void;
-
-// @public
 export const REMOTE_EXEC_DEFAULT_TIMEOUT_MS: number;
 
 // @public
 export const REMOTE_POWERLINE_DIRECTORY: string;
 
 // @public
-export function remoteDestroy(environmentId: string, executor: RemoteExecutor, logger?: AdapterLogger): Promise<void>;
+export function remoteDestroy(environmentId: string, executor: RemoteExecutor, tunnelRegistry: TunnelRegistry, logger?: AdapterLogger): Promise<void>;
 
 // @public
 export interface RemoteExecutor {
@@ -354,10 +343,10 @@ export interface RemoteExecutor {
 }
 
 // @public
-export function remoteHealthCheck(connection: PowerLineConnection): Promise<boolean>;
+export function remoteHealthCheck(connection: PowerLineConnection, tunnelRegistry: TunnelRegistry): Promise<boolean>;
 
 // @public
-export function remoteStop(environmentId: string, executor: RemoteExecutor, logger?: AdapterLogger): Promise<void>;
+export function remoteStop(environmentId: string, executor: RemoteExecutor, tunnelRegistry: TunnelRegistry, logger?: AdapterLogger): Promise<void>;
 
 // @public
 export interface RemoteTunnel {
@@ -408,6 +397,8 @@ export abstract class RemoteTunnelAdapter<TConfig extends RemoteTunnelConfig = R
     }>;
     // (undocumented)
     protected readonly sleepFn: (ms: number) => Promise<void>;
+    // (undocumented)
+    protected readonly tunnelRegistry: TunnelRegistry;
 }
 
 // @public
@@ -488,6 +479,14 @@ export interface TunnelPortProbe {
 // @public
 export interface TunnelProcessFactory {
     spawn(command: string, args: string[], options: SpawnOptions): ChildProcess;
+}
+
+// @public
+export class TunnelRegistry {
+    close(environmentId: string): Promise<void>;
+    closeAll(logger?: AdapterLogger): Promise<void>;
+    get(environmentId: string): TunnelState | undefined;
+    register(environmentId: string, state: TunnelState, logger?: AdapterLogger): void;
 }
 
 // @public

--- a/common/changes/@grackle-ai/cli/nick-pape-1477-tunnel-registry_2026-06-05-06-43.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1477-tunnel-registry_2026-06-05-06-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Scope tunnel registry into TunnelRegistry class for per-instance isolation",
-      "type": "patch",
+      "type": "minor",
       "packageName": "@grackle-ai/cli"
     }
   ],

--- a/common/changes/@grackle-ai/cli/nick-pape-1477-tunnel-registry_2026-06-05-06-43.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1477-tunnel-registry_2026-06-05-06-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Scope tunnel registry into TunnelRegistry class for per-instance isolation",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -835,7 +835,12 @@ export class DockerAdapter extends BaseAdapter {
     // Attach mode: never stop the externally-managed container. Stop the
     // in-container PowerLine and remove our connectivity sidecar only.
     if (cfg.attach) {
-      await remoteStop(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.tunnelRegistry, this.logger);
+      await remoteStop(
+        environmentId,
+        new DockerExecutor(cfg.attach, this.execFn),
+        this.tunnelRegistry,
+        this.logger,
+      );
       await removeSidecar(this.execFn, `${ATTACH_SIDECAR_PREFIX}${environmentId}`, this.logger);
       this.attachConnections.delete(environmentId);
       this.containerPorts.delete(environmentId);
@@ -857,7 +862,12 @@ export class DockerAdapter extends BaseAdapter {
     // Attach mode: never remove the externally-managed container. Stop the
     // in-container PowerLine, clean up its artifacts, and remove our sidecar.
     if (cfg.attach) {
-      await remoteDestroy(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.tunnelRegistry, this.logger);
+      await remoteDestroy(
+        environmentId,
+        new DockerExecutor(cfg.attach, this.execFn),
+        this.tunnelRegistry,
+        this.logger,
+      );
       await removeSidecar(this.execFn, `${ATTACH_SIDECAR_PREFIX}${environmentId}`, this.logger);
       this.attachConnections.delete(environmentId);
       this.containerPorts.delete(environmentId);

--- a/packages/adapter-docker/src/docker.ts
+++ b/packages/adapter-docker/src/docker.ts
@@ -10,6 +10,7 @@ import type {
 } from "@grackle-ai/adapter-sdk";
 import {
   BaseAdapter,
+  TunnelRegistry,
   createAhpHostTransport,
   isDevMode,
   bootstrapPowerLine,
@@ -471,6 +472,7 @@ export class DockerAdapter extends BaseAdapter {
   private readonly sleepFn: (ms: number) => Promise<void>;
   private readonly logger: AdapterLogger;
   private readonly isGitHubProviderEnabled: () => boolean;
+  private readonly tunnelRegistry: TunnelRegistry;
   private readonly containerPorts: Map<string, number> = new Map<string, number>();
   private readonly attachConnections: Map<string, AttachConnection> = new Map<
     string,
@@ -483,6 +485,7 @@ export class DockerAdapter extends BaseAdapter {
     this.sleepFn = deps.sleep ?? defaultSleep;
     this.logger = deps.logger ?? defaultLogger;
     this.isGitHubProviderEnabled = deps.isGitHubProviderEnabled ?? (() => false);
+    this.tunnelRegistry = deps.tunnelRegistry ?? new TunnelRegistry();
   }
 
   protected async *doProvision(
@@ -832,7 +835,7 @@ export class DockerAdapter extends BaseAdapter {
     // Attach mode: never stop the externally-managed container. Stop the
     // in-container PowerLine and remove our connectivity sidecar only.
     if (cfg.attach) {
-      await remoteStop(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.logger);
+      await remoteStop(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.tunnelRegistry, this.logger);
       await removeSidecar(this.execFn, `${ATTACH_SIDECAR_PREFIX}${environmentId}`, this.logger);
       this.attachConnections.delete(environmentId);
       this.containerPorts.delete(environmentId);
@@ -854,7 +857,7 @@ export class DockerAdapter extends BaseAdapter {
     // Attach mode: never remove the externally-managed container. Stop the
     // in-container PowerLine, clean up its artifacts, and remove our sidecar.
     if (cfg.attach) {
-      await remoteDestroy(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.logger);
+      await remoteDestroy(environmentId, new DockerExecutor(cfg.attach, this.execFn), this.tunnelRegistry, this.logger);
       await removeSidecar(this.execFn, `${ATTACH_SIDECAR_PREFIX}${environmentId}`, this.logger);
       this.attachConnections.delete(environmentId);
       this.containerPorts.delete(environmentId);

--- a/packages/adapter-sdk/src/adapter-dependencies.ts
+++ b/packages/adapter-sdk/src/adapter-dependencies.ts
@@ -1,5 +1,6 @@
 import type { AdapterLogger } from "./logger.js";
 import type { ExecResult } from "./exec.js";
+import type { TunnelRegistry } from "./tunnel-registry.js";
 
 /** Function signature for executing local commands. */
 export type ExecFunction = (
@@ -25,4 +26,6 @@ export interface AdapterDependencies {
    * Returns `undefined` when no token can be resolved (caller should fall back to `gh auth token`).
    */
   resolveGitHubToken?: (accountId?: string) => string | undefined;
+  /** Shared tunnel registry for managing active tunnel state (default: new TunnelRegistry()). */
+  tunnelRegistry?: TunnelRegistry;
 }

--- a/packages/adapter-sdk/src/connect.ts
+++ b/packages/adapter-sdk/src/connect.ts
@@ -2,7 +2,7 @@ import { AhpClientSocket, InMemoryClientIdStore } from "@grackle-ai/ahp-transpor
 import { createConnection } from "node:net";
 import type { PowerLineConnection } from "./adapter.js";
 import { AhpHostTransport } from "./ahp-host-transport.js";
-import { closeTunnel } from "./tunnel-registry.js";
+import type { TunnelRegistry } from "./tunnel-registry.js";
 import { sleep } from "./utils.js";
 import type { AdapterLogger } from "./logger.js";
 import { defaultLogger } from "./logger.js";
@@ -92,6 +92,7 @@ export async function connectThroughTunnel(
   environmentId: string,
   localPort: number,
   powerlineToken: string,
+  tunnelRegistry: TunnelRegistry,
   logger: AdapterLogger = defaultLogger,
 ): Promise<PowerLineConnection> {
   const baseUrl = `ws://127.0.0.1:${localPort}`;
@@ -138,7 +139,7 @@ export async function connectThroughTunnel(
 
   // Clean up the tunnel so we don't leak background processes on connect failure
   try {
-    await closeTunnel(environmentId);
+    await tunnelRegistry.close(environmentId);
   } catch (err) {
     logger.error({ environmentId, err }, "Failed to close tunnel after connect failure");
   }

--- a/packages/adapter-sdk/src/index.ts
+++ b/packages/adapter-sdk/src/index.ts
@@ -29,7 +29,7 @@ export type { RemoteExecutor } from "./remote-executor.js";
 export type { RemoteTunnel, TunnelProcessFactory, TunnelPortProbe } from "./tunnel.js";
 export { ProcessTunnel, ProcessReverseTunnel, REVERSE_TUNNEL_SETTLE_MS } from "./tunnel.js";
 export type { TunnelState } from "./tunnel-registry.js";
-export { registerTunnel, getTunnel, closeTunnel, closeAllTunnels } from "./tunnel-registry.js";
+export { TunnelRegistry } from "./tunnel-registry.js";
 
 // ─── Connect ────────────────────────────────────────────────
 export type { PortProber, WaitForLocalPortOptions } from "./connect.js";

--- a/packages/adapter-sdk/src/remote-tunnel-adapter.ts
+++ b/packages/adapter-sdk/src/remote-tunnel-adapter.ts
@@ -10,7 +10,7 @@ import { FatalAdapterError } from "./fatal-error.js";
 import { DEFAULT_MCP_PORT } from "@grackle-ai/common";
 import { bootstrapPowerLine, startRemotePowerLine } from "./bootstrap.js";
 import { connectThroughTunnel } from "./connect.js";
-import { registerTunnel, getTunnel, closeTunnel } from "./tunnel-registry.js";
+import { TunnelRegistry } from "./tunnel-registry.js";
 import { remoteStop, remoteDestroy, remoteHealthCheck } from "./shared-operations.js";
 import { sleep as defaultSleep, withFreePort, SSH_CONNECTIVITY_TIMEOUT_MS } from "./utils.js";
 import { exec as defaultExec } from "./exec.js";
@@ -62,6 +62,7 @@ export abstract class RemoteTunnelAdapter<
   protected readonly sleepFn: (ms: number) => Promise<void>;
   protected readonly isGitHubProviderEnabled: () => boolean;
   protected readonly resolveGitHubToken: (accountId?: string) => string | undefined;
+  protected readonly tunnelRegistry: TunnelRegistry;
 
   public constructor(deps: AdapterDependencies = {}) {
     super();
@@ -69,6 +70,7 @@ export abstract class RemoteTunnelAdapter<
     this.sleepFn = deps.sleep ?? defaultSleep;
     this.isGitHubProviderEnabled = deps.isGitHubProviderEnabled ?? (() => false);
     this.resolveGitHubToken = deps.resolveGitHubToken ?? (() => undefined);
+    this.tunnelRegistry = deps.tunnelRegistry ?? new TunnelRegistry();
   }
 
   // ─── Abstract factories (subclasses MUST implement) ────────
@@ -151,37 +153,37 @@ export abstract class RemoteTunnelAdapter<
     localPort: number,
     powerlineToken: string,
   ): Promise<PowerLineConnection> {
-    return connectThroughTunnel(environmentId, localPort, powerlineToken);
+    return connectThroughTunnel(environmentId, localPort, powerlineToken, this.tunnelRegistry);
   }
 
   /** Close and unregister the tunnel(s) for an environment. */
   protected async closeTunnelForEnvironment(environmentId: string): Promise<void> {
-    await closeTunnel(environmentId);
+    await this.tunnelRegistry.close(environmentId);
   }
 
   /** Register an active tunnel pair for an environment. */
   protected registerTunnelForEnvironment(environmentId: string, state: TunnelState): void {
-    registerTunnel(environmentId, state);
+    this.tunnelRegistry.register(environmentId, state);
   }
 
   /** Get the tunnel state for an environment. */
   protected getTunnelForEnvironment(environmentId: string): TunnelState | undefined {
-    return getTunnel(environmentId);
+    return this.tunnelRegistry.get(environmentId);
   }
 
   /** Stop the remote PowerLine and close the tunnel. */
   protected async runRemoteStop(environmentId: string, executor: RemoteExecutor): Promise<void> {
-    await remoteStop(environmentId, executor);
+    await remoteStop(environmentId, executor, this.tunnelRegistry);
   }
 
   /** Destroy remote PowerLine artifacts and close the tunnel. */
   protected async runRemoteDestroy(environmentId: string, executor: RemoteExecutor): Promise<void> {
-    await remoteDestroy(environmentId, executor);
+    await remoteDestroy(environmentId, executor, this.tunnelRegistry);
   }
 
   /** Ping the PowerLine to check liveness. */
   protected async runHealthCheck(connection: PowerLineConnection): Promise<boolean> {
-    return remoteHealthCheck(connection);
+    return remoteHealthCheck(connection, this.tunnelRegistry);
   }
 
   // ─── Shared lifecycle ──────────────────────────────────────

--- a/packages/adapter-sdk/src/shared-operations.test.ts
+++ b/packages/adapter-sdk/src/shared-operations.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock the tunnel-registry so we can control what getTunnel returns
-vi.mock("./tunnel-registry.js", () => ({
-  getTunnel: vi.fn(),
-  closeTunnel: vi.fn().mockResolvedValue(undefined),
-}));
-
-import { getTunnel } from "./tunnel-registry.js";
+import { TunnelRegistry } from "./tunnel-registry.js";
 import { remoteHealthCheck } from "./shared-operations.js";
 import type { PowerLineConnection } from "./adapter.js";
 
@@ -32,71 +26,66 @@ function createMockConnection(pingFn?: () => Promise<unknown>): PowerLineConnect
 
 // ── Tests ───────────────────────────────────────────────────
 
+let registry: TunnelRegistry;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  registry = new TunnelRegistry();
 });
 
 describe("remoteHealthCheck", () => {
   it("returns false when no tunnel state is registered", async () => {
-    vi.mocked(getTunnel).mockReturnValue(undefined);
     const conn = createMockConnection();
-    await expect(remoteHealthCheck(conn)).resolves.toBe(false);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(false);
     expect(conn.ping).not.toHaveBeenCalled();
   });
 
   it("returns false when the forward tunnel is dead", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
-      tunnel: createMockTunnel(false),
-    });
+    registry.register("env-1", { tunnel: createMockTunnel(false) });
     const conn = createMockConnection();
-    await expect(remoteHealthCheck(conn)).resolves.toBe(false);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(false);
     expect(conn.ping).not.toHaveBeenCalled();
   });
 
   it("returns false when the reverse tunnel is dead but the forward tunnel is alive", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
+    registry.register("env-1", {
       tunnel: createMockTunnel(true),
       reverseTunnel: createMockTunnel(false),
     });
     const conn = createMockConnection();
-    await expect(remoteHealthCheck(conn)).resolves.toBe(false);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(false);
     expect(conn.ping).not.toHaveBeenCalled();
   });
 
   it("returns true when both tunnels are alive and ping succeeds", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
+    registry.register("env-1", {
       tunnel: createMockTunnel(true),
       reverseTunnel: createMockTunnel(true),
     });
     const conn = createMockConnection();
-    await expect(remoteHealthCheck(conn)).resolves.toBe(true);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(true);
     expect(conn.ping).toHaveBeenCalledOnce();
   });
 
   it("returns true when no reverse tunnel is registered (local/docker adapters)", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
-      tunnel: createMockTunnel(true),
-      // no reverseTunnel
-    });
+    registry.register("env-1", { tunnel: createMockTunnel(true) });
     const conn = createMockConnection();
-    await expect(remoteHealthCheck(conn)).resolves.toBe(true);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(true);
     expect(conn.ping).toHaveBeenCalledOnce();
   });
 
   it("returns false when both tunnels are alive but ping throws", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
+    registry.register("env-1", {
       tunnel: createMockTunnel(true),
       reverseTunnel: createMockTunnel(true),
     });
     const conn = createMockConnection(() => Promise.reject(new Error("ECONNREFUSED")));
-    await expect(remoteHealthCheck(conn)).resolves.toBe(false);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(false);
   });
 
   it("returns false when forward tunnel is alive but ping throws (no reverse tunnel)", async () => {
-    vi.mocked(getTunnel).mockReturnValue({
-      tunnel: createMockTunnel(true),
-    });
+    registry.register("env-1", { tunnel: createMockTunnel(true) });
     const conn = createMockConnection(() => Promise.reject(new Error("timeout")));
-    await expect(remoteHealthCheck(conn)).resolves.toBe(false);
+    await expect(remoteHealthCheck(conn, registry)).resolves.toBe(false);
   });
 });

--- a/packages/adapter-sdk/src/shared-operations.ts
+++ b/packages/adapter-sdk/src/shared-operations.ts
@@ -1,6 +1,6 @@
 import type { PowerLineConnection } from "./adapter.js";
 import type { RemoteExecutor } from "./remote-executor.js";
-import { closeTunnel, getTunnel } from "./tunnel-registry.js";
+import type { TunnelRegistry } from "./tunnel-registry.js";
 import { buildRemoteKillCommand } from "./bootstrap.js";
 import { REMOTE_POWERLINE_DIRECTORY } from "./utils.js";
 import type { AdapterLogger } from "./logger.js";
@@ -13,6 +13,7 @@ import { defaultLogger } from "./logger.js";
 export async function remoteStop(
   environmentId: string,
   executor: RemoteExecutor,
+  tunnelRegistry: TunnelRegistry,
   logger: AdapterLogger = defaultLogger,
 ): Promise<void> {
   try {
@@ -23,7 +24,7 @@ export async function remoteStop(
       "Failed to kill remote PowerLine (may already be stopped)",
     );
   }
-  await closeTunnel(environmentId);
+  await tunnelRegistry.close(environmentId);
 }
 
 /**
@@ -33,6 +34,7 @@ export async function remoteStop(
 export async function remoteDestroy(
   environmentId: string,
   executor: RemoteExecutor,
+  tunnelRegistry: TunnelRegistry,
   logger: AdapterLogger = defaultLogger,
 ): Promise<void> {
   try {
@@ -47,12 +49,15 @@ export async function remoteDestroy(
   } catch (err) {
     logger.debug({ environmentId, err }, "Failed to clean up remote PowerLine artifacts");
   }
-  await closeTunnel(environmentId);
+  await tunnelRegistry.close(environmentId);
 }
 
 /** Check that the tunnel is alive and the PowerLine responds to a ping. */
-export async function remoteHealthCheck(connection: PowerLineConnection): Promise<boolean> {
-  const state = getTunnel(connection.environmentId);
+export async function remoteHealthCheck(
+  connection: PowerLineConnection,
+  tunnelRegistry: TunnelRegistry,
+): Promise<boolean> {
+  const state = tunnelRegistry.get(connection.environmentId);
   if (!state?.tunnel.isAlive()) {
     return false;
   }

--- a/packages/adapter-sdk/src/tunnel-registry.test.ts
+++ b/packages/adapter-sdk/src/tunnel-registry.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TunnelRegistry } from "./tunnel-registry.js";
+import type { RemoteTunnel } from "./tunnel.js";
+
+function createMockTunnel(): RemoteTunnel {
+  return {
+    localPort: 12345,
+    isAlive: vi.fn().mockReturnValue(true),
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("TunnelRegistry", () => {
+  let registry: TunnelRegistry;
+
+  beforeEach(() => {
+    registry = new TunnelRegistry();
+  });
+
+  it("register() stores state retrievable via get()", () => {
+    const tunnel = createMockTunnel();
+    registry.register("env-1", { tunnel });
+    expect(registry.get("env-1")).toEqual({ tunnel });
+  });
+
+  it("get() returns undefined for unregistered IDs", () => {
+    expect(registry.get("nonexistent")).toBeUndefined();
+  });
+
+  it("register() closes existing tunnel when replacing", () => {
+    const oldTunnel = createMockTunnel();
+    const newTunnel = createMockTunnel();
+    registry.register("env-1", { tunnel: oldTunnel });
+    registry.register("env-1", { tunnel: newTunnel });
+
+    expect(oldTunnel.close).toHaveBeenCalledOnce();
+    expect(registry.get("env-1")!.tunnel).toBe(newTunnel);
+  });
+
+  it("register() closes existing reverse tunnel when replacing", () => {
+    const oldTunnel = createMockTunnel();
+    const oldReverse = createMockTunnel();
+    const newTunnel = createMockTunnel();
+    registry.register("env-1", { tunnel: oldTunnel, reverseTunnel: oldReverse });
+    registry.register("env-1", { tunnel: newTunnel });
+
+    expect(oldTunnel.close).toHaveBeenCalledOnce();
+    expect(oldReverse.close).toHaveBeenCalledOnce();
+  });
+
+  it("close() closes both tunnels and removes from registry", async () => {
+    const tunnel = createMockTunnel();
+    const reverse = createMockTunnel();
+    registry.register("env-1", { tunnel, reverseTunnel: reverse });
+
+    await registry.close("env-1");
+
+    expect(tunnel.close).toHaveBeenCalledOnce();
+    expect(reverse.close).toHaveBeenCalledOnce();
+    expect(registry.get("env-1")).toBeUndefined();
+  });
+
+  it("close() is a no-op for unknown IDs", async () => {
+    await expect(registry.close("nonexistent")).resolves.toBeUndefined();
+  });
+
+  it("closeAll() closes all registered tunnels", async () => {
+    const t1 = createMockTunnel();
+    const t2 = createMockTunnel();
+    registry.register("env-1", { tunnel: t1 });
+    registry.register("env-2", { tunnel: t2 });
+
+    await registry.closeAll();
+
+    expect(t1.close).toHaveBeenCalledOnce();
+    expect(t2.close).toHaveBeenCalledOnce();
+    expect(registry.get("env-1")).toBeUndefined();
+    expect(registry.get("env-2")).toBeUndefined();
+  });
+
+  it("closeAll() logs errors but continues on individual failures", async () => {
+    const t1 = createMockTunnel();
+    t1.close = vi.fn().mockRejectedValue(new Error("close failed"));
+    const t2 = createMockTunnel();
+    registry.register("env-1", { tunnel: t1 });
+    registry.register("env-2", { tunnel: t2 });
+
+    const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await registry.closeAll(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledOnce();
+    expect(t2.close).toHaveBeenCalledOnce();
+    expect(registry.get("env-2")).toBeUndefined();
+  });
+
+  it("instances are isolated from each other", () => {
+    const r1 = new TunnelRegistry();
+    const r2 = new TunnelRegistry();
+    const tunnel = createMockTunnel();
+
+    r1.register("env-1", { tunnel });
+
+    expect(r1.get("env-1")).toBeDefined();
+    expect(r2.get("env-1")).toBeUndefined();
+  });
+});

--- a/packages/adapter-sdk/src/tunnel-registry.ts
+++ b/packages/adapter-sdk/src/tunnel-registry.ts
@@ -9,59 +9,62 @@ export interface TunnelState {
   reverseTunnel?: RemoteTunnel;
 }
 
-const tunnelMap: Map<string, TunnelState> = new Map<string, TunnelState>();
+/** Per-instance registry of active tunnels, injected via {@link AdapterDependencies}. */
+export class TunnelRegistry {
+  private readonly tunnelMap: Map<string, TunnelState> = new Map<string, TunnelState>();
 
-/** Register an active tunnel for an environment, closing any existing tunnel first. */
-export function registerTunnel(
-  environmentId: string,
-  state: TunnelState,
-  logger: AdapterLogger = defaultLogger,
-): void {
-  const existing = tunnelMap.get(environmentId);
-  if (existing) {
-    existing.tunnel.close().catch((err) => {
-      logger.warn(
-        { err, environmentId },
-        "Failed to close existing tunnel before registering new one",
-      );
-    });
-    if (existing.reverseTunnel) {
-      existing.reverseTunnel.close().catch((err) => {
+  /** Register an active tunnel for an environment, closing any existing tunnel first. */
+  public register(
+    environmentId: string,
+    state: TunnelState,
+    logger: AdapterLogger = defaultLogger,
+  ): void {
+    const existing = this.tunnelMap.get(environmentId);
+    if (existing) {
+      existing.tunnel.close().catch((err) => {
         logger.warn(
           { err, environmentId },
-          "Failed to close existing reverse tunnel before registering new one",
+          "Failed to close existing tunnel before registering new one",
         );
       });
+      if (existing.reverseTunnel) {
+        existing.reverseTunnel.close().catch((err) => {
+          logger.warn(
+            { err, environmentId },
+            "Failed to close existing reverse tunnel before registering new one",
+          );
+        });
+      }
+    }
+    this.tunnelMap.set(environmentId, state);
+  }
+
+  /** Get the tunnel state for an environment. */
+  public get(environmentId: string): TunnelState | undefined {
+    return this.tunnelMap.get(environmentId);
+  }
+
+  /** Close and unregister the tunnel(s) for an environment. */
+  public async close(environmentId: string): Promise<void> {
+    const state = this.tunnelMap.get(environmentId);
+    if (state) {
+      await state.tunnel.close();
+      if (state.reverseTunnel) {
+        await state.reverseTunnel.close();
+      }
+      this.tunnelMap.delete(environmentId);
     }
   }
-  tunnelMap.set(environmentId, state);
-}
 
-/** Get the tunnel state for an environment. */
-export function getTunnel(environmentId: string): TunnelState | undefined {
-  return tunnelMap.get(environmentId);
-}
-
-/** Close and unregister the tunnel(s) for an environment. */
-export async function closeTunnel(environmentId: string): Promise<void> {
-  const state = tunnelMap.get(environmentId);
-  if (state) {
-    await state.tunnel.close();
-    if (state.reverseTunnel) {
-      await state.reverseTunnel.close();
-    }
-    tunnelMap.delete(environmentId);
-  }
-}
-
-/** Close all active tunnels (called during server shutdown). */
-export async function closeAllTunnels(logger: AdapterLogger = defaultLogger): Promise<void> {
-  const ids = [...tunnelMap.keys()];
-  for (const id of ids) {
-    try {
-      await closeTunnel(id);
-    } catch (err) {
-      logger.error({ environmentId: id, err }, "Failed to close tunnel during shutdown");
+  /** Close all active tunnels (called during server shutdown). */
+  public async closeAll(logger: AdapterLogger = defaultLogger): Promise<void> {
+    const ids = [...this.tunnelMap.keys()];
+    for (const id of ids) {
+      try {
+        await this.close(id);
+      } catch (err) {
+        logger.error({ environmentId: id, err }, "Failed to close tunnel during shutdown");
+      }
     }
   }
 }

--- a/packages/server/src/adapter-registry.ts
+++ b/packages/server/src/adapter-registry.ts
@@ -1,5 +1,6 @@
 import { registerAdapter, exec, logger } from "@grackle-ai/core";
 import { credentialProviders, githubAccountStore } from "@grackle-ai/database";
+import { TunnelRegistry } from "@grackle-ai/adapter-sdk";
 import { DockerAdapter } from "@grackle-ai/adapter-docker";
 import { LocalAdapter } from "@grackle-ai/adapter-local";
 import { SshAdapter } from "@grackle-ai/adapter-ssh";
@@ -8,11 +9,15 @@ import { CodespaceAdapter } from "@grackle-ai/adapter-codespace";
 /**
  * Register all built-in environment adapters (Docker, Local, SSH, Codespace)
  * with the adapter manager, injecting shared server dependencies.
+ *
+ * @returns The shared {@link TunnelRegistry} instance for shutdown cleanup.
  */
-export function registerAllAdapters(): void {
+export function registerAllAdapters(): TunnelRegistry {
+  const tunnelRegistry = new TunnelRegistry();
   const adapterDeps = {
     exec,
     logger,
+    tunnelRegistry,
     isGitHubProviderEnabled: (): boolean =>
       credentialProviders.getCredentialProviders().github !== "off",
     resolveGitHubToken: (accountId?: string): string | undefined =>
@@ -23,4 +28,5 @@ export function registerAllAdapters(): void {
   registerAdapter(new LocalAdapter());
   registerAdapter(new SshAdapter(adapterDeps));
   registerAdapter(new CodespaceAdapter(adapterDeps));
+  return tunnelRegistry;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -197,7 +197,7 @@ async function main(): Promise<void> {
   const apiKey = loadOrCreateApiKey(grackleHome);
 
   // Register all built-in environment adapters
-  registerAllAdapters();
+  const tunnelRegistry = registerAllAdapters();
 
   // Bootstrap the local environment (PowerLine + provisioning)
   const { powerLineManager: localPowerLineManager } = await bootstrapLocalEnvironment(
@@ -634,6 +634,7 @@ async function main(): Promise<void> {
     reconciliationManager,
     localPowerLineManager,
     pluginShutdown: loaded.shutdown,
+    tunnelRegistry,
   });
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/packages/server/src/shutdown.test.ts
+++ b/packages/server/src/shutdown.test.ts
@@ -75,7 +75,9 @@ function createMockContext(overrides?: Partial<ShutdownContext>): ShutdownContex
     },
     reconciliationManager: { stop: vi.fn(async () => {}) },
     localPowerLineManager: { stop: vi.fn(async () => {}) },
-    tunnelRegistry: { closeAll: vi.fn(async () => {}) } as unknown as ShutdownContext["tunnelRegistry"],
+    tunnelRegistry: {
+      closeAll: vi.fn(async () => {}),
+    } as unknown as ShutdownContext["tunnelRegistry"],
     ...overrides,
   };
 }

--- a/packages/server/src/shutdown.test.ts
+++ b/packages/server/src/shutdown.test.ts
@@ -32,8 +32,6 @@ vi.mock("@grackle-ai/auth", () => ({
   stopOAuthCleanup: vi.fn(),
 }));
 
-vi.mock("@grackle-ai/adapter-sdk", () => ({}));
-
 import { createShutdown, type ShutdownContext } from "./shutdown.js";
 import { logger } from "@grackle-ai/core";
 import { stopWalCheckpointTimer } from "@grackle-ai/database";

--- a/packages/server/src/shutdown.test.ts
+++ b/packages/server/src/shutdown.test.ts
@@ -32,15 +32,12 @@ vi.mock("@grackle-ai/auth", () => ({
   stopOAuthCleanup: vi.fn(),
 }));
 
-vi.mock("@grackle-ai/adapter-sdk", () => ({
-  closeAllTunnels: vi.fn(async () => {}),
-}));
+vi.mock("@grackle-ai/adapter-sdk", () => ({}));
 
 import { createShutdown, type ShutdownContext } from "./shutdown.js";
 import { logger } from "@grackle-ai/core";
 import { stopWalCheckpointTimer } from "@grackle-ai/database";
 import { stopPairingCleanup, stopSessionCleanup, stopOAuthCleanup } from "@grackle-ai/auth";
-import { closeAllTunnels } from "@grackle-ai/adapter-sdk";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const { __setSqlite } = (await import("@grackle-ai/database")) as unknown as {
@@ -78,6 +75,7 @@ function createMockContext(overrides?: Partial<ShutdownContext>): ShutdownContex
     },
     reconciliationManager: { stop: vi.fn(async () => {}) },
     localPowerLineManager: { stop: vi.fn(async () => {}) },
+    tunnelRegistry: { closeAll: vi.fn(async () => {}) } as unknown as ShutdownContext["tunnelRegistry"],
     ...overrides,
   };
 }
@@ -143,9 +141,10 @@ describe("createShutdown", () => {
   });
 
   it("closes all tunnels", async () => {
-    const shutdown = createShutdown(createMockContext());
+    const ctx = createMockContext();
+    const shutdown = createShutdown(ctx);
     await shutdown();
-    expect(closeAllTunnels).toHaveBeenCalledOnce();
+    expect(ctx.tunnelRegistry!.closeAll).toHaveBeenCalledOnce();
   });
 
   it("closes gRPC server", async () => {

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,7 +1,7 @@
 import { logger, shutdownOtlpLogs } from "@grackle-ai/core";
 import { sqlite, stopWalCheckpointTimer } from "@grackle-ai/database";
 import { stopPairingCleanup, stopSessionCleanup, stopOAuthCleanup } from "@grackle-ai/auth";
-import { closeAllTunnels } from "@grackle-ai/adapter-sdk";
+import type { TunnelRegistry } from "@grackle-ai/adapter-sdk";
 
 /** Hard timeout (ms) so upgraded WS connections don't block exit. */
 const SHUTDOWN_TIMEOUT_MS: number = 5_000;
@@ -30,6 +30,8 @@ export interface ShutdownContext {
   localPowerLineManager?: { stop: () => Promise<void> };
   /** Plugin shutdown function — disposes subscribers and calls plugin teardown hooks. */
   pluginShutdown?: () => Promise<void>;
+  /** Shared tunnel registry — closed during shutdown. */
+  tunnelRegistry?: TunnelRegistry;
 }
 
 /**
@@ -60,7 +62,9 @@ export function createShutdown(context: ShutdownContext): () => Promise<void> {
       await context.localPowerLineManager.stop();
     }
 
-    await closeAllTunnels();
+    if (context.tunnelRegistry) {
+      await context.tunnelRegistry.closeAll(logger);
+    }
 
     await new Promise<void>((resolve) => {
       context.grpcServer.close((err?: Error) => {


### PR DESCRIPTION
## Summary

Closes #1477

- Replace module-level `const tunnelMap` in `adapter-sdk/src/tunnel-registry.ts` with a `TunnelRegistry` class
- Inject via the existing `AdapterDependencies` pattern — each server instance creates one registry shared across all adapters
- Thread registry to `connectThroughTunnel`, `remoteStop`, `remoteDestroy`, `remoteHealthCheck` (SDK-internal helpers)
- Update SSH, Codespace, and Docker adapters to use `this.tunnelRegistry.*` instead of free functions
- Wire registry through `ShutdownContext` so `createShutdown()` calls `registry.closeAll()`
- Add unit tests for the `TunnelRegistry` class itself
- Migrate existing tests from module-level mocks to injected registry instances (cleaner isolation)

The Docker adapter's `containerPorts` and `attachConnections` globals were already instance-scoped from a prior refactor — no changes needed there.

## Test plan

- [ ] `rush build` passes (all packages compile, API reports regenerate)
- [ ] `rush test` for adapter-sdk, adapter-ssh, adapter-codespace, server — all pass
- [ ] Full CI green