### PR TITLE
Centralize timestamp creation with serverTimestamp()

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -2997,6 +2997,9 @@ export interface SequencedLogOptions<T> {
 }
 
 // @public
+export function serverEpochMs(): number;
+
+// @public
 type ServerEvent = Message<"grackle.ServerEvent"> & {
     event: {
         value: SessionEvent;
@@ -3015,6 +3018,9 @@ type ServerEvent = Message<"grackle.ServerEvent"> & {
 
 // @public
 const ServerEventSchema: GenMessage<ServerEvent>;
+
+// @public
+export function serverTimestamp(): string;
 
 // @public
 type Session = Message<"grackle.Session"> & {

--- a/common/api/runtime-acp.public.api.md
+++ b/common/api/runtime-acp.public.api.md
@@ -48,7 +48,7 @@ export function selectEnvVarAuthMethod(authMethods: Array<Record<string, unknown
 
 // Warnings were encountered during analysis:
 //
-// src/acp.ts:52:1 - (ae-internal-missing-underscore) The name "AcpSdkModule" should be prefixed with an underscore because the declaration is marked as @internal
+// src/acp.ts:53:1 - (ae-internal-missing-underscore) The name "AcpSdkModule" should be prefixed with an underscore because the declaration is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/runtime-claude-code.public.api.md
+++ b/common/api/runtime-claude-code.public.api.md
@@ -19,7 +19,7 @@ export class ClaudeCodeRuntime extends BaseAgentRuntime {
 
 // Warnings were encountered during analysis:
 //
-// src/claude-code.ts:92:1 - (ae-internal-missing-underscore) The name "mapMessage" should be prefixed with an underscore because the declaration is marked as @internal
+// src/claude-code.ts:93:1 - (ae-internal-missing-underscore) The name "mapMessage" should be prefixed with an underscore because the declaration is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/runtime-copilot.public.api.md
+++ b/common/api/runtime-copilot.public.api.md
@@ -21,10 +21,10 @@ export class CopilotRuntime extends BaseAgentRuntime {
 
 // Warnings were encountered during analysis:
 //
-// src/copilot.ts:53:1 - (ae-forgotten-export) The symbol "CopilotSdkModule" needs to be exported by the entry point index.d.ts
-// src/copilot.ts:99:1 - (ae-internal-missing-underscore) The name "resolveGithubToken" should be prefixed with an underscore because the declaration is marked as @internal
-// src/copilot.ts:110:1 - (ae-internal-missing-underscore) The name "resolveProviderConfig" should be prefixed with an underscore because the declaration is marked as @internal
-// src/copilot.ts:134:1 - (ae-internal-missing-underscore) The name "CopilotSession" should be prefixed with an underscore because the declaration is marked as @internal
+// src/copilot.ts:54:1 - (ae-forgotten-export) The symbol "CopilotSdkModule" needs to be exported by the entry point index.d.ts
+// src/copilot.ts:100:1 - (ae-internal-missing-underscore) The name "resolveGithubToken" should be prefixed with an underscore because the declaration is marked as @internal
+// src/copilot.ts:111:1 - (ae-internal-missing-underscore) The name "resolveProviderConfig" should be prefixed with an underscore because the declaration is marked as @internal
+// src/copilot.ts:135:1 - (ae-internal-missing-underscore) The name "CopilotSession" should be prefixed with an underscore because the declaration is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/changes/@grackle-ai/cli/nick-pape-1502-centralize-timestamps_2026-06-05-06-19.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1502-centralize-timestamps_2026-06-05-06-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Centralize timestamp creation with serverTimestamp() utility",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/clock.ts
+++ b/packages/common/src/clock.ts
@@ -1,0 +1,9 @@
+/** Return the current time as an ISO 8601 string. */
+export function serverTimestamp(): string {
+  return new Date().toISOString();
+}
+
+/** Return the current time as epoch milliseconds. */
+export function serverEpochMs(): number {
+  return Date.now();
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./clock.js";
 export * from "./errors.js";
 export * as grackle from "./grackle-barrel.js";
 export * as powerline from "./gen/grackle/powerline/powerline_pb.js";

--- a/packages/core/src/event-bus.ts
+++ b/packages/core/src/event-bus.ts
@@ -1,5 +1,5 @@
 import { ulid } from "ulid";
-import { SequencedLog, type LogSink } from "@grackle-ai/common";
+import { SequencedLog, type LogSink, serverTimestamp } from "@grackle-ai/common";
 import { persistEvent } from "@grackle-ai/database";
 import { logger } from "./logger.js";
 
@@ -144,7 +144,7 @@ const domainEventLog: SequencedLog<DomainEventBody> = new SequencedLog<DomainEve
  * @returns The created GrackleEvent.
  */
 export function emit(type: GrackleEventType, payload: Record<string, unknown>): GrackleEvent {
-  const timestamp: string = new Date().toISOString();
+  const timestamp: string = serverTimestamp();
 
   // Persist synchronously via the sequenced log (SQLite is fast in WAL mode).
   // The log assigns the monotonic ULID sequence key, which becomes the event id.

--- a/packages/core/src/event-processor.ts
+++ b/packages/core/src/event-processor.ts
@@ -9,6 +9,7 @@ import {
   delegationIdentityKey,
   deriveChildSessionId,
   readAgentResultStatus,
+  serverTimestamp,
 } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
 import type { ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
@@ -97,7 +98,7 @@ export function publishWidgetEvent(sessionId: string, payload: WidgetEventPayloa
     const event = create(grackle.SessionEventSchema, {
       sessionId,
       type: grackle.EventType.WIDGET,
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: JSON.stringify(payload),
       raw: JSON.stringify({ widget: true, toolName: payload.toolName }),
     });
@@ -205,7 +206,7 @@ export function processEventStream(
         const sysCtxEvent = create(grackle.SessionEventSchema, {
           sessionId,
           type: grackle.EventType.SYSTEM,
-          timestamp: new Date().toISOString(),
+          timestamp: serverTimestamp(),
           content: options.systemContext,
           raw: JSON.stringify({ systemContext: true }),
         });
@@ -238,7 +239,7 @@ export function processEventStream(
         // (when consumer received it, not when producer emitted), which is
         // acceptable for display purposes — events still arrive in causal
         // order via the action stream's serverSeq monotonicity.
-        const eventTimestamp: string = event.timestamp || new Date().toISOString();
+        const eventTimestamp: string = event.timestamp || serverTimestamp();
         const eventRaw: string = event.raw ?? "";
         const eventToolCallId: string = event.toolCallId ?? "";
         const eventTurnId: string = event.turnId ?? "";
@@ -558,7 +559,7 @@ export function processEventStream(
         const suspendedEvent = create(grackle.SessionEventSchema, {
           sessionId,
           type: grackle.EventType.STATUS,
-          timestamp: new Date().toISOString(),
+          timestamp: serverTimestamp(),
           content: SESSION_STATUS.SUSPENDED,
         });
         suspendedEvent.serverSeq = recordSessionAction(suspendedEvent) ?? "";

--- a/packages/core/src/signals/signal-delivery.ts
+++ b/packages/core/src/signals/signal-delivery.ts
@@ -1,5 +1,5 @@
 import { create } from "@bufbuild/protobuf";
-import { grackle, SESSION_STATUS, END_REASON } from "@grackle-ai/common";
+import { grackle, SESSION_STATUS, END_REASON, serverTimestamp } from "@grackle-ai/common";
 import { sessionStore } from "@grackle-ai/database";
 import * as adapterManager from "../adapter-manager.js";
 import { reanimateAgent } from "../reanimate-agent.js";
@@ -128,7 +128,7 @@ export async function sendInputToSession(
     const signalEvent = create(grackle.SessionEventSchema, {
       sessionId,
       type: grackle.EventType.SIGNAL,
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: text,
     });
     // Stamp the ULID before persisting + broadcasting so the UI can dedup the

--- a/packages/core/src/stream-registry.ts
+++ b/packages/core/src/stream-registry.ts
@@ -17,6 +17,7 @@ import { logger } from "./logger.js";
 import { isReservedStreamName, LIFECYCLE_PREFIX } from "./stream-names.js";
 import { emitStreamMessage } from "./stream-message-bus.js";
 import { emit, type GrackleEventType } from "./event-bus.js";
+import { serverTimestamp } from "@grackle-ai/common";
 
 /**
  * Monotonic ULID generator for transcript sequence keys. Unlike plain `ulid()`,
@@ -455,7 +456,7 @@ export function publish(streamId: string, senderId: string, content: string): St
     id: uuid(),
     senderId,
     content,
-    timestamp: new Date().toISOString(),
+    timestamp: serverTimestamp(),
     deliveredTo: new Set(),
   };
 

--- a/packages/core/src/subagent-session.ts
+++ b/packages/core/src/subagent-session.ts
@@ -30,6 +30,7 @@ import {
   END_REASON,
   TERMINAL_SESSION_STATUSES,
   SUBAGENT_RUNTIME,
+  serverTimestamp,
 } from "@grackle-ai/common";
 import type { DelegationInfo, SessionStatus } from "@grackle-ai/common";
 import { sessionStore } from "@grackle-ai/database";
@@ -89,7 +90,7 @@ function recordChildEvent(
   const event = create(grackle.SessionEventSchema, {
     sessionId: childSessionId,
     type,
-    timestamp: new Date().toISOString(),
+    timestamp: serverTimestamp(),
     content: clamp(content),
   });
   // serverSeq first so the durable log, JSONL, and live push share a dedup key.

--- a/packages/database/src/dispatch-queue-store.ts
+++ b/packages/database/src/dispatch-queue-store.ts
@@ -10,6 +10,7 @@
 import db from "./db.js";
 import { dispatchQueue, type DispatchQueueRow } from "./schema.js";
 import { eq, asc } from "drizzle-orm";
+import { serverTimestamp } from "@grackle-ai/common";
 
 export type { DispatchQueueRow };
 
@@ -54,7 +55,7 @@ export function enqueue(entry: EnqueueEntry): void {
       notes: entry.notes ?? "",
       pipe: entry.pipe ?? "",
       parentSessionId: entry.parentSessionId ?? "",
-      enqueuedAt: new Date().toISOString(),
+      enqueuedAt: serverTimestamp(),
     })
     .onConflictDoNothing()
     .run();

--- a/packages/database/src/escalation-store.ts
+++ b/packages/database/src/escalation-store.ts
@@ -1,6 +1,7 @@
 import db from "./db.js";
 import { escalations, type EscalationRow } from "./schema.js";
 import { eq, desc, asc, and } from "drizzle-orm";
+import { serverTimestamp } from "@grackle-ai/common";
 
 export type { EscalationRow };
 
@@ -121,7 +122,7 @@ export function listPendingEscalations(): EscalationRow[] {
  * (deliveredAt for "delivered", acknowledgedAt for "acknowledged").
  */
 export function updateEscalationStatus(id: string, status: string): void {
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const updates: Record<string, unknown> = { status };
 
   if (status === "delivered") {

--- a/packages/database/src/schedule-store.ts
+++ b/packages/database/src/schedule-store.ts
@@ -1,6 +1,7 @@
 import db from "./db.js";
 import { schedules, type ScheduleRow } from "./schema.js";
 import { eq, and, lte, sql } from "drizzle-orm";
+import { serverTimestamp } from "@grackle-ai/common";
 
 export type { ScheduleRow };
 
@@ -145,7 +146,7 @@ export function deleteSchedule(id: string): void {
  * These are the schedules that should fire on the current tick.
  */
 export function getDueSchedules(): ScheduleRow[] {
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   return db
     .select()
     .from(schedules)

--- a/packages/database/src/session-store.ts
+++ b/packages/database/src/session-store.ts
@@ -1,7 +1,7 @@
 import db from "./db.js";
 import { sessions, type SessionRow } from "./schema.js";
 import { eq, and, inArray, desc, asc, ne, sql } from "drizzle-orm";
-import { SESSION_STATUS, SUBAGENT_RUNTIME } from "@grackle-ai/common";
+import { SESSION_STATUS, SUBAGENT_RUNTIME, serverTimestamp } from "@grackle-ai/common";
 import type { SessionStatus, PipeMode, EndReason } from "@grackle-ai/common";
 
 export type { SessionRow };
@@ -94,7 +94,7 @@ export function createSession(
       // We always set startedAt explicitly (ISO 8601 format with milliseconds).
       // The schema default also produces ISO format via strftime, but we set it
       // here for consistency. ISO format sorts lexicographically correctly.
-      startedAt: new Date().toISOString(),
+      startedAt: serverTimestamp(),
     })
     .run();
 }
@@ -148,7 +148,7 @@ export function updateSession(
   error?: string,
   endReason?: EndReason,
 ): void {
-  const endedAt = status === SESSION_STATUS.STOPPED ? new Date().toISOString() : null;
+  const endedAt = status === SESSION_STATUS.STOPPED ? serverTimestamp() : null;
   const patch: Partial<typeof sessions.$inferInsert> = {
     status,
     endedAt,
@@ -163,10 +163,7 @@ export function updateSession(
 
 /** Record that a SIGTERM signal was sent to a session. */
 export function setSigtermSentAt(id: string): void {
-  db.update(sessions)
-    .set({ sigtermSentAt: new Date().toISOString() })
-    .where(eq(sessions.id, id))
-    .run();
+  db.update(sessions).set({ sigtermSentAt: serverTimestamp() }).where(eq(sessions.id, id)).run();
 }
 
 /** Clear the SIGTERM sent flag (e.g. when delivery fails after optimistic set). */
@@ -294,7 +291,7 @@ export function suspendSession(id: string): void {
   db.update(sessions)
     .set({
       status: SESSION_STATUS.SUSPENDED,
-      suspendedAt: new Date().toISOString(),
+      suspendedAt: serverTimestamp(),
       error: null,
     })
     .where(eq(sessions.id, id))

--- a/packages/knowledge-core/src/clock.ts
+++ b/packages/knowledge-core/src/clock.ts
@@ -1,0 +1,9 @@
+/** Return the current time as an ISO 8601 string. */
+export function serverTimestamp(): string {
+  return new Date().toISOString();
+}
+
+/** Return the current time as epoch milliseconds. */
+export function serverEpochMs(): number {
+  return Date.now();
+}

--- a/packages/knowledge-core/src/edge-store.ts
+++ b/packages/knowledge-core/src/edge-store.ts
@@ -11,6 +11,7 @@ import { getSession } from "./client.js";
 import { logger } from "./logger.js";
 import { NODE_LABEL } from "./constants.js";
 import { EDGE_TYPE, type EdgeType, type KnowledgeEdge } from "./types.js";
+import { serverTimestamp } from "./clock.js";
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -85,7 +86,7 @@ export async function createEdge(
 ): Promise<KnowledgeEdge> {
   assertValidEdgeType(type);
 
-  const createdAt = new Date().toISOString();
+  const createdAt = serverTimestamp();
   const metadataStr: string | null = metadata !== undefined ? JSON.stringify(metadata) : null;
 
   const session = getSession();
@@ -198,7 +199,7 @@ export async function upsertEdge(
 ): Promise<KnowledgeEdge> {
   assertValidEdgeType(type);
 
-  const createdAt = new Date().toISOString();
+  const createdAt = serverTimestamp();
   const metadataStr: string | null = metadata !== undefined ? JSON.stringify(metadata) : null;
 
   const session = getSession();

--- a/packages/knowledge-core/src/node-store.ts
+++ b/packages/knowledge-core/src/node-store.ts
@@ -21,6 +21,7 @@ import {
   type KnowledgeEdge,
   type EdgeType,
 } from "./types.js";
+import { serverTimestamp } from "./clock.js";
 
 // ---------------------------------------------------------------------------
 // Input types
@@ -229,7 +230,7 @@ export function recordToEdge(raw: Record<string, unknown>): KnowledgeEdge {
  */
 export async function createReferenceNode(input: CreateReferenceNodeInput): Promise<string> {
   const id = randomUUID();
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const props = {
     id,
     kind: NODE_KIND.REFERENCE,
@@ -265,7 +266,7 @@ export async function createReferenceNode(input: CreateReferenceNodeInput): Prom
  */
 export async function createNativeNode(input: CreateNativeNodeInput): Promise<string> {
   const id = randomUUID();
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const props = {
     id,
     kind: NODE_KIND.NATIVE,
@@ -368,7 +369,7 @@ export async function updateNode(
 
   const patchedUpdates = {
     ...mutableUpdates,
-    updatedAt: new Date().toISOString(),
+    updatedAt: serverTimestamp(),
   };
 
   const session = getSession();
@@ -437,7 +438,7 @@ const UPSERT_REFERENCE_NODE_CYPHER: string = `
  * @returns The (stable) node ID.
  */
 export async function upsertReferenceNode(input: UpsertReferenceNodeInput): Promise<string> {
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const mutable: Record<string, unknown> = {
     label: input.label,
     workspaceId: input.workspaceId,

--- a/packages/mcp/src/tools/component.ts
+++ b/packages/mcp/src/tools/component.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { grackle } from "@grackle-ai/common";
+import { grackle, serverTimestamp } from "@grackle-ai/common";
 import type { GrackleClients, ToolDefinition, ToolResult } from "../tool-registry.js";
 import type { AuthContext } from "@grackle-ai/auth";
 import { jsonResult } from "../result-helpers.js";
@@ -166,7 +166,7 @@ export const componentTools: ToolDefinition[] = [
     async handler(args: Record<string, unknown>) {
       const message: string =
         typeof args.message === "string" ? args.message : "Hello from Grackle";
-      return jsonResult({ message, renderedAt: new Date().toISOString() });
+      return jsonResult({ message, renderedAt: serverTimestamp() });
     },
   },
   {

--- a/packages/plugin-core/src/escalation-handlers.ts
+++ b/packages/plugin-core/src/escalation-handlers.ts
@@ -1,6 +1,6 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
-import { grackle } from "@grackle-ai/common";
+import { grackle, serverTimestamp } from "@grackle-ai/common";
 import { escalationStore } from "@grackle-ai/database";
 import { ulid } from "ulid";
 import { routeEscalation, toEscalationModel } from "@grackle-ai/core";
@@ -48,7 +48,7 @@ export async function createEscalation(
         source: "explicit",
         urgency: req.urgency || "normal",
         status: "pending",
-        createdAt: new Date().toISOString(),
+        createdAt: serverTimestamp(),
         deliveredAt: null,
         acknowledgedAt: null,
         taskUrl,

--- a/packages/plugin-core/src/grpc-shared.ts
+++ b/packages/plugin-core/src/grpc-shared.ts
@@ -10,7 +10,7 @@
  */
 
 import { create } from "@bufbuild/protobuf";
-import { grackle } from "@grackle-ai/common";
+import { grackle, serverTimestamp } from "@grackle-ai/common";
 import {
   ROOT_TASK_ID,
   SESSION_STATUS,
@@ -60,7 +60,7 @@ export function suspendSessionAndPublish(session: SessionRow): void {
     create(grackle.SessionEventSchema, {
       sessionId: session.id,
       type: grackle.EventType.STATUS,
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: SESSION_STATUS.SUSPENDED,
       raw: "",
     }),
@@ -93,7 +93,7 @@ export function killSessionAndCleanup(session: SessionRow): void {
       create(grackle.SessionEventSchema, {
         sessionId: session.id,
         type: grackle.EventType.STATUS,
-        timestamp: new Date().toISOString(),
+        timestamp: serverTimestamp(),
         content: END_REASON.KILLED,
         raw: "",
       }),

--- a/packages/plugin-core/src/lifecycle.ts
+++ b/packages/plugin-core/src/lifecycle.ts
@@ -13,7 +13,13 @@
  */
 
 import { create } from "@bufbuild/protobuf";
-import { grackle, SESSION_STATUS, TERMINAL_SESSION_STATUSES, END_REASON } from "@grackle-ai/common";
+import {
+  grackle,
+  SESSION_STATUS,
+  TERMINAL_SESSION_STATUSES,
+  END_REASON,
+  serverTimestamp,
+} from "@grackle-ai/common";
 import type { SessionStatus, EndReason } from "@grackle-ai/common";
 import { sessionStore, taskStore } from "@grackle-ai/database";
 import {
@@ -100,7 +106,7 @@ export function createLifecycleSubscriber(ctx: PluginContext): Disposable {
       create(grackle.SessionEventSchema, {
         sessionId,
         type: grackle.EventType.STATUS,
-        timestamp: new Date().toISOString(),
+        timestamp: serverTimestamp(),
         content: reason,
         raw: "",
       }),

--- a/packages/plugin-core/src/signals/escalation-auto.ts
+++ b/packages/plugin-core/src/signals/escalation-auto.ts
@@ -7,7 +7,7 @@
  * to explicitly call `escalate_to_human`.
  */
 
-import { SESSION_STATUS, ROOT_TASK_ID } from "@grackle-ai/common";
+import { SESSION_STATUS, ROOT_TASK_ID, serverTimestamp } from "@grackle-ai/common";
 import type { GrackleEvent } from "@grackle-ai/core";
 import { taskStore, sessionStore, escalationStore } from "@grackle-ai/database";
 import { readLastTextEntry } from "@grackle-ai/core";
@@ -140,7 +140,7 @@ async function handleTaskUpdated(delivered: Map<string, number>, taskId: string)
     source: "auto",
     urgency: "normal",
     status: "pending",
-    createdAt: new Date().toISOString(),
+    createdAt: serverTimestamp(),
     deliveredAt: undefined,
     acknowledgedAt: undefined,
     taskUrl,

--- a/packages/plugin-core/src/task-lifecycle-handlers.ts
+++ b/packages/plugin-core/src/task-lifecycle-handlers.ts
@@ -1,7 +1,7 @@
 /** Task lifecycle handlers extracted from task-handlers.ts (#1470). @module */
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
-import { grackle } from "@grackle-ai/common";
+import { grackle, serverTimestamp } from "@grackle-ai/common";
 import {
   SESSION_STATUS,
   TERMINAL_SESSION_STATUSES,
@@ -63,7 +63,7 @@ export async function completeTask(req: grackle.TaskId): Promise<grackle.Task> {
         create(grackle.SessionEventSchema, {
           sessionId: "",
           type: grackle.EventType.SYSTEM,
-          timestamp: new Date().toISOString(),
+          timestamp: serverTimestamp(),
           content: JSON.stringify({
             type: "task_unblocked",
             taskId: t.id,
@@ -218,7 +218,7 @@ export async function stopTask(req: grackle.TaskId): Promise<grackle.Task> {
         create(grackle.SessionEventSchema, {
           sessionId: activeSession.id,
           type: grackle.EventType.STATUS,
-          timestamp: new Date().toISOString(),
+          timestamp: serverTimestamp(),
           content: END_REASON.INTERRUPTED,
           raw: "",
         }),

--- a/packages/plugin-scheduling/src/cron-phase.ts
+++ b/packages/plugin-scheduling/src/cron-phase.ts
@@ -12,7 +12,12 @@ import { computeNextRunAt } from "./schedule-expression.js";
 import type { ScheduleRow, SessionRow } from "@grackle-ai/database";
 import type { GrackleEventType, TaskModel } from "@grackle-ai/core";
 import type { ReconciliationPhase } from "@grackle-ai/plugin-sdk";
-import { ROOT_TASK_ID, SESSION_STATUS, type SessionStatus } from "@grackle-ai/common";
+import {
+  ROOT_TASK_ID,
+  SESSION_STATUS,
+  type SessionStatus,
+  serverTimestamp,
+} from "@grackle-ai/common";
 
 /**
  * Session statuses considered "alive" — a heartbeat tick whose target task
@@ -143,7 +148,7 @@ function computeNextOrDisable(deps: CronPhaseDeps, schedule: ScheduleRow): strin
 
 /** Fire a heartbeat-style schedule (#1438): reanimate target session, or fresh-spawn. */
 async function fireScheduleAsHeartbeat(deps: CronPhaseDeps, schedule: ScheduleRow): Promise<void> {
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const nextRunAt = computeNextOrDisable(deps, schedule);
   if (!nextRunAt) {
     return;
@@ -236,7 +241,7 @@ async function fireScheduleAsHeartbeat(deps: CronPhaseDeps, schedule: ScheduleRo
 
 /** Fire a fresh-task schedule (today's behavior): create new task, enqueue, advance. */
 function fireScheduleAsTask(deps: CronPhaseDeps, schedule: ScheduleRow): void {
-  const now = new Date().toISOString();
+  const now = serverTimestamp();
   const nextRunAt = computeNextOrDisable(deps, schedule);
   if (!nextRunAt) {
     return;

--- a/packages/powerline/src/runtimes/stub-scenario.ts
+++ b/packages/powerline/src/runtimes/stub-scenario.ts
@@ -1,3 +1,4 @@
+import { serverTimestamp } from "@grackle-ai/common";
 import type { AgentEventType } from "@grackle-ai/common";
 import type { AgentEvent } from "@grackle-ai/runtime-sdk";
 
@@ -200,7 +201,7 @@ export function buildEventFromEmitStep(
   step: EmitStep,
   lastToolUseId: string | undefined,
 ): [AgentEvent, string | undefined] {
-  const timestamp = new Date().toISOString();
+  const timestamp = serverTimestamp();
   let content = step.content ?? "";
   let raw = step.raw;
   let newToolUseId: string | undefined;

--- a/packages/powerline/src/runtimes/stub.ts
+++ b/packages/powerline/src/runtimes/stub.ts
@@ -7,7 +7,7 @@ import type {
   SpawnOptions,
   ResumeOptions,
 } from "@grackle-ai/runtime-sdk";
-import { SESSION_STATUS, assertTransition } from "@grackle-ai/common";
+import { SESSION_STATUS, assertTransition, serverTimestamp } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
 import {
   parseScenario,
@@ -108,7 +108,7 @@ export class StubSession implements AgentSession {
 
   /** Original hardcoded echo behavior, preserved for backward compatibility. */
   private async *runLegacy(): AsyncIterable<AgentEvent> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     this.transitionTo(SESSION_STATUS.RUNNING);
 
     yield { type: "system", timestamp: ts(), content: "Stub runtime initialized" };
@@ -191,7 +191,7 @@ export class StubSession implements AgentSession {
 
   /** Execute a parsed JSON scenario step by step. */
   private async *runScenario(): AsyncIterable<AgentEvent> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     this.transitionTo(SESSION_STATUS.RUNNING);
     const steps = this.scenario!.steps;
     let lastToolUseId: string | undefined;

--- a/packages/runtime-acp/src/acp.ts
+++ b/packages/runtime-acp/src/acp.ts
@@ -23,6 +23,7 @@ import {
   getRuntimeBinDirectory,
   getRuntimeConfigDirectory,
 } from "@grackle-ai/runtime-sdk";
+import { serverTimestamp } from "@grackle-ai/common";
 
 // ─── Configuration ──────────────────────────────────────────
 
@@ -123,7 +124,7 @@ function getAcpSdk(runtimeName: string): Promise<AcpSdkModule> {
  * Only actionable update types are mapped; intermediate progress is skipped.
  */
 export function mapSessionUpdate(update: Record<string, unknown>): AgentEvent[] {
-  const ts = new Date().toISOString();
+  const ts = serverTimestamp();
   const raw = update;
   const updateType = update.sessionUpdate as string;
 
@@ -380,7 +381,7 @@ class AcpSession extends BaseAgentSession {
   // ─── BaseAgentSession hooks ──────────────────────────────
 
   protected async setupSdk(): Promise<void> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     const sdk = await getAcpSdk(this.config.name);
 
     // Resolve working directory

--- a/packages/runtime-claude-code/src/claude-code.ts
+++ b/packages/runtime-claude-code/src/claude-code.ts
@@ -10,6 +10,7 @@ import {
 import { accessSync, mkdirSync, copyFileSync, chmodSync, constants as fsConstants } from "node:fs";
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
+import { serverTimestamp } from "@grackle-ai/common";
 
 // Dynamic import — try @anthropic-ai/claude-agent-sdk first, then @anthropic-ai/claude-code
 type QueryFn = (opts: Record<string, unknown>) => Promise<unknown>;
@@ -90,7 +91,7 @@ function parseUsageFromMessage(msg: Record<string, unknown>): {
 
 /** @internal Map a raw Claude Agent SDK message to Grackle AgentEvent(s). Exported for testing. */
 export function mapMessage(msg: Record<string, unknown>): AgentEvent[] {
-  const ts = new Date().toISOString();
+  const ts = serverTimestamp();
   const type = msg.type as string | undefined;
 
   // SDK streaming format: { type: "assistant", message: { role, content: [...] } }
@@ -503,7 +504,7 @@ class ClaudeCodeSession extends BaseAgentSession {
   private async consumePersistentStream(
     conversation: AsyncIterable<Record<string, unknown>>,
   ): Promise<void> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
 
     for await (const msg of conversation) {
       if (this.killed) {
@@ -636,7 +637,7 @@ class ClaudeCodeSession extends BaseAgentSession {
    */
   private async consumeQuery(prompt: string, sdkOptions: Record<string, unknown>): Promise<number> {
     const query: QueryFn = await getQuery();
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
 
     // Reset cumulative usage baseline for this query() call. In resume-per-input
     // mode, each query() call reports usage cumulative within that call only (not

--- a/packages/runtime-codex/src/codex.ts
+++ b/packages/runtime-codex/src/codex.ts
@@ -6,7 +6,7 @@ import {
   ensureRuntimeInstalled,
   importFromRuntime,
 } from "@grackle-ai/runtime-sdk";
-import { SESSION_STATUS } from "@grackle-ai/common";
+import { SESSION_STATUS, serverTimestamp } from "@grackle-ai/common";
 
 // ─── Environment variable names ────────────────────────────
 // All configuration is driven by environment variables so the
@@ -111,7 +111,7 @@ class CodexSession extends BaseAgentSession {
   // ─── BaseAgentSession hooks ──────────────────────────────
 
   protected async setupSdk(): Promise<void> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     const { Codex } = await getCodexSdk();
 
     // ── Resolve working directory ──
@@ -212,7 +212,7 @@ class CodexSession extends BaseAgentSession {
 
     this.emit({
       type: "system",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: `Codex thread started (model: ${this.model || "default"})`,
       diagnostic: true,
     });
@@ -246,7 +246,7 @@ class CodexSession extends BaseAgentSession {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async consumeStream(streamResult: any): Promise<number> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.activeStream = streamResult;
     let messageCount = 0;

--- a/packages/runtime-copilot/src/copilot.ts
+++ b/packages/runtime-copilot/src/copilot.ts
@@ -6,6 +6,7 @@ import {
   ensureRuntimeInstalled,
   importFromRuntime,
 } from "@grackle-ai/runtime-sdk";
+import { serverTimestamp } from "@grackle-ai/common";
 
 // ─── Environment variable names ────────────────────────────
 // All configuration is driven by environment variables so the
@@ -157,7 +158,7 @@ export class CopilotSession extends BaseAgentSession {
   // ─── BaseAgentSession hooks ──────────────────────────────
 
   protected async setupSdk(): Promise<void> {
-    const ts = (): string => new Date().toISOString();
+    const ts = (): string => serverTimestamp();
     const copilotSdk = await getCopilotSdk();
 
     // ── Resolve working directory ──

--- a/packages/runtime-genaiscript/src/genaiscript.ts
+++ b/packages/runtime-genaiscript/src/genaiscript.ts
@@ -14,7 +14,7 @@ import type {
   ResumeOptions,
 } from "@grackle-ai/runtime-sdk";
 import { logger, ensureRuntimeInstalled } from "@grackle-ai/runtime-sdk";
-import { SESSION_STATUS, assertTransition } from "@grackle-ai/common";
+import { SESSION_STATUS, assertTransition, serverTimestamp } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
 
 /** Shape of the JSON result from genaiscript's res.json output. */
@@ -102,7 +102,7 @@ class GenAIScriptSession implements AgentSession {
   }
 
   public async *stream(): AsyncIterable<AgentEvent> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     this.transitionTo(SESSION_STATUS.RUNNING);
 
     if (!this.scriptContent) {

--- a/packages/runtime-sdk/src/base-session.ts
+++ b/packages/runtime-sdk/src/base-session.ts
@@ -1,5 +1,5 @@
 import type { AgentSession, AgentEvent, CreateSessionOptions } from "./runtime.js";
-import { SESSION_STATUS, assertTransition } from "@grackle-ai/common";
+import { SESSION_STATUS, assertTransition, serverTimestamp } from "@grackle-ai/common";
 import type { SessionStatus } from "@grackle-ai/common";
 import { AsyncQueue } from "./async-queue.js";
 import { resolveWorkingDirectory, resolveMcpServers } from "./runtime-utils.js";
@@ -86,7 +86,7 @@ export abstract class BaseAgentSession implements AgentSession {
   protected async setupForResume(): Promise<void> {
     this.emit({
       type: "system",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: `Session resumed (id: ${this.resumeSessionId})`,
       diagnostic: true,
     });
@@ -161,7 +161,7 @@ export abstract class BaseAgentSession implements AgentSession {
     }
     this.emit({
       type: "usage",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: JSON.stringify({
         input_tokens: inputTokens,
         output_tokens: outputTokens,
@@ -180,7 +180,7 @@ export abstract class BaseAgentSession implements AgentSession {
     if (wasEmpty && id) {
       this.emit({
         type: "runtime_session_id",
-        timestamp: new Date().toISOString(),
+        timestamp: serverTimestamp(),
         content: id,
       });
     }
@@ -229,7 +229,7 @@ export abstract class BaseAgentSession implements AgentSession {
     this.currentTurnId = randomUUID();
     this.emit({
       type: "turn_started",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: userMessage,
       turnId: this.currentTurnId,
     });
@@ -242,7 +242,7 @@ export abstract class BaseAgentSession implements AgentSession {
     }
     this.emit({
       type: "turn_complete",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: "",
       turnId: this.currentTurnId,
     });
@@ -252,7 +252,7 @@ export abstract class BaseAgentSession implements AgentSession {
   // ─── Shared lifecycle implementation ──────────────────────
 
   public async *stream(): AsyncIterable<AgentEvent> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
 
     this.transitionTo(SESSION_STATUS.RUNNING);
 
@@ -282,7 +282,7 @@ export abstract class BaseAgentSession implements AgentSession {
 
   /** Core session logic: setup SDK, handle resume or initial query, transition to waiting_input. */
   private async runSession(): Promise<void> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
 
     try {
       await this.setupSdk();
@@ -346,7 +346,7 @@ export abstract class BaseAgentSession implements AgentSession {
    * lifecycle — closes it when the loop exits.
    */
   private async processInputLoop(): Promise<void> {
-    const ts: () => string = () => new Date().toISOString();
+    const ts: () => string = () => serverTimestamp();
     for await (const text of this.inputQueue) {
       if (this.killed) {
         break;
@@ -383,7 +383,7 @@ export abstract class BaseAgentSession implements AgentSession {
   /** Fire-and-forget launch of the input processing loop. */
   private startInputLoop(): void {
     this.processInputLoop().catch((err) => {
-      const ts = new Date().toISOString();
+      const ts = serverTimestamp();
       logger.error({ err }, `Input loop crashed in ${this.runtimeDisplayName} session`);
       this.transitionTo(SESSION_STATUS.STOPPED);
       // A failed turn never completes — drop the turn id so terminal events are
@@ -408,7 +408,7 @@ export abstract class BaseAgentSession implements AgentSession {
     // Emit a final status event BEFORE closing the queue so the server receives it.
     this.emit({
       type: "status",
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
       content: reason,
     });
     // releaseResources() and eventQueue.close() are also called by processInputLoop()

--- a/packages/runtime-sdk/src/runtime-utils.ts
+++ b/packages/runtime-sdk/src/runtime-utils.ts
@@ -5,6 +5,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { ensureWorktree, validateGitBranchName } from "./worktree.js";
 import { logger } from "./logger.js";
+import { serverTimestamp } from "@grackle-ai/common";
 
 // ─── Injectable interfaces ──────────────────────────────────
 
@@ -195,7 +196,7 @@ export async function resolveWorkingDirectory(
     git = NODE_GIT_REPOSITORY,
     locator = NODE_WORKSPACE_LOCATOR,
   } = options;
-  const ts = (): string => new Date().toISOString();
+  const ts = (): string => serverTimestamp();
 
   if (branch && workingDirectory && useWorktrees) {
     // Worktrees enabled — create a worktree for the branch.


### PR DESCRIPTION
## Summary

Closes #1502

- Add `serverTimestamp()` and `serverEpochMs()` utilities to `@grackle-ai/common` (`packages/common/src/clock.ts`)
- Replace all 27 production `new Date().toISOString()` call sites with `serverTimestamp()` across 13 packages
- Add a local `clock.ts` copy in `knowledge-core` to preserve its zero-dependency stance

No behavior change — pure mechanical refactor for format consistency and future clock-injection testability.

## Packages touched

| Package | Sites replaced |
|---|---|
| runtime-sdk | 11 |
| core | 8 |
| plugin-core | 7 |
| database | 7 |
| knowledge-core | 6 |
| runtime-codex | 3 |
| runtime-claude-code | 3 |
| powerline | 3 |
| runtime-acp | 2 |
| plugin-scheduling | 2 |
| runtime-genaiscript | 1 |
| runtime-copilot | 1 |
| mcp | 1 |

## What's NOT changed

- `Date.now()` calls used for timing/backoff math (auth expiry, reconnect delays, crash-loop detection) — these aren't stored timestamps
- Vendored code (`packages/ahp/src/vendor/`)
- Test files (`.test.ts`) — left as-is
- Test utilities (mocks, storybook helpers)

## Test plan

- [ ] `rush build` passes clean (no warnings)
- [ ] `rush test` passes (no behavior change)
- [ ] Grep confirms zero remaining `new Date().toISOString()` in production code