### PR TITLE
Agent settings: editable environment + RPC through hook

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -3814,6 +3814,7 @@ type UpdateAgentRequest = Message<"grackle.UpdateAgentRequest"> & {
     name?: string;
     avatar?: string;
     primaryPersonaId?: string;
+    environmentId?: string;
 };
 
 // @public

--- a/common/changes/@grackle-ai/cli/nick-pape-1447-agent-settings-env-heartbeat_2026-06-10-19-23.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1447-agent-settings-env-heartbeat_2026-06-10-19-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add environment re-homing to UpdateAgentRequest (proto optional field), route heartbeat mutations through useAgents hook, and expose editable environment picker in Agent Settings tab",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/common/src/proto/grackle/grackle_types.proto
+++ b/packages/common/src/proto/grackle/grackle_types.proto
@@ -936,6 +936,7 @@ message UpdateAgentRequest {
   optional string name = 2;
   optional string avatar = 3;
   optional string primary_persona_id = 4;
+  optional string environment_id = 5; // Re-home the agent to a different environment (#1447)
 }
 
 // Upsert the Agent's heartbeat (#1438). All fields are presence-tracked:

--- a/packages/database/src/agent-store.ts
+++ b/packages/database/src/agent-store.ts
@@ -18,7 +18,7 @@ export interface AgentStore {
   listAgents(): AgentRow[];
   updateAgent(
     id: string,
-    fields: { name?: string; avatar?: string; primaryPersonaId?: string },
+    fields: { name?: string; avatar?: string; primaryPersonaId?: string; environmentId?: string },
   ): void;
   deleteAgent(id: string): void;
   getAgentsByEnvironment(environmentId: string): AgentRow[];
@@ -70,7 +70,7 @@ export function listAgents(): AgentRow[] {
  */
 export function updateAgent(
   id: string,
-  fields: { name?: string; avatar?: string; primaryPersonaId?: string },
+  fields: { name?: string; avatar?: string; primaryPersonaId?: string; environmentId?: string },
 ): void {
   const updates: Record<string, unknown> = {
     updatedAt: sql`datetime('now')`,
@@ -83,6 +83,9 @@ export function updateAgent(
   }
   if (fields.primaryPersonaId !== undefined) {
     updates.primaryPersonaId = fields.primaryPersonaId;
+  }
+  if (fields.environmentId !== undefined) {
+    updates.environmentId = fields.environmentId;
   }
   db.update(agents).set(updates).where(eq(agents.id, id)).run();
 }

--- a/packages/plugin-core/src/agent-handlers.test.ts
+++ b/packages/plugin-core/src/agent-handlers.test.ts
@@ -52,7 +52,12 @@ vi.mock("@grackle-ai/database", () => ({
     },
     updateAgent: (
       id: string,
-      fields: { name?: string; avatar?: string; primaryPersonaId?: string },
+      fields: {
+        name?: string;
+        avatar?: string;
+        primaryPersonaId?: string;
+        environmentId?: string;
+      },
     ): void => {
       const existing = mockDb.agents.get(id);
       if (existing) {
@@ -62,6 +67,8 @@ vi.mock("@grackle-ai/database", () => ({
           avatar: fields.avatar ?? (existing as { avatar: string }).avatar,
           primaryPersonaId:
             fields.primaryPersonaId ?? (existing as { primaryPersonaId: string }).primaryPersonaId,
+          environmentId:
+            fields.environmentId ?? (existing as { environmentId: string }).environmentId,
         });
       }
     },
@@ -365,6 +372,56 @@ describe("agent-handlers", () => {
         create(grackle.UpdateAgentRequestSchema, { id: other.id, name: "  Taken  " }),
       ),
     ).rejects.toThrow(/already exists/i);
+  });
+
+  // ── #1447 — updateAgent: environment re-homing ──────────────────────
+
+  it("updateAgent changes environmentId to a valid environment and emits agent.updated", async () => {
+    mockDb.environments.set("remote", { id: "remote", displayName: "Remote" });
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, {
+        environmentId: "local",
+        name: "Roaming Bot",
+      }),
+    );
+    expect(created.environmentId).toBe("local");
+
+    const updated = await agentHandlers.updateAgent(
+      create(grackle.UpdateAgentRequestSchema, { id: created.id, environmentId: "remote" }),
+    );
+    expect(updated.environmentId).toBe("remote");
+    // Other fields preserved.
+    expect(updated.name).toBe("Roaming Bot");
+    expect(emitMock).toHaveBeenCalledWith("agent.updated", expect.objectContaining({}));
+    mockDb.environments.delete("remote");
+  });
+
+  it("updateAgent rejects an unknown environmentId with NotFound", async () => {
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "Ghost Mover" }),
+    );
+    await expect(
+      agentHandlers.updateAgent(
+        create(grackle.UpdateAgentRequestSchema, {
+          id: created.id,
+          environmentId: "does-not-exist",
+        }),
+      ),
+    ).rejects.toThrow(/environment not found/i);
+    // Stored environment should be unchanged.
+    const row = mockDb.agents.get(created.id) as { environmentId: string };
+    expect(row.environmentId).toBe("local");
+  });
+
+  it("updateAgent rejects an empty environmentId (required field)", async () => {
+    const created = await agentHandlers.createAgent(
+      create(grackle.CreateAgentRequestSchema, { environmentId: "local", name: "No Empty Env" }),
+    );
+    await expect(
+      agentHandlers.updateAgent(
+        create(grackle.UpdateAgentRequestSchema, { id: created.id, environmentId: "" }),
+      ),
+    ).rejects.toThrow(/environment_id is required/i);
   });
 
   // ── #1418 — environment validation + cascade delete ─────────────────

--- a/packages/plugin-core/src/agent-handlers.ts
+++ b/packages/plugin-core/src/agent-handlers.ts
@@ -82,7 +82,12 @@ export async function getAgent(req: grackle.AgentId): Promise<grackle.Agent> {
 export async function updateAgent(req: grackle.UpdateAgentRequest): Promise<grackle.Agent> {
   const existing = requireAgent(req.id);
 
-  if (req.name === undefined && req.avatar === undefined && req.primaryPersonaId === undefined) {
+  if (
+    req.name === undefined &&
+    req.avatar === undefined &&
+    req.primaryPersonaId === undefined &&
+    req.environmentId === undefined
+  ) {
     throw new ValidationError("No updatable fields provided");
   }
 
@@ -97,12 +102,22 @@ export async function updateAgent(req: grackle.UpdateAgentRequest): Promise<grac
     }
   }
 
+  // Validate and resolve new environment when provided. environment_id is
+  // required on Agents (not clearable), so reject empty strings the same way
+  // createAgent does (#1447).
+  let trimmedEnvironmentId: string | undefined;
+  if (req.environmentId !== undefined) {
+    trimmedEnvironmentId = requireTrimmed(req.environmentId, "environment_id");
+    requireEnvironment(trimmedEnvironmentId);
+  }
+
   // Trim avatar / primaryPersonaId on the way through too (presence-tracked:
   // undefined = keep existing, "" or whitespace-only = clear).
   agentStore.updateAgent(req.id, {
     name: trimmedName,
     avatar: req.avatar === undefined ? undefined : req.avatar.trim(),
     primaryPersonaId: req.primaryPersonaId === undefined ? undefined : req.primaryPersonaId.trim(),
+    environmentId: trimmedEnvironmentId,
   });
   emit("agent.updated", { agentId: req.id });
   const row = agentStore.getAgent(req.id);

--- a/packages/web-components/src/hooks/types.ts
+++ b/packages/web-components/src/hooks/types.ts
@@ -237,6 +237,8 @@ export interface UpdateAgentFields {
   name?: string;
   avatar?: string;
   primaryPersonaId?: string;
+  /** Re-home the agent to a different environment (#1447). */
+  environmentId?: string;
 }
 
 /** Provisioning progress state for a single environment. */
@@ -602,6 +604,11 @@ export interface UseAgentsResult {
   updateAgent: (id: string, updates: UpdateAgentFields) => Promise<AgentData>;
   /** Delete an agent by ID. */
   deleteAgent: (id: string) => Promise<void>;
+  /** Update the agent's heartbeat schedule. Presence-tracked: omit a field to leave it unchanged (#1447). */
+  setHeartbeat: (
+    agentId: string,
+    opts: { cadence?: string; rules?: string; enabled?: boolean },
+  ) => Promise<void>;
   /** Handle a domain event from the event bus. Returns `true` if handled. */
   handleEvent: (event: GrackleEvent) => boolean;
   /** Lifecycle hook for connect/disconnect/event routing. */

--- a/packages/web-components/src/mocks/MockGrackleProvider.tsx
+++ b/packages/web-components/src/mocks/MockGrackleProvider.tsx
@@ -1140,7 +1140,10 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
         deleteAgent: async (id: string) => {
           setAgents((prev) => prev.filter((a) => a.id !== id));
         },
-        setHeartbeat: async (agentId: string, opts) => {
+        setHeartbeat: async (
+          agentId: string,
+          opts: { cadence?: string; rules?: string; enabled?: boolean },
+        ) => {
           console.log("[MockGrackle] setHeartbeat", { agentId, opts });
         },
         domainHook: NOOP_DOMAIN_HOOK,

--- a/packages/web-components/src/mocks/MockGrackleProvider.tsx
+++ b/packages/web-components/src/mocks/MockGrackleProvider.tsx
@@ -1140,6 +1140,9 @@ export function MockGrackleProvider({ children }: MockGrackleProviderProps): JSX
         deleteAgent: async (id: string) => {
           setAgents((prev) => prev.filter((a) => a.id !== id));
         },
+        setHeartbeat: async (agentId: string, opts) => {
+          console.log("[MockGrackle] setHeartbeat", { agentId, opts });
+        },
         domainHook: NOOP_DOMAIN_HOOK,
       },
 

--- a/packages/web/src/hooks/useAgents.test.ts
+++ b/packages/web/src/hooks/useAgents.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for the useAgents hook (#1447).
+ *
+ * Covers: environmentId forwarding in updateAgent, setHeartbeat dispatch
+ * and re-fetch, and the domainHook contract.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useAgents } from "./useAgents.js";
+import type { GrackleEvent } from "@grackle-ai/web-components";
+
+// ---------------------------------------------------------------------------
+// Mock the gRPC client via vi.hoisted so it exists before vi.mock runs.
+// ---------------------------------------------------------------------------
+
+const mockClient = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  createAgent: vi.fn(),
+  updateAgent: vi.fn(),
+  deleteAgent: vi.fn(),
+  setAgentHeartbeat: vi.fn(),
+}));
+
+vi.mock("./useGrackleClient.js", () => ({
+  orchestrationClient: mockClient,
+}));
+
+// proto-converters: identity passthrough — we only care about the hook wiring.
+vi.mock("./proto-converters.js", () => ({
+  protoToAgent: (p: unknown) => p,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_A = {
+  id: "a1",
+  name: "Agent Alpha",
+  avatar: "🐦",
+  primaryPersonaId: "p1",
+  environmentId: "env-local",
+};
+
+function setup(): { result: { current: ReturnType<typeof useAgents> } } {
+  return renderHook(() => useAgents());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: listAgents returns one agent.
+  mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+});
+
+// ---------------------------------------------------------------------------
+// loadAgents
+// ---------------------------------------------------------------------------
+
+describe("loadAgents", () => {
+  it("populates the agents list on success", async () => {
+    const { result } = setup();
+    await act(() => result.current.loadAgents());
+    expect(result.current.agents).toEqual([AGENT_A]);
+  });
+
+  it("leaves the list empty and does not throw on RPC error", async () => {
+    mockClient.listAgents.mockRejectedValue(new Error("offline"));
+    const { result } = setup();
+    await act(() => result.current.loadAgents());
+    expect(result.current.agents).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateAgent — environmentId forwarding (#1447)
+// ---------------------------------------------------------------------------
+
+describe("updateAgent", () => {
+  it("forwards environmentId to the gRPC client", async () => {
+    const updated = { ...AGENT_A, environmentId: "env-remote" };
+    mockClient.updateAgent.mockResolvedValue(updated);
+
+    const { result } = setup();
+    await act(() => result.current.updateAgent("a1", { environmentId: "env-remote" }));
+
+    expect(mockClient.updateAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a1", environmentId: "env-remote" }),
+    );
+  });
+
+  it("passes undefined environmentId when not provided (preserves field)", async () => {
+    const updated = { ...AGENT_A, name: "Agent Beta" };
+    mockClient.updateAgent.mockResolvedValue(updated);
+
+    const { result } = setup();
+    await act(() => result.current.updateAgent("a1", { name: "Agent Beta" }));
+
+    const call = mockClient.updateAgent.mock.calls[0][0] as Record<string, unknown>;
+    // environmentId absent → proto3 optional treats it as "keep existing".
+    expect(call.environmentId).toBeUndefined();
+  });
+
+  it("applies the optimistic update to the local agents list", async () => {
+    const updated = { ...AGENT_A, name: "Renamed" };
+    mockClient.updateAgent.mockResolvedValue(updated);
+    mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+
+    const { result } = setup();
+    await act(() => result.current.loadAgents());
+    await act(() => result.current.updateAgent("a1", { name: "Renamed" }));
+
+    expect(result.current.agents[0].name).toBe("Renamed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setHeartbeat (#1447)
+// ---------------------------------------------------------------------------
+
+describe("setHeartbeat", () => {
+  it("calls setAgentHeartbeat with the correct agentId and opts", async () => {
+    mockClient.setAgentHeartbeat.mockResolvedValue({});
+    mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+
+    const { result } = setup();
+    await act(() =>
+      result.current.setHeartbeat("a1", { cadence: "5m", rules: "check queue", enabled: true }),
+    );
+
+    expect(mockClient.setAgentHeartbeat).toHaveBeenCalledWith({
+      agentId: "a1",
+      cadence: "5m",
+      rules: "check queue",
+      enabled: true,
+    });
+  });
+
+  it("triggers a loadAgents re-fetch after the RPC resolves", async () => {
+    mockClient.setAgentHeartbeat.mockResolvedValue({});
+    mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+
+    const { result } = setup();
+    await act(() => result.current.setHeartbeat("a1", { enabled: false }));
+
+    // One call from the loadAgents inside setHeartbeat.
+    expect(mockClient.listAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards partial opts (only enabled) without setting cadence/rules", async () => {
+    mockClient.setAgentHeartbeat.mockResolvedValue({});
+    mockClient.listAgents.mockResolvedValue({ agents: [] });
+
+    const { result } = setup();
+    await act(() => result.current.setHeartbeat("a1", { enabled: false }));
+
+    const call = mockClient.setAgentHeartbeat.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.enabled).toBe(false);
+    expect(call.cadence).toBeUndefined();
+    expect(call.rules).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// domainHook — event routing
+// ---------------------------------------------------------------------------
+
+describe("domainHook", () => {
+  it("re-fetches on agent.updated event", async () => {
+    mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+
+    const { result } = setup();
+    const event: GrackleEvent = {
+      id: "ev1",
+      type: "agent.updated",
+      timestamp: "2026-01-01T00:00:00Z",
+      payload: {},
+    };
+    act(() => {
+      result.current.domainHook.handleEvent(event);
+    });
+
+    await waitFor(() => {
+      expect(mockClient.listAgents).toHaveBeenCalled();
+    });
+  });
+
+  it("re-fetches on agent.heartbeat.updated event", async () => {
+    mockClient.listAgents.mockResolvedValue({ agents: [AGENT_A] });
+
+    const { result } = setup();
+    const event: GrackleEvent = {
+      id: "ev2",
+      type: "agent.heartbeat.updated",
+      timestamp: "2026-01-01T00:00:00Z",
+      payload: {},
+    };
+    act(() => {
+      result.current.domainHook.handleEvent(event);
+    });
+
+    await waitFor(() => {
+      expect(mockClient.listAgents).toHaveBeenCalled();
+    });
+  });
+
+  it("does not re-fetch on unrelated events", () => {
+    const { result } = setup();
+    const event: GrackleEvent = {
+      id: "ev3",
+      type: "task.created",
+      timestamp: "2026-01-01T00:00:00Z",
+      payload: {},
+    };
+    act(() => {
+      result.current.domainHook.handleEvent(event);
+    });
+    // listAgents not called (no loadAgents triggered by unrelated event).
+    expect(mockClient.listAgents).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/useAgents.ts
+++ b/packages/web/src/hooks/useAgents.ts
@@ -87,6 +87,7 @@ export function useAgents(): UseAgentsResult {
         name: updates.name,
         avatar: updates.avatar,
         primaryPersonaId: updates.primaryPersonaId,
+        environmentId: updates.environmentId,
       });
       const updated = protoToAgent(resp);
       setAgents((prev) => prev.map((a) => (a.id === updated.id ? updated : a)));
@@ -99,6 +100,23 @@ export function useAgents(): UseAgentsResult {
     await grackleClient.deleteAgent({ id });
     setAgents((prev) => prev.filter((a) => a.id !== id));
   }, []);
+
+  const setHeartbeat = useCallback(
+    async (
+      agentId: string,
+      opts: { cadence?: string; rules?: string; enabled?: boolean },
+    ): Promise<void> => {
+      await grackleClient.setAgentHeartbeat({
+        agentId,
+        cadence: opts.cadence,
+        rules: opts.rules,
+        enabled: opts.enabled,
+      });
+      // Re-fetch so the agent list reflects the updated heartbeat state.
+      await loadAgents();
+    },
+    [loadAgents],
+  );
 
   const domainHook: DomainHook = useMemo(
     () => ({
@@ -116,6 +134,7 @@ export function useAgents(): UseAgentsResult {
     createAgent,
     updateAgent,
     deleteAgent,
+    setHeartbeat,
     handleEvent,
     domainHook,
   };

--- a/packages/web/src/hooks/useGrackleSocket.ts
+++ b/packages/web/src/hooks/useGrackleSocket.ts
@@ -519,6 +519,7 @@ export function useGrackleSocket(): UseGrackleSocketResult {
       createAgent: agentsHook.createAgent,
       updateAgent: agentsHook.updateAgent,
       deleteAgent: agentsHook.deleteAgent,
+      setHeartbeat: agentsHook.setHeartbeat,
       domainHook: agentsHook.domainHook,
     }),
     [
@@ -527,6 +528,7 @@ export function useGrackleSocket(): UseGrackleSocketResult {
       agentsHook.createAgent,
       agentsHook.updateAgent,
       agentsHook.deleteAgent,
+      agentsHook.setHeartbeat,
       agentsHook.domainHook,
     ],
   );

--- a/packages/web/src/pages/agent-tabs/AgentSettingsTab.stories.tsx
+++ b/packages/web/src/pages/agent-tabs/AgentSettingsTab.stories.tsx
@@ -1,0 +1,156 @@
+/**
+ * Storybook interaction tests for AgentSettingsTab (#1447).
+ *
+ * Verifies editable environment picker and heartbeat fields without
+ * a running server stack.
+ */
+import type { JSX } from "react";
+import { MemoryRouter, Routes, Route, Outlet } from "react-router";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
+import { withMockGrackle } from "@grackle-ai/web-components";
+import type { AgentData } from "@grackle-ai/web-components";
+import { AgentSettingsTab } from "./AgentSettingsTab.js";
+import type { AgentOutletContext } from "../AgentLayout.js";
+
+// ---------------------------------------------------------------------------
+// Local agent fixture — mirrors MOCK_AGENTS[0] but defined inline since
+// MOCK_AGENTS is not yet a public storybook-helpers export.
+// ---------------------------------------------------------------------------
+
+const AGENT: AgentData = {
+  id: "refactor-bot",
+  name: "Refactor Bot",
+  avatar: "🔧",
+  primaryPersonaId: "persona-fe",
+  environmentId: "env-local-01",
+  heartbeat: {
+    id: "hb-refactor-bot",
+    title: "Refactor Bot Heartbeat",
+    description: "Wake every 15 minutes and check the queue.",
+    scheduleExpression: "*/15 * * * *",
+    personaId: "persona-fe",
+    workspaceId: "proj-alpha",
+    parentTaskId: "rb-root",
+    enabled: true,
+    lastRunAt: "",
+    nextRunAt: "",
+    runCount: 42,
+    createdAt: "2026-02-22T09:00:00Z",
+    updatedAt: "2026-02-25T18:30:00Z",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper — provides the outlet context AgentSettingsTab reads via
+// useAgentContext() → useOutletContext().
+// ---------------------------------------------------------------------------
+
+function SettingsTabRoute({ agent }: AgentOutletContext): JSX.Element {
+  return (
+    <MemoryRouter initialEntries={["/agents/refactor-bot/settings"]}>
+      <Routes>
+        <Route
+          path="/agents/:agentId"
+          element={<Outlet context={{ agent } satisfies AgentOutletContext} />}
+        >
+          <Route path="settings" element={<AgentSettingsTab />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const meta: Meta = {
+  title: "pages/agent-tabs/AgentSettingsTab",
+  component: AgentSettingsTab,
+  decorators: [withMockGrackle],
+  parameters: { skipRouter: true },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Renders
+// ---------------------------------------------------------------------------
+
+/** Default rendering: shows the settings form with all sections. */
+export const Default: Story = {
+  render: () => <SettingsTabRoute agent={AGENT} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("agent-settings-tab")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-name")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-environment")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-persona")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-delete")).toBeInTheDocument();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Environment picker (#1447 Task 1)
+// ---------------------------------------------------------------------------
+
+/** Environment field is an editable select showing the display name, not the id. */
+export const EnvironmentEditable: Story = {
+  render: () => <SettingsTabRoute agent={AGENT} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const envField = canvas.getByTestId("agent-settings-environment");
+    await expect(envField).toBeInTheDocument();
+
+    // Should show the display name of the current environment.
+    // AGENT.environmentId = "env-local-01" → MockGrackleProvider default displayName is "Local Dev".
+    await expect(envField).toHaveTextContent("Local Dev");
+  },
+};
+
+/** Clicking the environment field opens an editable select. */
+export const EnvironmentSelectOpens: Story = {
+  render: () => <SettingsTabRoute agent={AGENT} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const envField = canvas.getByTestId("agent-settings-environment");
+
+    await userEvent.click(envField);
+
+    // After clicking, a <select> element should be visible inside the field.
+    const select = envField.querySelector("select");
+    if (select) {
+      await expect(select).toBeInTheDocument();
+    } else {
+      // EditableSelect may render differently; just confirm the field is interactive.
+      await expect(envField).toBeInTheDocument();
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Heartbeat section (#1447 Task 2 — routing through hook)
+// ---------------------------------------------------------------------------
+
+/** Heartbeat section is visible when the agent has a heartbeat. */
+export const HeartbeatVisible: Story = {
+  render: () => <SettingsTabRoute agent={AGENT} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-heartbeat-enabled")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-heartbeat-rules")).toBeInTheDocument();
+  },
+};
+
+/** No-heartbeat agent shows the "Set a cadence" prompt and a cadence field. */
+export const HeartbeatAbsent: Story = {
+  render: () => <SettingsTabRoute agent={{ ...AGENT, heartbeat: undefined }} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No heartbeat configured/i)).toBeInTheDocument();
+    // Cadence field still shown so the user can set one.
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
+    // No enabled checkbox without a schedule.
+    await expect(canvas.queryByTestId("agent-settings-heartbeat-enabled")).not.toBeInTheDocument();
+  },
+};

--- a/packages/web/src/pages/agent-tabs/AgentSettingsTab.stories.tsx
+++ b/packages/web/src/pages/agent-tabs/AgentSettingsTab.stories.tsx
@@ -3,6 +3,12 @@
  *
  * Verifies editable environment picker and heartbeat fields without
  * a running server stack.
+ *
+ * testid suffix convention used by the Editable* components:
+ *   - display mode (button): `${testId}-button`
+ *   - edit mode (input/textarea): `${testId}-input`
+ *   - edit mode (select): `${testId}-select`
+ *   - EditableCheckbox: uses base `${testId}` directly on the label
  */
 import type { JSX } from "react";
 import { MemoryRouter, Routes, Route, Outlet } from "react-router";
@@ -79,11 +85,14 @@ export const Default: Story = {
   render: () => <SettingsTabRoute agent={AGENT} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // Outer container — direct testid on the section div
     await expect(canvas.getByTestId("agent-settings-tab")).toBeInTheDocument();
-    await expect(canvas.getByTestId("agent-settings-name")).toBeInTheDocument();
-    await expect(canvas.getByTestId("agent-settings-environment")).toBeInTheDocument();
-    await expect(canvas.getByTestId("agent-settings-persona")).toBeInTheDocument();
-    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
+    // Editable* display-mode elements render the base testid with `-button` suffix
+    await expect(canvas.getByTestId("agent-settings-name-button")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-environment-button")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-persona-button")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence-button")).toBeInTheDocument();
+    // Delete button is a plain <Button> — uses the base testid directly
     await expect(canvas.getByTestId("agent-settings-delete")).toBeInTheDocument();
   },
 };
@@ -98,32 +107,27 @@ export const EnvironmentEditable: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const envField = canvas.getByTestId("agent-settings-environment");
-    await expect(envField).toBeInTheDocument();
+    // EditableSelect in display mode renders a button with the `-button` suffix.
+    const envButton = canvas.getByTestId("agent-settings-environment-button");
+    await expect(envButton).toBeInTheDocument();
 
-    // Should show the display name of the current environment.
-    // AGENT.environmentId = "env-local-01" → MockGrackleProvider default displayName is "Local Dev".
-    await expect(envField).toHaveTextContent("Local Dev");
+    // AGENT.environmentId = "env-local-01" → MockGrackleProvider maps it to "Local Dev".
+    await expect(envButton).toHaveTextContent("Local Dev");
   },
 };
 
-/** Clicking the environment field opens an editable select. */
+/** Clicking the environment field switches it to edit mode (renders a <select>). */
 export const EnvironmentSelectOpens: Story = {
   render: () => <SettingsTabRoute agent={AGENT} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const envField = canvas.getByTestId("agent-settings-environment");
 
-    await userEvent.click(envField);
+    // Click the display-mode button to enter edit mode
+    const envButton = canvas.getByTestId("agent-settings-environment-button");
+    await userEvent.click(envButton);
 
-    // After clicking, a <select> element should be visible inside the field.
-    const select = envField.querySelector("select");
-    if (select) {
-      await expect(select).toBeInTheDocument();
-    } else {
-      // EditableSelect may render differently; just confirm the field is interactive.
-      await expect(envField).toBeInTheDocument();
-    }
+    // EditableSelect in edit mode renders a <select> with the `-select` suffix
+    await expect(canvas.getByTestId("agent-settings-environment-select")).toBeInTheDocument();
   },
 };
 
@@ -136,9 +140,11 @@ export const HeartbeatVisible: Story = {
   render: () => <SettingsTabRoute agent={AGENT} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
+    // EditableTextField / EditableTextArea display-mode buttons use `-button` suffix
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence-button")).toBeInTheDocument();
+    await expect(canvas.getByTestId("agent-settings-heartbeat-rules-button")).toBeInTheDocument();
+    // EditableCheckbox uses the base testid directly on its <label>
     await expect(canvas.getByTestId("agent-settings-heartbeat-enabled")).toBeInTheDocument();
-    await expect(canvas.getByTestId("agent-settings-heartbeat-rules")).toBeInTheDocument();
   },
 };
 
@@ -148,9 +154,9 @@ export const HeartbeatAbsent: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText(/No heartbeat configured/i)).toBeInTheDocument();
-    // Cadence field still shown so the user can set one.
-    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence")).toBeInTheDocument();
-    // No enabled checkbox without a schedule.
+    // Cadence field still shown so the user can set one (display-mode button)
+    await expect(canvas.getByTestId("agent-settings-heartbeat-cadence-button")).toBeInTheDocument();
+    // No enabled checkbox when there is no schedule
     await expect(canvas.queryByTestId("agent-settings-heartbeat-enabled")).not.toBeInTheDocument();
   },
 };

--- a/packages/web/src/pages/agent-tabs/AgentSettingsTab.tsx
+++ b/packages/web/src/pages/agent-tabs/AgentSettingsTab.tsx
@@ -19,7 +19,6 @@ import {
   useToast,
   type SelectOption,
 } from "@grackle-ai/web-components";
-import { orchestrationClient } from "../../hooks/useGrackleClient.js";
 import { useAgentContext } from "../AgentLayout.js";
 import styles from "./AgentSettingsTab.module.scss";
 
@@ -34,7 +33,7 @@ export function AgentSettingsTab(): JSX.Element {
   const navigate = useAppNavigate();
   const { showToast } = useToast();
   const {
-    agents: { updateAgent, deleteAgent },
+    agents: { updateAgent, deleteAgent, setHeartbeat },
     personas: { personas },
     environments: { environments },
   } = useGrackle();
@@ -46,6 +45,11 @@ export function AgentSettingsTab(): JSX.Element {
     { value: "", label: "(none)" },
     ...personas.map((p) => ({ value: p.id, label: p.name })),
   ];
+
+  const environmentOptions: SelectOption[] = environments.map((e) => ({
+    value: e.id,
+    label: e.displayName || e.id,
+  }));
 
   const handleSaveName = (value: string): void => {
     updateAgent(agent.id, { name: value }).then(
@@ -68,23 +72,30 @@ export function AgentSettingsTab(): JSX.Element {
     );
   };
 
+  const handleSaveEnvironment = (value: string): void => {
+    updateAgent(agent.id, { environmentId: value }).then(
+      () => showToast("Environment updated", "success"),
+      () => showToast("Failed to update environment", "error"),
+    );
+  };
+
   const handleSaveHeartbeatCadence = (value: string): void => {
     const cadence = value.trim();
-    orchestrationClient.setAgentHeartbeat({ agentId: agent.id, cadence: cadence || "" }).then(
+    setHeartbeat(agent.id, { cadence: cadence || "" }).then(
       () => showToast(cadence ? "Heartbeat updated" : "Heartbeat cleared", "success"),
       () => showToast("Failed to update heartbeat", "error"),
     );
   };
 
   const handleSaveHeartbeatRules = (value: string): void => {
-    orchestrationClient.setAgentHeartbeat({ agentId: agent.id, rules: value }).then(
+    setHeartbeat(agent.id, { rules: value }).then(
       () => showToast("Heartbeat rules updated", "success"),
       () => showToast("Failed to update rules", "error"),
     );
   };
 
   const handleToggleHeartbeat = (enabled: boolean): void => {
-    orchestrationClient.setAgentHeartbeat({ agentId: agent.id, enabled }).then(
+    setHeartbeat(agent.id, { enabled }).then(
       () => showToast(enabled ? "Heartbeat resumed" : "Heartbeat paused", "success"),
       () => showToast("Failed to toggle heartbeat", "error"),
     );
@@ -149,10 +160,16 @@ export function AgentSettingsTab(): JSX.Element {
         </div>
         <div className={styles.field}>
           <label className={styles.label}>Environment</label>
-          <div className={styles.readOnly} data-testid="agent-settings-environment">
-            {environments.find((e) => e.id === agent.environmentId)?.displayName ||
-              agent.environmentId}
-          </div>
+          <EditableSelect
+            value={agent.environmentId}
+            onSave={handleSaveEnvironment}
+            options={environmentOptions}
+            fieldId="agent-environment"
+            activeFieldId={activeFieldId}
+            onActivate={setActiveFieldId}
+            ariaLabel="Home environment"
+            data-testid="agent-settings-environment"
+          />
         </div>
       </section>
 

--- a/packages/web/src/pages/agent-tabs/AgentSettingsTab.tsx
+++ b/packages/web/src/pages/agent-tabs/AgentSettingsTab.tsx
@@ -46,10 +46,19 @@ export function AgentSettingsTab(): JSX.Element {
     ...personas.map((p) => ({ value: p.id, label: p.name })),
   ];
 
-  const environmentOptions: SelectOption[] = environments.map((e) => ({
-    value: e.id,
-    label: e.displayName || e.id,
-  }));
+  const environmentOptions: SelectOption[] = (() => {
+    const opts = environments.map((e) => ({
+      value: e.id,
+      label: e.displayName || e.id,
+    }));
+    // Always ensure the agent's current environment appears even if the
+    // environments list hasn't finished loading — prevents the field from
+    // briefly showing the placeholder "None" on first render.
+    if (agent.environmentId && !opts.some((o) => o.value === agent.environmentId)) {
+      opts.unshift({ value: agent.environmentId, label: agent.environmentId });
+    }
+    return opts;
+  })();
 
   const handleSaveName = (value: string): void => {
     updateAgent(agent.id, { name: value }).then(


### PR DESCRIPTION
## Summary

- Adds `optional string environment_id = 5` to `UpdateAgentRequest` (proto3 optional — `undefined` = keep existing) so agents can be re-homed to a different environment after creation
- Routes all three heartbeat mutation handlers (`handleSaveHeartbeatCadence`, `handleSaveHeartbeatRules`, `handleToggleHeartbeat`) through the new `useAgents.setHeartbeat` hook instead of calling `orchestrationClient` directly — consistent with every other agent mutation
- Surfaces the environment field as an `EditableSelect` in the Agent Settings tab (mirroring the Primary Persona picker) so users can re-home an agent without deleting and recreating it

## Test plan

- [x] Handler unit tests — `packages/plugin-core/src/agent-handlers.test.ts`: new cases for valid environment re-homing, unknown environment (NotFound), empty environment (InvalidArgument)
- [x] Hook unit tests — new `packages/web/src/hooks/useAgents.test.ts` (11 tests): `environmentId` forwarding, `setHeartbeat` dispatch + re-fetch, domainHook event routing
- [x] Full build clean with zero warnings: `rush build` across `common`, `database`, `plugin-core`, `web-components`, `web`
- [x] `rush test -t @grackle-ai/plugin-core` and `rush test -t @grackle-ai/web` pass
- [x] Manual: launched isolated server, created agent with `test-local` environment, navigated to Settings tab — Environment field shows "Test Local" as an editable select; clicking opens the picker

## Screenshots

**Agent Settings tab — editable Environment field:**
![Agent Settings default](https://gist.githubusercontent.com/nick-pape/ee3792b68fd5c82fb78de19aa10cf088/raw/agent-settings-default.svg)

**Environment picker open:**
![Environment picker](https://gist.githubusercontent.com/nick-pape/ee3792b68fd5c82fb78de19aa10cf088/raw/agent-settings-env-picker.svg)

Closes #1447