### PR TITLE
Fix useStreams ignoring showInternals on stream events (#1537)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1537-streams-show-internals_2026-06-10-18-35.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1537-streams-show-internals_2026-06-10-18-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix useStreams hook ignoring showInternals toggle on stream lifecycle events and socket reconnect",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/web/src/hooks/useStreams.test.ts
+++ b/packages/web/src/hooks/useStreams.test.ts
@@ -175,6 +175,34 @@ describe("useStreams.handleEvent", () => {
     };
     expect(result.current.handleEvent(event)).toBe(false);
   });
+
+  it("replays last includeInternal value when refetching on stream events (#1537)", async () => {
+    mockClient.listStreams.mockResolvedValue({ streams: [] });
+    const { result } = renderHook(() => useStreams());
+
+    // Caller sets showInternals = true
+    await act(async () => {
+      await result.current.loadStreams(true);
+    });
+
+    vi.clearAllMocks();
+    mockClient.listStreams.mockResolvedValue({ streams: [] });
+
+    // A stream lifecycle event must refetch with includeInternal: true
+    const event = {
+      id: "e1",
+      type: "stream.created",
+      timestamp: "2026-01-01T00:00:00Z",
+      payload: {},
+    };
+    await act(async () => {
+      result.current.handleEvent(event);
+    });
+
+    await waitFor(() => {
+      expect(mockClient.listStreams).toHaveBeenCalledWith({ includeInternal: true });
+    });
+  });
 });
 
 describe("useStreams.domainHook", () => {
@@ -225,5 +253,25 @@ describe("useStreams.domainHook", () => {
       payload: {},
     };
     expect(result.current.domainHook.handleEvent(event)).toBe(false);
+  });
+
+  it("onConnect replays last includeInternal value after showInternals was set (#1537)", async () => {
+    mockClient.listStreams.mockResolvedValue({ streams: [] });
+    const { result } = renderHook(() => useStreams());
+
+    // Caller sets showInternals = true
+    await act(async () => {
+      await result.current.loadStreams(true);
+    });
+
+    vi.clearAllMocks();
+    mockClient.listStreams.mockResolvedValue({ streams: [] });
+
+    // Reconnect must refetch with includeInternal: true
+    await act(async () => {
+      await result.current.domainHook.onConnect();
+    });
+
+    expect(mockClient.listStreams).toHaveBeenCalledWith({ includeInternal: true });
   });
 });

--- a/packages/web/src/hooks/useStreams.ts
+++ b/packages/web/src/hooks/useStreams.ts
@@ -38,9 +38,12 @@ export function useStreams(): UseStreamsResult {
   const { loading: streamsLoading, track: trackStreams } = useLoadingState();
   /** Incremented on disconnect so in-flight responses from the previous connection are discarded. */
   const epochRef = useRef(0);
+  /** Last includeInternal value passed to loadStreams; replayed on event- and reconnect-driven refreshes (#1537). */
+  const includeInternalRef = useRef<boolean>(false);
 
   const loadStreams = useCallback(
     async (includeInternal: boolean = false): Promise<void> => {
+      includeInternalRef.current = includeInternal;
       const myEpoch = epochRef.current;
       try {
         const resp = await trackStreams(grackleClient.listStreams({ includeInternal }));
@@ -127,7 +130,7 @@ export function useStreams(): UseStreamsResult {
         case "stream.attached":
         case "stream.detached":
         case "stream.closed":
-          loadStreams().catch(() => {}); // TODO(#1537): does not respect showInternals
+          loadStreams(includeInternalRef.current).catch(() => {});
           return true;
         default:
           return false;
@@ -138,7 +141,7 @@ export function useStreams(): UseStreamsResult {
 
   const domainHook: DomainHook = useMemo(
     () => ({
-      onConnect: loadStreams,
+      onConnect: () => loadStreams(includeInternalRef.current),
       onDisconnect: () => {
         epochRef.current += 1;
         setStreams([]);


### PR DESCRIPTION
## Summary
- Add an `includeInternalRef` to `useStreams` that records the last `includeInternal` value passed to `loadStreams`
- `handleEvent` now replays that ref value when refetching on `stream.created/attached/detached/closed` events, so toggling "Show Internals" ON is no longer silently reset on every stream lifecycle event
- `domainHook.onConnect` also replays the ref, so socket reconnects respect the user's current toggle state
- 2 new unit tests covering both regression paths

## Test plan
- [x] 300/300 unit tests pass (`rushx test` in `packages/web`)
- [x] `rush build -t @grackle-ai/web` — clean, zero warnings
- [x] New test: `handleEvent` replays `includeInternal: true` after `loadStreams(true)`
- [x] New test: `onConnect` replays `includeInternal: true` after `loadStreams(true)`

Closes #1537