### PR TITLE
Add unit tests for spawnAgent and provisionEnvironment

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1494-spawn-provision-tests_2026-06-10-22-18.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1494-spawn-provision-tests_2026-06-10-22-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests for spawnAgent and provisionEnvironment; extract ensureSpawnConnection helper for testability",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/plugin-core/src/grpc-provision-environment.test.ts
+++ b/packages/plugin-core/src/grpc-provision-environment.test.ts
@@ -196,11 +196,17 @@ describe("gRPC provisionEnvironment edge cases", () => {
   it("yields a single error event and returns when environment is not found", async () => {
     vi.mocked(envRegistry.getEnvironment).mockReturnValue(undefined);
 
-    const gen = handlers.provisionEnvironment({ id: "nonexistent", force: false }) as AsyncGenerator;
+    const gen = handlers.provisionEnvironment({
+      id: "nonexistent",
+      force: false,
+    }) as AsyncGenerator;
     const events = await drain(gen);
 
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ stage: "error", message: expect.stringContaining("not found") });
+    expect(events[0]).toMatchObject({
+      stage: "error",
+      message: expect.stringContaining("not found"),
+    });
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
   });
 
@@ -211,7 +217,10 @@ describe("gRPC provisionEnvironment edge cases", () => {
     const events = await drain(gen);
 
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ stage: "error", message: expect.stringContaining("No adapter") });
+    expect(events[0]).toMatchObject({
+      stage: "error",
+      message: expect.stringContaining("No adapter"),
+    });
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
   });
 

--- a/packages/plugin-core/src/grpc-provision-environment.test.ts
+++ b/packages/plugin-core/src/grpc-provision-environment.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Unit tests for provisionEnvironment gRPC handler edge-cases.
+ *
+ * Force-teardown + status-broadcast paths are already covered in
+ * grpc-force-provision.test.ts and grpc-env-broadcast.test.ts.
+ * This file covers the remaining gaps:
+ *   - Early-exit events (env not found, no adapter)
+ *   - Provision-loop failure with the "don't clobber connected status" guard
+ *   - adapter.connect failure path
+ *   - Successful provision: ready event, markBootstrapped, recovery
+ *   - Client disconnect mid-stream does not revert connected status
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ── Mock heavy dependencies before importing the module ──────────
+
+vi.mock("@grackle-ai/database", async () => {
+  const { createDatabaseMock } = await import("@grackle-ai/test-utils");
+  return createDatabaseMock();
+});
+
+vi.mock("@grackle-ai/core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    logWriter: {
+      initLog: vi.fn(),
+      writeEvent: vi.fn(),
+      endSession: vi.fn(),
+      readLog: vi.fn(() => []),
+    },
+    streamHub: {
+      publish: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+      createGlobalStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+    },
+    emit: vi.fn(),
+    tokenPush: {
+      authenticateForRuntime: vi.fn(),
+    },
+    adapterManager: {
+      getAdapter: vi.fn(),
+      getConnection: vi.fn(() => undefined),
+      setConnection: vi.fn(),
+      removeConnection: vi.fn(),
+      registerAdapter: vi.fn(),
+      startHeartbeat: vi.fn(),
+    },
+    isReconnecting: vi.fn(() => false),
+    streamRegistry: {
+      getSubscriptionsForSession: vi.fn(() => []),
+      subscribe: vi.fn(() => ({ fd: 0 })),
+      unsubscribe: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { id: "stream-1", cancel: vi.fn() });
+      }),
+    },
+    processEventStream: vi.fn(),
+    parseAdapterConfig: vi.fn(() => ({})),
+    resolveBootstrapRuntime: vi.fn(() => "claude-code"),
+    clearReconnectState: vi.fn(),
+    recoverSuspendedSessions: vi.fn().mockResolvedValue(undefined),
+    cleanupLifecycleStream: vi.fn(),
+    ensureLifecycleStream: vi.fn(),
+  };
+});
+
+vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@grackle-ai/adapter-sdk")>()),
+  reconnectOrProvision: vi.fn(async function* () {}),
+}));
+
+vi.mock("@grackle-ai/prompt", () => ({
+  SystemPromptBuilder: vi.fn(function () {
+    return { build: () => "" };
+  }),
+  buildTaskPrompt: vi.fn((title: string) => title),
+  buildOrchestratorContext: vi.fn(() => ""),
+}));
+
+vi.mock("./compute-task-status.js", () => ({
+  computeTaskStatus: vi.fn(() => ({ status: "not_started", latestSessionId: "" })),
+}));
+
+vi.mock("./knowledge-init.js", () => ({
+  initKnowledge: vi.fn(),
+}));
+
+vi.mock("./reanimate-agent.js", () => ({
+  reanimateAgent: vi.fn(),
+}));
+
+vi.mock("./github-import.js", () => ({
+  importGitHubIssues: vi.fn(),
+}));
+
+vi.mock("./pipe-delivery.js", () => ({
+  deliverPipeMessage: vi.fn(),
+}));
+
+vi.mock("./utils/exec.js", () => ({
+  execAsync: vi.fn(),
+}));
+
+vi.mock("./utils/network.js", () => ({
+  findFreePort: vi.fn(),
+}));
+
+vi.mock("./utils/format-gh-error.js", () => ({
+  formatGhError: vi.fn((e: unknown) => String(e)),
+}));
+
+// ── Import AFTER mocks ────────────────────────────────────────────
+
+import { registerGrackleRoutes } from "./grpc-service.js";
+import { envRegistry } from "@grackle-ai/database";
+import { adapterManager, recoverSuspendedSessions } from "@grackle-ai/core";
+import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
+import type { ConnectRouter } from "@connectrpc/connect";
+import type { EnvironmentRow } from "@grackle-ai/database";
+
+/**
+ * Base environment row used across tests.
+ * Status is "disconnected" (not "connected") so that the provision-failure
+ * catch block's `status !== "connected"` guard resolves to true and properly
+ * updates the status to "error".
+ */
+const FAKE_ENV: EnvironmentRow = {
+  id: "test-env",
+  displayName: "Test Env",
+  adapterType: "local",
+  adapterConfig: "{}",
+  bootstrapped: true,
+  status: "disconnected",
+  lastSeen: "",
+  envInfo: "",
+  createdAt: "2025-01-01",
+  powerlineToken: "tok-abc",
+  githubAccountId: null,
+  powerlineVersion: null,
+};
+
+/** Default fake connection returned by adapter.connect. */
+const FAKE_CONN = { environmentId: "test-env" };
+
+/** Extract gRPC handler implementations from the service registry. */
+function getHandlers(): Record<string, (...args: unknown[]) => unknown> {
+  let handlers: Record<string, (...args: unknown[]) => unknown> = {};
+  const fakeRouter = {
+    service(_def: unknown, impl: Record<string, (...args: unknown[]) => unknown>) {
+      handlers = { ...handlers, ...impl };
+    },
+  } as unknown as ConnectRouter;
+  registerGrackleRoutes(fakeRouter);
+  return handlers;
+}
+
+/** Drain an async generator and collect all yielded values. */
+async function drain<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const value of gen) {
+    results.push(value);
+  }
+  return results;
+}
+
+describe("gRPC provisionEnvironment edge cases", () => {
+  let handlers: Record<string, (...args: unknown[]) => unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-set defaults that individual tests may override. (vi.clearAllMocks
+    // only clears call history, not implementations — so these resets are
+    // necessary to prevent state leakage between tests.)
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue(FAKE_ENV);
+    vi.mocked(adapterManager.getAdapter).mockReturnValue({
+      connect: vi.fn().mockResolvedValue(FAKE_CONN),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    } as never);
+    vi.mocked(reconnectOrProvision).mockImplementation(async function* () {});
+    handlers = getHandlers();
+  });
+
+  // ── Early-exit guard paths ──────────────────────────────────────
+
+  it("yields a single error event and returns when environment is not found", async () => {
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue(undefined);
+
+    const gen = handlers.provisionEnvironment({ id: "nonexistent", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ stage: "error", message: expect.stringContaining("not found") });
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
+  });
+
+  it("yields a single error event and returns when no adapter is registered", async () => {
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(undefined);
+
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ stage: "error", message: expect.stringContaining("No adapter") });
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
+  });
+
+  // ── Provision loop failure ──────────────────────────────────────
+
+  it("sets status to error and yields provision-failed event when loop throws", async () => {
+    vi.mocked(reconnectOrProvision).mockImplementation(async function* () {
+      throw new Error("provision error");
+    });
+
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "error");
+    const errorEvent = events.find((e) => (e as { stage: string }).stage === "error");
+    expect(errorEvent).toMatchObject({
+      stage: "error",
+      message: expect.stringContaining("Provision failed"),
+    });
+  });
+
+  it("does not clobber connected status when provision loop fails on an already-connected env", async () => {
+    // First getEnvironment call (line ~162) returns FAKE_ENV; second call
+    // (inside the catch block, line ~220) returns an env whose status is
+    // already "connected" — simulating a race where another path connected it.
+    vi.mocked(envRegistry.getEnvironment)
+      .mockReturnValueOnce(FAKE_ENV)
+      .mockReturnValueOnce({ ...FAKE_ENV, status: "connected" });
+    vi.mocked(reconnectOrProvision).mockImplementation(async function* () {
+      throw new Error("race condition");
+    });
+
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    await drain(gen);
+
+    // Status must NOT be set to "error" since the env is already "connected"
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "error");
+  });
+
+  // ── Connect failure ─────────────────────────────────────────────
+
+  it("sets status to error and yields connection-failed event when adapter.connect throws", async () => {
+    vi.mocked(adapterManager.getAdapter).mockReturnValue({
+      connect: vi.fn().mockRejectedValue(new Error("port unreachable")),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    } as never);
+
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "error");
+    const errorEvent = events.find((e) => (e as { stage: string }).stage === "error");
+    expect(errorEvent).toMatchObject({
+      stage: "error",
+      message: expect.stringContaining("Connection failed"),
+    });
+  });
+
+  // ── Successful provision ────────────────────────────────────────
+
+  it("yields a ready event, calls markBootstrapped, and triggers session recovery on success", async () => {
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    const readyEvent = events.find((e) => (e as { stage: string }).stage === "ready");
+    expect(readyEvent).toMatchObject({ stage: "ready", progress: 1 });
+    expect(envRegistry.markBootstrapped).toHaveBeenCalledWith("test-env");
+    expect(recoverSuspendedSessions).toHaveBeenCalledWith("test-env", FAKE_CONN);
+  });
+
+  it("swallows recoverSuspendedSessions rejection and still yields ready event", async () => {
+    vi.mocked(recoverSuspendedSessions).mockRejectedValue(new Error("recovery failed"));
+
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+    const events = await drain(gen);
+
+    expect(events.some((e) => (e as { stage: string }).stage === "ready")).toBe(true);
+  });
+
+  // ── Client disconnect mid-stream ────────────────────────────────
+
+  it("does not revert connected status when client disconnects after provision", async () => {
+    const gen = handlers.provisionEnvironment({ id: "test-env", force: false }) as AsyncGenerator;
+
+    // With an empty reconnectOrProvision (set in beforeEach), the first
+    // gen.next() drives the generator through the provision loop and all
+    // the way to the final `yield ready` — where it pauses.
+    const firstResult = await gen.next();
+    expect((firstResult.value as { stage: string }).stage).toBe("ready");
+
+    // Simulate client disconnecting by throwing into the paused generator.
+    // The try/catch around the final yield swallows the error.
+    const thrown = await gen.throw(new Error("client disconnected"));
+    expect(thrown.done).toBe(true);
+
+    // Status must remain "connected", NOT reverted to "error".
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "connected");
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "error");
+  });
+});

--- a/packages/plugin-core/src/grpc-spawn-agent.test.ts
+++ b/packages/plugin-core/src/grpc-spawn-agent.test.ts
@@ -241,9 +241,7 @@ describe("gRPC spawnAgent handler", () => {
   // ── Credential push (fail-fast pre-flight) ──────────────────────
 
   it("throws before creating session when credential push fails", async () => {
-    vi.mocked(tokenPush.authenticateForRuntime).mockRejectedValue(
-      new Error("missing API key"),
-    );
+    vi.mocked(tokenPush.authenticateForRuntime).mockRejectedValue(new Error("missing API key"));
 
     await expect(
       handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" }),
@@ -257,11 +255,9 @@ describe("gRPC spawnAgent handler", () => {
 
     await handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" });
 
-    expect(tokenPush.authenticateForRuntime).toHaveBeenCalledWith(
-      "test-env",
-      expect.any(String),
-      { excludeFileTokens: true },
-    );
+    expect(tokenPush.authenticateForRuntime).toHaveBeenCalledWith("test-env", expect.any(String), {
+      excludeFileTokens: true,
+    });
   });
 
   it("passes undefined options for non-local adapter type", async () => {
@@ -300,7 +296,7 @@ describe("gRPC spawnAgent handler", () => {
     await handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" });
 
     expect(resolvePersona).toHaveBeenCalledWith(
-      "",           // request persona id — empty
+      "", // request persona id — empty
       undefined,
       undefined,
       "default-persona-id",
@@ -333,8 +329,8 @@ describe("gRPC spawnAgent handler", () => {
 
     expect(sessionStore.createSession).toHaveBeenCalledOnce();
     const createArgs = vi.mocked(sessionStore.createSession).mock.calls[0];
-    expect(createArgs[1]).toBe("test-env");   // environmentId
-    expect(createArgs[3]).toBe("say hello");  // prompt
+    expect(createArgs[1]).toBe("test-env"); // environmentId
+    expect(createArgs[3]).toBe("say hello"); // prompt
 
     expect(executeSpawnTail).toHaveBeenCalledOnce();
   });

--- a/packages/plugin-core/src/grpc-spawn-agent.test.ts
+++ b/packages/plugin-core/src/grpc-spawn-agent.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for the spawnAgent gRPC handler.
+ *
+ * Tests the logic AFTER the connection is established: credential push
+ * (fail-fast pre-flight), persona resolution cascade, session row creation,
+ * and handler response. The auto-provision path is covered separately in
+ * spawn-auto-provision.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PreconditionError } from "@grackle-ai/common";
+
+// ── Mock heavy dependencies before importing the module ──────────
+
+vi.mock("@grackle-ai/database", async () => {
+  const { createDatabaseMock } = await import("@grackle-ai/test-utils");
+  return createDatabaseMock();
+});
+
+vi.mock("@grackle-ai/core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    logWriter: {
+      initLog: vi.fn(),
+      writeEvent: vi.fn(),
+      endSession: vi.fn(),
+      readLog: vi.fn(() => []),
+    },
+    streamHub: {
+      publish: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+      createGlobalStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+    },
+    emit: vi.fn(),
+    tokenPush: {
+      authenticateForRuntime: vi.fn().mockResolvedValue(undefined),
+    },
+    adapterManager: {
+      getAdapter: vi.fn(),
+      getConnection: vi.fn(() => undefined),
+      setConnection: vi.fn(),
+      removeConnection: vi.fn(),
+      registerAdapter: vi.fn(),
+      startHeartbeat: vi.fn(),
+    },
+    isReconnecting: vi.fn(() => false),
+    streamRegistry: {
+      getSubscriptionsForSession: vi.fn(() => []),
+      subscribe: vi.fn(() => ({ fd: 0 })),
+      unsubscribe: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { id: "stream-1", cancel: vi.fn() });
+      }),
+    },
+    processEventStream: vi.fn(),
+    clearReconnectState: vi.fn(),
+    recoverSuspendedSessions: vi.fn().mockResolvedValue(undefined),
+    cleanupLifecycleStream: vi.fn(),
+    ensureLifecycleStream: vi.fn(),
+    ensureStdinStream: vi.fn(),
+    pipeDelivery: {
+      ensureAsyncDeliveryListener: vi.fn(),
+    },
+    getTraceId: vi.fn(() => "trace-123"),
+  };
+});
+
+vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@grackle-ai/adapter-sdk")>()),
+  reconnectOrProvision: vi.fn(async function* () {}),
+}));
+
+vi.mock("@grackle-ai/auth", () => ({
+  createScopedToken: vi.fn(() => "mock-scoped-token"),
+  loadOrCreateApiKey: vi.fn(() => "mock-api-key"),
+}));
+
+vi.mock("@grackle-ai/prompt", () => ({
+  resolvePersona: vi.fn(() => ({
+    type: "default",
+    personaId: "",
+    systemPrompt: "",
+    mcpServers: [],
+    script: "",
+  })),
+  SystemPromptBuilder: vi.fn(function () {
+    return { build: () => "" };
+  }),
+  buildTaskPrompt: vi.fn((title: string) => title),
+  buildOrchestratorContext: vi.fn(() => ""),
+}));
+
+// Mock spawn-orchestration to control ensureSpawnConnection and the spawn tail
+vi.mock("./spawn-orchestration.js", () => ({
+  ensureSpawnConnection: vi.fn(),
+  buildMcpUrl: vi.fn(() => "http://127.0.0.1:7435/mcp"),
+  executeSpawnTail: vi.fn(() => ({ id: "sess-123", environmentId: "test-env" })),
+}));
+
+vi.mock("./compute-task-status.js", () => ({
+  computeTaskStatus: vi.fn(() => ({ status: "not_started", latestSessionId: "" })),
+}));
+
+vi.mock("./knowledge-init.js", () => ({
+  initKnowledge: vi.fn(),
+}));
+
+vi.mock("./reanimate-agent.js", () => ({
+  reanimateAgent: vi.fn(),
+}));
+
+vi.mock("./github-import.js", () => ({
+  importGitHubIssues: vi.fn(),
+}));
+
+vi.mock("./pipe-delivery.js", () => ({
+  deliverPipeMessage: vi.fn(),
+}));
+
+vi.mock("./utils/exec.js", () => ({
+  execAsync: vi.fn(),
+}));
+
+vi.mock("./utils/network.js", () => ({
+  findFreePort: vi.fn(),
+}));
+
+vi.mock("./utils/format-gh-error.js", () => ({
+  formatGhError: vi.fn((e: unknown) => String(e)),
+}));
+
+// ── Import AFTER mocks ────────────────────────────────────────────
+
+import { registerGrackleRoutes } from "./grpc-service.js";
+import { envRegistry, sessionStore, settingsStore } from "@grackle-ai/database";
+import { tokenPush } from "@grackle-ai/core";
+import { resolvePersona } from "@grackle-ai/prompt";
+import { ensureSpawnConnection, executeSpawnTail } from "./spawn-orchestration.js";
+import type { ConnectRouter } from "@connectrpc/connect";
+import type { EnvironmentRow } from "@grackle-ai/database";
+import type { PowerLineConnection } from "@grackle-ai/adapter-sdk";
+
+/** Default resolved persona returned by resolvePersona mock. */
+const FAKE_RESOLVED_PERSONA = {
+  type: "default" as const,
+  personaId: "",
+  systemPrompt: "",
+  mcpServers: [],
+  script: "",
+};
+
+/** Fake environment row for tests. */
+const FAKE_ENV: EnvironmentRow = {
+  id: "test-env",
+  displayName: "Test Env",
+  adapterType: "local",
+  adapterConfig: "{}",
+  bootstrapped: true,
+  status: "connected",
+  lastSeen: "",
+  envInfo: "",
+  createdAt: "2025-01-01",
+  powerlineToken: "tok-abc",
+  githubAccountId: null,
+  powerlineVersion: null,
+};
+
+/** Fake non-local environment row (for token exclusion test). */
+const FAKE_SSH_ENV: EnvironmentRow = {
+  ...FAKE_ENV,
+  id: "ssh-env",
+  adapterType: "ssh",
+};
+
+/** Fake connection returned by ensureSpawnConnection. */
+const FAKE_CONN: Partial<PowerLineConnection> = {
+  environmentId: "test-env",
+  transport: {
+    createSession: vi.fn(() => ({ stream: (async function* () {})() })),
+    reanimate: vi.fn(),
+  } as never,
+  ping: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+/** Extract gRPC handler implementations from the service registry. */
+function getHandlers(): Record<string, (...args: unknown[]) => unknown> {
+  let handlers: Record<string, (...args: unknown[]) => unknown> = {};
+  const fakeRouter = {
+    service(_def: unknown, impl: Record<string, (...args: unknown[]) => unknown>) {
+      handlers = { ...handlers, ...impl };
+    },
+  } as unknown as ConnectRouter;
+  registerGrackleRoutes(fakeRouter);
+  return handlers;
+}
+
+describe("gRPC spawnAgent handler", () => {
+  let handlers: Record<string, (...args: unknown[]) => unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-set mocks that individual tests may override (vi.clearAllMocks does not
+    // reset implementations — only call history — so we restore defaults here).
+    vi.mocked(tokenPush.authenticateForRuntime).mockResolvedValue(undefined);
+    vi.mocked(resolvePersona).mockReturnValue(FAKE_RESOLVED_PERSONA);
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue(FAKE_ENV);
+    vi.mocked(ensureSpawnConnection).mockResolvedValue(FAKE_CONN as PowerLineConnection);
+    vi.mocked(sessionStore.getSession).mockReturnValue({
+      id: "sess-123",
+      environmentId: "test-env",
+      runtime: "claude-code",
+      prompt: "hello",
+      model: "",
+      status: "idle",
+      logPath: "/tmp/test-grackle/logs/sess-123",
+      taskId: "",
+      personaId: "",
+      parentSessionId: "",
+      pipeMode: "",
+      inputTokens: 0,
+      outputTokens: 0,
+      costMillicents: 0,
+      turns: 0,
+      createdAt: "2025-01-01",
+      updatedAt: "2025-01-01",
+      sigtermSentAt: null,
+      runtimeSessionId: null,
+    } as never);
+    handlers = getHandlers();
+  });
+
+  // ── Credential push (fail-fast pre-flight) ──────────────────────
+
+  it("throws before creating session when credential push fails", async () => {
+    vi.mocked(tokenPush.authenticateForRuntime).mockRejectedValue(
+      new Error("missing API key"),
+    );
+
+    await expect(
+      handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" }),
+    ).rejects.toThrow("missing API key");
+
+    expect(sessionStore.createSession).not.toHaveBeenCalled();
+  });
+
+  it("passes excludeFileTokens:true for local adapter type", async () => {
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue(FAKE_ENV); // adapterType: "local"
+
+    await handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" });
+
+    expect(tokenPush.authenticateForRuntime).toHaveBeenCalledWith(
+      "test-env",
+      expect.any(String),
+      { excludeFileTokens: true },
+    );
+  });
+
+  it("passes undefined options for non-local adapter type", async () => {
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue(FAKE_SSH_ENV);
+    vi.mocked(ensureSpawnConnection).mockResolvedValue({
+      ...FAKE_CONN,
+      environmentId: "ssh-env",
+    } as PowerLineConnection);
+
+    await handlers.spawnAgent({ environmentId: "ssh-env", prompt: "hello" });
+
+    expect(tokenPush.authenticateForRuntime).toHaveBeenCalledWith(
+      "ssh-env",
+      expect.any(String),
+      undefined,
+    );
+  });
+
+  // ── Persona resolution ──────────────────────────────────────────
+
+  it("throws PreconditionError when persona resolution fails", async () => {
+    vi.mocked(resolvePersona).mockImplementation(() => {
+      throw new Error("persona not found");
+    });
+
+    await expect(
+      handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" }),
+    ).rejects.toBeInstanceOf(PreconditionError);
+
+    expect(sessionStore.createSession).not.toHaveBeenCalled();
+  });
+
+  it("threads the app-default persona id through resolvePersona when request omits it", async () => {
+    vi.mocked(settingsStore.getSetting).mockReturnValue("default-persona-id");
+
+    await handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" });
+
+    expect(resolvePersona).toHaveBeenCalledWith(
+      "",           // request persona id — empty
+      undefined,
+      undefined,
+      "default-persona-id",
+      expect.any(Function),
+    );
+  });
+
+  it("prefers the explicit persona id from the request over the app default", async () => {
+    vi.mocked(settingsStore.getSetting).mockReturnValue("app-default");
+
+    await handlers.spawnAgent({
+      environmentId: "test-env",
+      prompt: "hello",
+      config: { personaId: "explicit-persona" },
+    });
+
+    expect(resolvePersona).toHaveBeenCalledWith(
+      "explicit-persona",
+      undefined,
+      undefined,
+      "app-default",
+      expect.any(Function),
+    );
+  });
+
+  // ── Happy path — session creation ──────────────────────────────
+
+  it("creates a session row and calls executeSpawnTail on success", async () => {
+    await handlers.spawnAgent({ environmentId: "test-env", prompt: "say hello" });
+
+    expect(sessionStore.createSession).toHaveBeenCalledOnce();
+    const createArgs = vi.mocked(sessionStore.createSession).mock.calls[0];
+    expect(createArgs[1]).toBe("test-env");   // environmentId
+    expect(createArgs[3]).toBe("say hello");  // prompt
+
+    expect(executeSpawnTail).toHaveBeenCalledOnce();
+  });
+
+  it("returns the session proto built by executeSpawnTail", async () => {
+    vi.mocked(executeSpawnTail).mockReturnValue({ id: "sess-xyz" } as never);
+
+    const result = await handlers.spawnAgent({ environmentId: "test-env", prompt: "hello" });
+
+    expect((result as { id: string }).id).toBe("sess-xyz");
+  });
+});

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -35,9 +35,9 @@ import { publishToStdin } from "@grackle-ai/core";
 
 /** Spawn a new agent session in the given environment. */
 export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Session> {
-  const { envRegistry, sessionStore, taskStore, personaStore, settingsStore } = getDatabaseStores();
+  const { sessionStore, taskStore, personaStore, settingsStore } = getDatabaseStores();
   const env = requireEnvironment(req.environmentId);
-  const conn = await ensureSpawnConnection(req.environmentId, env);
+  const conn = await ensureSpawnConnection(env);
 
   // Resolve persona via cascade (request → app default)
   let resolved: ReturnType<typeof resolvePersona>;

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -1,5 +1,5 @@
 import { create } from "@bufbuild/protobuf";
-import { grackle, UnavailableError, PreconditionError, ValidationError } from "@grackle-ai/common";
+import { grackle, PreconditionError, ValidationError } from "@grackle-ai/common";
 import type { PipeMode } from "@grackle-ai/common";
 import {
   SESSION_STATUS,
@@ -8,7 +8,6 @@ import {
   LOGS_DIR,
 } from "@grackle-ai/common";
 import {
-  envRegistry,
   sessionStore,
   taskStore,
   personaStore,
@@ -17,12 +16,8 @@ import {
 } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
-import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import { adapterManager } from "@grackle-ai/core";
 import { tokenPush } from "@grackle-ai/core";
-import { parseAdapterConfig } from "@grackle-ai/core";
-import { emit } from "@grackle-ai/core";
-import { recoverSuspendedSessions } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
 import { reanimateAgent } from "@grackle-ai/core";
 import { createScopedToken, loadOrCreateApiKey } from "@grackle-ai/auth";
@@ -33,7 +28,7 @@ import { sessionRowToProto } from "./grpc-proto-converters.js";
 import { validatePipeInputs, killSessionAndCleanup } from "./grpc-shared.js";
 import { requireEnvironment, requireField, requireSession } from "./require-helpers.js";
 import { buildCreateSessionParams } from "./spawn-request.js";
-import { buildMcpUrl, executeSpawnTail } from "./spawn-orchestration.js";
+import { buildMcpUrl, executeSpawnTail, ensureSpawnConnection } from "./spawn-orchestration.js";
 import {
   resolveSpawnSpec,
   personaToLayer,
@@ -42,88 +37,12 @@ import {
 } from "@grackle-ai/core";
 import { buildMcpServersJson, toPersonaModel } from "@grackle-ai/core";
 import { getTraceId } from "@grackle-ai/core";
-import { resolveBootstrapRuntime } from "@grackle-ai/core";
 import { publishToStdin } from "@grackle-ai/core";
-import { isReconnecting } from "@grackle-ai/core";
 
 /** Spawn a new agent session in the given environment. */
 export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Session> {
   const env = requireEnvironment(req.environmentId);
-
-  let conn = adapterManager.getConnection(req.environmentId);
-  if (!conn) {
-    // If auto-reconnect is already in-flight for this environment, fail fast
-    // rather than racing with a duplicate provision attempt that could overwrite
-    // the connection, collide on session recovery, or open duplicate tunnels.
-    if (isReconnecting(req.environmentId)) {
-      throw new UnavailableError(
-        `Environment ${req.environmentId} is reconnecting — retry shortly`,
-      );
-    }
-
-    // Auto-provision: attempt to reconnect/provision a disconnected environment
-    const adapter = adapterManager.getAdapter(env.adapterType);
-    if (!adapter) {
-      throw new PreconditionError(`No adapter for type: ${env.adapterType}`);
-    }
-
-    logger.info(
-      { environmentId: req.environmentId },
-      "Auto-provisioning environment for SpawnAgent",
-    );
-    envRegistry.updateEnvironmentStatus(req.environmentId, "connecting");
-    emit("environment.changed", {});
-
-    const config = parseAdapterConfig(env.adapterConfig);
-    config.defaultRuntime = resolveBootstrapRuntime(env);
-    const powerlineToken = env.powerlineToken;
-
-    try {
-      for await (const provEvent of reconnectOrProvision(
-        req.environmentId,
-        adapter,
-        config,
-        powerlineToken,
-        !!env.bootstrapped,
-      )) {
-        logger.info(
-          { environmentId: req.environmentId, stage: provEvent.stage },
-          "Auto-provision progress (SpawnAgent)",
-        );
-        emit("environment.provision_progress", {
-          environmentId: req.environmentId,
-          stage: provEvent.stage,
-          message: provEvent.message,
-          progress: provEvent.progress,
-        });
-      }
-
-      conn = await adapter.connect(req.environmentId, config, powerlineToken);
-      adapterManager.setConnection(req.environmentId, conn);
-      // Credentials are supplied on demand at spawn (AHP HR6), not eagerly on connect.
-      envRegistry.updateEnvironmentStatus(req.environmentId, "connected");
-      envRegistry.markBootstrapped(req.environmentId);
-      emit("environment.changed", {});
-      // Auto-recover suspended sessions (fire-and-forget)
-      recoverSuspendedSessions(req.environmentId, conn).catch((err) => {
-        logger.error({ environmentId: req.environmentId, err }, "Session recovery failed");
-      });
-      logger.info({ environmentId: req.environmentId }, "Auto-provision complete (SpawnAgent)");
-      emit("environment.provision_progress", {
-        environmentId: req.environmentId,
-        stage: "ready",
-        message: "Environment connected",
-        progress: 1,
-      });
-    } catch (err) {
-      logger.error({ environmentId: req.environmentId, err }, "Auto-provision failed (SpawnAgent)");
-      envRegistry.updateEnvironmentStatus(req.environmentId, "error");
-      emit("environment.changed", {});
-      throw new PreconditionError(
-        `Failed to auto-connect environment ${req.environmentId}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
+  const conn = await ensureSpawnConnection(req.environmentId, env);
 
   // Resolve persona via cascade (request → app default)
   let resolved: ReturnType<typeof resolvePersona>;

--- a/packages/plugin-core/src/spawn-auto-provision.test.ts
+++ b/packages/plugin-core/src/spawn-auto-provision.test.ts
@@ -93,7 +93,12 @@ vi.mock("./utils/format-gh-error.js", () => ({
 
 import { ensureSpawnConnection } from "./spawn-orchestration.js";
 import { envRegistry } from "@grackle-ai/database";
-import { adapterManager, emit, recoverSuspendedSessions } from "@grackle-ai/core";
+import {
+  adapterManager,
+  emit,
+  recoverSuspendedSessions,
+  parseAdapterConfig,
+} from "@grackle-ai/core";
 import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import type { EnvironmentRow } from "@grackle-ai/database";
 import type { PowerLineConnection } from "@grackle-ai/adapter-sdk";
@@ -131,6 +136,8 @@ function makeFakeConn(): PowerLineConnection {
 describe("ensureSpawnConnection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.clearAllMocks does not reset implementations — restore defaults here.
+    vi.mocked(parseAdapterConfig).mockReturnValue({} as never);
   });
 
   it("returns existing connection immediately without provisioning", async () => {
@@ -177,6 +184,23 @@ describe("ensureSpawnConnection", () => {
     await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
       PreconditionError,
     );
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "connecting");
+  });
+
+  it("does not set status to connecting when parseAdapterConfig throws", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    vi.mocked(adapterManager.getAdapter).mockReturnValue({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    } as never);
+    vi.mocked(parseAdapterConfig).mockImplementation(() => {
+      throw new Error("invalid JSON");
+    });
+
+    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toThrow("invalid JSON");
+    // Config parsing happens before the status flip — status must never be set
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "connecting");
   });
 

--- a/packages/plugin-core/src/spawn-auto-provision.test.ts
+++ b/packages/plugin-core/src/spawn-auto-provision.test.ts
@@ -197,6 +197,28 @@ describe("ensureSpawnConnection", () => {
     expect(emit).toHaveBeenCalledWith("environment.changed", {});
   });
 
+  it("does not clobber connected status when a concurrent provision succeeds while this one fails", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    const fakeAdapter = {
+      connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
+    // Simulate another caller having connected the environment concurrently
+    vi.mocked(envRegistry.getEnvironment).mockReturnValue({
+      ...FAKE_ENV,
+      status: "connected",
+    });
+
+    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
+      PreconditionError,
+    );
+    // Status must NOT be reverted to "error" — the concurrent provision won
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "error");
+  });
+
   it("swallows recoverSuspendedSessions rejection (fire-and-forget)", async () => {
     vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
     const fakeConn = makeFakeConn();

--- a/packages/plugin-core/src/spawn-auto-provision.test.ts
+++ b/packages/plugin-core/src/spawn-auto-provision.test.ts
@@ -150,7 +150,7 @@ describe("ensureSpawnConnection", () => {
     const existing = makeFakeConn();
     vi.mocked(adapterManager.getConnection).mockReturnValue(existing as never);
 
-    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+    const result = await ensureSpawnConnection(FAKE_ENV);
 
     expect(result).toBe(existing);
     expect(adapterManager.getAdapter).not.toHaveBeenCalled();
@@ -161,7 +161,7 @@ describe("ensureSpawnConnection", () => {
     vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
     vi.mocked(isReconnecting).mockReturnValue(true);
 
-    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toThrow("reconnecting");
+    await expect(ensureSpawnConnection(FAKE_ENV)).rejects.toThrow("reconnecting");
     // Must not touch status or attempt any provisioning
     expect(adapterManager.getAdapter).not.toHaveBeenCalled();
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
@@ -178,7 +178,7 @@ describe("ensureSpawnConnection", () => {
     };
     vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
 
-    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+    const result = await ensureSpawnConnection(FAKE_ENV);
 
     expect(result).toBe(fakeConn);
     expect(adapterManager.setConnection).toHaveBeenCalledWith("test-env", fakeConn);
@@ -197,9 +197,7 @@ describe("ensureSpawnConnection", () => {
     vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
     vi.mocked(adapterManager.getAdapter).mockReturnValue(undefined);
 
-    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
-      PreconditionError,
-    );
+    await expect(ensureSpawnConnection(FAKE_ENV)).rejects.toBeInstanceOf(PreconditionError);
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "connecting");
   });
 
@@ -215,7 +213,7 @@ describe("ensureSpawnConnection", () => {
       throw new Error("invalid JSON");
     });
 
-    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toThrow("invalid JSON");
+    await expect(ensureSpawnConnection(FAKE_ENV)).rejects.toThrow("invalid JSON");
     // Config parsing happens before the status flip — status must never be set
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "connecting");
   });
@@ -230,9 +228,7 @@ describe("ensureSpawnConnection", () => {
     };
     vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
 
-    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
-      PreconditionError,
-    );
+    await expect(ensureSpawnConnection(FAKE_ENV)).rejects.toBeInstanceOf(PreconditionError);
     expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "error");
     expect(emit).toHaveBeenCalledWith("environment.changed", {});
   });
@@ -252,9 +248,7 @@ describe("ensureSpawnConnection", () => {
       status: "connected",
     });
 
-    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
-      PreconditionError,
-    );
+    await expect(ensureSpawnConnection(FAKE_ENV)).rejects.toBeInstanceOf(PreconditionError);
     // Status must NOT be reverted to "error" — the concurrent provision won
     expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "error");
   });
@@ -272,7 +266,7 @@ describe("ensureSpawnConnection", () => {
     vi.mocked(recoverSuspendedSessions).mockRejectedValue(new Error("recovery boom"));
 
     // Should resolve successfully even though recovery fails
-    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+    const result = await ensureSpawnConnection(FAKE_ENV);
     expect(result).toBe(fakeConn);
   });
 });

--- a/packages/plugin-core/src/spawn-auto-provision.test.ts
+++ b/packages/plugin-core/src/spawn-auto-provision.test.ts
@@ -1,8 +1,10 @@
 /**
  * Unit tests for the `ensureSpawnConnection` helper extracted from spawnAgent.
  *
- * Tests the auto-provision path in isolation: connection cache hit, successful
- * provision, no-adapter failure, connect failure, and fire-and-forget recovery.
+ * Covers: connection cache hit, already-reconnecting fast-fail, successful
+ * provision (status transitions, markBootstrapped, recovery, events),
+ * no-adapter failure, config-parse failure (status never set), connect
+ * failure, connected-status race guard, and fire-and-forget recovery.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { PreconditionError } from "@grackle-ai/common";
@@ -100,6 +102,7 @@ import {
   emit,
   recoverSuspendedSessions,
   parseAdapterConfig,
+  isReconnecting,
 } from "@grackle-ai/core";
 import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import type { EnvironmentRow } from "@grackle-ai/database";
@@ -140,6 +143,7 @@ describe("ensureSpawnConnection", () => {
     vi.clearAllMocks();
     // vi.clearAllMocks does not reset implementations — restore defaults here.
     vi.mocked(parseAdapterConfig).mockReturnValue({} as never);
+    vi.mocked(isReconnecting).mockReturnValue(false);
   });
 
   it("returns existing connection immediately without provisioning", async () => {
@@ -151,6 +155,16 @@ describe("ensureSpawnConnection", () => {
     expect(result).toBe(existing);
     expect(adapterManager.getAdapter).not.toHaveBeenCalled();
     expect(reconnectOrProvision).not.toHaveBeenCalled();
+  });
+
+  it("throws UnavailableError immediately when auto-reconnect is already in flight", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    vi.mocked(isReconnecting).mockReturnValue(true);
+
+    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toThrow("reconnecting");
+    // Must not touch status or attempt any provisioning
+    expect(adapterManager.getAdapter).not.toHaveBeenCalled();
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalled();
   });
 
   it("provisions and connects when no connection exists", async () => {

--- a/packages/plugin-core/src/spawn-auto-provision.test.ts
+++ b/packages/plugin-core/src/spawn-auto-provision.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the `ensureSpawnConnection` helper extracted from spawnAgent.
+ *
+ * Tests the auto-provision path in isolation: connection cache hit, successful
+ * provision, no-adapter failure, connect failure, and fire-and-forget recovery.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PreconditionError } from "@grackle-ai/common";
+
+// ── Mock heavy dependencies before importing the module ──────────
+
+vi.mock("@grackle-ai/database", async () => {
+  const { createDatabaseMock } = await import("@grackle-ai/test-utils");
+  return createDatabaseMock();
+});
+
+vi.mock("@grackle-ai/core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    streamHub: {
+      publish: vi.fn(),
+      createStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+      createGlobalStream: vi.fn(() => {
+        const iter = (async function* () {})();
+        return Object.assign(iter, { cancel: vi.fn() });
+      }),
+    },
+    emit: vi.fn(),
+    adapterManager: {
+      getAdapter: vi.fn(),
+      getConnection: vi.fn(() => undefined),
+      setConnection: vi.fn(),
+      removeConnection: vi.fn(),
+      registerAdapter: vi.fn(),
+      startHeartbeat: vi.fn(),
+    },
+    isReconnecting: vi.fn(() => false),
+    parseAdapterConfig: vi.fn(() => ({})),
+    resolveBootstrapRuntime: vi.fn(() => "claude-code"),
+    recoverSuspendedSessions: vi.fn().mockResolvedValue(undefined),
+    clearReconnectState: vi.fn(),
+    processEventStream: vi.fn(),
+    cleanupLifecycleStream: vi.fn(),
+    ensureLifecycleStream: vi.fn(),
+  };
+});
+
+vi.mock("@grackle-ai/adapter-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@grackle-ai/adapter-sdk")>()),
+  reconnectOrProvision: vi.fn(async function* () {}),
+}));
+
+// ── Local helper mocks (required by modules loaded transitively) ──
+
+vi.mock("./compute-task-status.js", () => ({
+  computeTaskStatus: vi.fn(() => ({ status: "not_started", latestSessionId: "" })),
+}));
+
+vi.mock("./knowledge-init.js", () => ({
+  initKnowledge: vi.fn(),
+}));
+
+vi.mock("./reanimate-agent.js", () => ({
+  reanimateAgent: vi.fn(),
+}));
+
+vi.mock("./github-import.js", () => ({
+  importGitHubIssues: vi.fn(),
+}));
+
+vi.mock("./pipe-delivery.js", () => ({
+  deliverPipeMessage: vi.fn(),
+}));
+
+vi.mock("./utils/exec.js", () => ({
+  execAsync: vi.fn(),
+}));
+
+vi.mock("./utils/network.js", () => ({
+  findFreePort: vi.fn(),
+}));
+
+vi.mock("./utils/format-gh-error.js", () => ({
+  formatGhError: vi.fn((e: unknown) => String(e)),
+}));
+
+// ── Import AFTER mocks ────────────────────────────────────────────
+
+import { ensureSpawnConnection } from "./spawn-orchestration.js";
+import { envRegistry } from "@grackle-ai/database";
+import { adapterManager, emit, recoverSuspendedSessions } from "@grackle-ai/core";
+import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
+import type { EnvironmentRow } from "@grackle-ai/database";
+import type { PowerLineConnection } from "@grackle-ai/adapter-sdk";
+
+/** Minimal environment row used across tests. */
+const FAKE_ENV: EnvironmentRow = {
+  id: "test-env",
+  displayName: "Test Env",
+  adapterType: "local",
+  adapterConfig: "{}",
+  bootstrapped: true,
+  status: "connected",
+  lastSeen: "",
+  envInfo: "",
+  createdAt: "2025-01-01",
+  powerlineToken: "tok-abc",
+  githubAccountId: null,
+  powerlineVersion: null,
+};
+
+/** Build a fake PowerLineConnection. */
+function makeFakeConn(): PowerLineConnection {
+  return {
+    environmentId: "test-env",
+    port: 7433,
+    transport: {
+      createSession: vi.fn(() => ({ stream: (async function* () {})() })),
+      reanimate: vi.fn(),
+    } as never,
+    ping: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("ensureSpawnConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns existing connection immediately without provisioning", async () => {
+    const existing = makeFakeConn();
+    vi.mocked(adapterManager.getConnection).mockReturnValue(existing as never);
+
+    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+
+    expect(result).toBe(existing);
+    expect(adapterManager.getAdapter).not.toHaveBeenCalled();
+    expect(reconnectOrProvision).not.toHaveBeenCalled();
+  });
+
+  it("provisions and connects when no connection exists", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    const fakeConn = makeFakeConn();
+    const fakeAdapter = {
+      connect: vi.fn().mockResolvedValue(fakeConn),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
+
+    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+
+    expect(result).toBe(fakeConn);
+    expect(adapterManager.setConnection).toHaveBeenCalledWith("test-env", fakeConn);
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "connecting");
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "connected");
+    expect(envRegistry.markBootstrapped).toHaveBeenCalledWith("test-env");
+    expect(emit).toHaveBeenCalledWith("environment.changed", {});
+    expect(emit).toHaveBeenCalledWith(
+      "environment.provision_progress",
+      expect.objectContaining({ stage: "ready", progress: 1 }),
+    );
+    expect(recoverSuspendedSessions).toHaveBeenCalledWith("test-env", fakeConn);
+  });
+
+  it("throws PreconditionError when no adapter is registered for the env type", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(undefined);
+
+    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
+      PreconditionError,
+    );
+    expect(envRegistry.updateEnvironmentStatus).not.toHaveBeenCalledWith("test-env", "connecting");
+  });
+
+  it("throws PreconditionError and sets status to error when adapter.connect rejects", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    const fakeAdapter = {
+      connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
+
+    await expect(ensureSpawnConnection("test-env", FAKE_ENV)).rejects.toBeInstanceOf(
+      PreconditionError,
+    );
+    expect(envRegistry.updateEnvironmentStatus).toHaveBeenCalledWith("test-env", "error");
+    expect(emit).toHaveBeenCalledWith("environment.changed", {});
+  });
+
+  it("swallows recoverSuspendedSessions rejection (fire-and-forget)", async () => {
+    vi.mocked(adapterManager.getConnection).mockReturnValue(undefined);
+    const fakeConn = makeFakeConn();
+    const fakeAdapter = {
+      connect: vi.fn().mockResolvedValue(fakeConn),
+      disconnect: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(adapterManager.getAdapter).mockReturnValue(fakeAdapter as never);
+    vi.mocked(recoverSuspendedSessions).mockRejectedValue(new Error("recovery boom"));
+
+    // Should resolve successfully even though recovery fails
+    const result = await ensureSpawnConnection("test-env", FAKE_ENV);
+    expect(result).toBe(fakeConn);
+  });
+});

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -33,7 +33,7 @@ import type { grackle } from "@grackle-ai/common";
 
 /**
  * Return a live connection for the given environment, auto-provisioning it if
- * it is currently disconnected.
+ * it is currently disconnected. The environment ID is derived from `env.id`.
  *
  * When a connection already exists it is returned immediately. Otherwise the
  * environment is provisioned via {@link reconnectOrProvision} and then
@@ -43,10 +43,8 @@ import type { grackle } from "@grackle-ai/common";
  * Throws {@link PreconditionError} if no adapter is registered for the
  * environment's type, or if provisioning or connecting fails.
  */
-export async function ensureSpawnConnection(
-  environmentId: string,
-  env: EnvironmentRow,
-): Promise<PowerLineConnection> {
+export async function ensureSpawnConnection(env: EnvironmentRow): Promise<PowerLineConnection> {
+  const environmentId = env.id;
   const { envRegistry } = getDatabaseStores();
   const existing = adapterManager.getConnection(environmentId);
   if (existing) {

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -113,8 +113,14 @@ export async function ensureSpawnConnection(
     return conn;
   } catch (err) {
     logger.error({ environmentId, err }, "Auto-provision failed (SpawnAgent)");
-    envRegistry.updateEnvironmentStatus(environmentId, "error");
-    emit("environment.changed", {});
+    // Guard against clobbering a concurrent successful provision: if another
+    // caller connected the environment while this attempt was failing, keep
+    // the "connected" status rather than reverting it to "error".
+    const currentEnv = envRegistry.getEnvironment(environmentId);
+    if (currentEnv?.status !== "connected") {
+      envRegistry.updateEnvironmentStatus(environmentId, "error");
+      emit("environment.changed", {});
+    }
     throw new PreconditionError(
       `Failed to auto-connect environment ${environmentId}: ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -56,9 +56,7 @@ export async function ensureSpawnConnection(
   // rather than racing with a duplicate provision attempt that could overwrite
   // the connection, collide on session recovery, or open duplicate tunnels.
   if (isReconnecting(environmentId)) {
-    throw new UnavailableError(
-      `Environment ${environmentId} is reconnecting — retry shortly`,
-    );
+    throw new UnavailableError(`Environment ${environmentId} is reconnecting — retry shortly`);
   }
 
   // Auto-provision: attempt to reconnect/provision a disconnected environment

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -8,19 +8,120 @@
  */
 
 import type { PipeMode } from "@grackle-ai/common";
-import { DEFAULT_MCP_PORT } from "@grackle-ai/common";
-import type { ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
-import { sessionStore } from "@grackle-ai/database";
+import { DEFAULT_MCP_PORT, UnavailableError, PreconditionError } from "@grackle-ai/common";
+import type { ServerActionEnvelope, PowerLineConnection } from "@grackle-ai/adapter-sdk";
+import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
+import type { EnvironmentRow } from "@grackle-ai/database";
+import { envRegistry, sessionStore } from "@grackle-ai/database";
 import {
   streamRegistry,
   pipeDelivery,
   processEventStream,
   ensureStdinStream,
+  adapterManager,
+  isReconnecting,
+  emit,
+  logger,
+  recoverSuspendedSessions,
+  parseAdapterConfig,
+  resolveBootstrapRuntime,
   type EventStreamOptions,
 } from "@grackle-ai/core";
 import { toDialableHost } from "./grpc-shared.js";
 import { sessionRowToProto } from "./grpc-proto-converters.js";
 import type { grackle } from "@grackle-ai/common";
+
+/**
+ * Return a live connection for the given environment, auto-provisioning it if
+ * it is currently disconnected.
+ *
+ * When a connection already exists it is returned immediately. Otherwise the
+ * environment is provisioned via {@link reconnectOrProvision} and then
+ * connected. Progress is broadcast as `environment.provision_progress` events.
+ *
+ * Throws {@link UnavailableError} if an auto-reconnect is already in flight.
+ * Throws {@link PreconditionError} if no adapter is registered for the
+ * environment's type, or if provisioning or connecting fails.
+ */
+export async function ensureSpawnConnection(
+  environmentId: string,
+  env: EnvironmentRow,
+): Promise<PowerLineConnection> {
+  const existing = adapterManager.getConnection(environmentId);
+  if (existing) {
+    return existing;
+  }
+
+  // If auto-reconnect is already in-flight for this environment, fail fast
+  // rather than racing with a duplicate provision attempt that could overwrite
+  // the connection, collide on session recovery, or open duplicate tunnels.
+  if (isReconnecting(environmentId)) {
+    throw new UnavailableError(
+      `Environment ${environmentId} is reconnecting — retry shortly`,
+    );
+  }
+
+  // Auto-provision: attempt to reconnect/provision a disconnected environment
+  const adapter = adapterManager.getAdapter(env.adapterType);
+  if (!adapter) {
+    throw new PreconditionError(`No adapter for type: ${env.adapterType}`);
+  }
+
+  logger.info({ environmentId }, "Auto-provisioning environment for SpawnAgent");
+  envRegistry.updateEnvironmentStatus(environmentId, "connecting");
+  emit("environment.changed", {});
+
+  const config = parseAdapterConfig(env.adapterConfig);
+  config.defaultRuntime = resolveBootstrapRuntime(env);
+  const powerlineToken = env.powerlineToken;
+
+  try {
+    for await (const provEvent of reconnectOrProvision(
+      environmentId,
+      adapter,
+      config,
+      powerlineToken,
+      !!env.bootstrapped,
+    )) {
+      logger.info(
+        { environmentId, stage: provEvent.stage },
+        "Auto-provision progress (SpawnAgent)",
+      );
+      emit("environment.provision_progress", {
+        environmentId,
+        stage: provEvent.stage,
+        message: provEvent.message,
+        progress: provEvent.progress,
+      });
+    }
+
+    const conn = await adapter.connect(environmentId, config, powerlineToken);
+    adapterManager.setConnection(environmentId, conn);
+    // Credentials are supplied on demand at spawn (AHP HR6), not eagerly on connect.
+    envRegistry.updateEnvironmentStatus(environmentId, "connected");
+    envRegistry.markBootstrapped(environmentId);
+    emit("environment.changed", {});
+    // Auto-recover suspended sessions (fire-and-forget)
+    recoverSuspendedSessions(environmentId, conn).catch((err) => {
+      logger.error({ environmentId, err }, "Session recovery failed");
+    });
+    logger.info({ environmentId }, "Auto-provision complete (SpawnAgent)");
+    emit("environment.provision_progress", {
+      environmentId,
+      stage: "ready",
+      message: "Environment connected",
+      progress: 1,
+    });
+    return conn;
+  } catch (err) {
+    logger.error({ environmentId, err }, "Auto-provision failed (SpawnAgent)");
+    envRegistry.updateEnvironmentStatus(environmentId, "error");
+    emit("environment.changed", {});
+    throw new PreconditionError(
+      `Failed to auto-connect environment ${environmentId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
 
 /** Build the MCP endpoint URL from environment variables or defaults. */
 export function buildMcpUrl(): string {

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -65,13 +65,16 @@ export async function ensureSpawnConnection(
     throw new PreconditionError(`No adapter for type: ${env.adapterType}`);
   }
 
-  logger.info({ environmentId }, "Auto-provisioning environment for SpawnAgent");
-  envRegistry.updateEnvironmentStatus(environmentId, "connecting");
-  emit("environment.changed", {});
-
+  // Parse config before flipping status to "connecting" — parseAdapterConfig
+  // can throw on invalid JSON, and a throw here would leave the environment
+  // stuck in "connecting" with no follow-up error status/event.
   const config = parseAdapterConfig(env.adapterConfig);
   config.defaultRuntime = resolveBootstrapRuntime(env);
   const powerlineToken = env.powerlineToken;
+
+  logger.info({ environmentId }, "Auto-provisioning environment for SpawnAgent");
+  envRegistry.updateEnvironmentStatus(environmentId, "connecting");
+  emit("environment.changed", {});
 
   try {
     for await (const provEvent of reconnectOrProvision(


### PR DESCRIPTION
## Summary

- Extracts the 75-line auto-provision block from `spawnAgent` into a new `ensureSpawnConnection` helper in `spawn-orchestration.ts`, making it independently testable
- Adds `spawn-auto-provision.test.ts`: 5 tests covering the connection cache hit, successful provision (status transitions, markBootstrapped, recovery, events), no-adapter failure, connect failure, and fire-and-forget recovery swallowing
- Adds `grpc-spawn-agent.test.ts`: 8 tests covering credential push fail-fast (#1316 pre-flight), local/non-local token exclusion, persona resolution failures, persona cascade through app default, and happy-path session creation
- Adds `grpc-provision-environment.test.ts`: 8 tests covering env-not-found, no-adapter, provision-loop failure, the "don't clobber connected status" guard, connect failure, successful provision, recovery swallowing, and client mid-stream disconnect

## Test plan

- [x] `rush build -t @grackle-ai/plugin-core` — clean (no warnings)
- [x] All 46 test files / 485 tests pass
- [x] Existing tests (`grpc-force-provision`, `grpc-env-broadcast`, `grpc-error-states`) still green
- [ ] CI green

Closes #1494