### PR TITLE
test: add unit tests for waitForPipe, getSessionFds, and pipe handler validation branches

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1498-pipe-handler-test-gaps_2026-06-10-22-17.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1498-pipe-handler-test-gaps_2026-06-10-22-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests for waitForPipe, getSessionFds, and pipe handler validation branches (#1498)",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/plugin-core/src/wait-for-pipe.test.ts
+++ b/packages/plugin-core/src/wait-for-pipe.test.ts
@@ -6,7 +6,7 @@
  * SQLite via setupTestDatabase() — do NOT add a vi.mock for @grackle-ai/database.
  */
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
-import { ConnectError, Code } from "@connectrpc/connect";
+import { Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
 import { streamRegistry, pipeDelivery } from "@grackle-ai/core";

--- a/packages/plugin-core/src/wait-for-pipe.test.ts
+++ b/packages/plugin-core/src/wait-for-pipe.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit/integration tests for waitForPipe and getSessionFds.
+ *
+ * Uses the real in-memory stream registry and pipe-delivery (not mocked), so
+ * the sync-consume path fires correctly.  The database uses a real in-memory
+ * SQLite via setupTestDatabase() — do NOT add a vi.mock for @grackle-ai/database.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { ConnectError, Code } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { grackle } from "@grackle-ai/common";
+import { streamRegistry, pipeDelivery } from "@grackle-ai/core";
+import { setupTestDatabase } from "@grackle-ai/test-utils/db";
+import { waitForPipe, getSessionFds } from "./pipe-handlers.js";
+
+// ── Real in-memory SQLite ─────────────────────────────────────────────────────
+// Neither waitForPipe nor getSessionFds calls the DB, but importing pipe-handlers
+// loads sessionStore; setupTestDatabase() initialises the connection so the module
+// loads cleanly and any store-spy assertions work.
+const testDb = setupTestDatabase();
+afterAll(() => testDb.cleanup());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// waitForPipe
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("waitForPipe", () => {
+  let cleanupSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    streamRegistry._resetForTesting();
+    pipeDelivery._resetForTesting();
+    vi.clearAllMocks();
+    // Passthrough spy — exercises real cleanup AND records arguments.
+    cleanupSpy = vi.spyOn(pipeDelivery, "cleanupSyncPipeAndLifecycle");
+  });
+
+  it("throws NotFound when no subscription exists for (sessionId, fd)", async () => {
+    await expect(
+      waitForPipe(create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: 5 })),
+    ).rejects.toMatchObject({ code: Code.NotFound });
+  });
+
+  it("throws FailedPrecondition when the subscription is not a sync subscription (async mode)", async () => {
+    const stream = streamRegistry.createStream("pipe:child");
+    const parentSub = streamRegistry.subscribe(stream.id, "parent", "rw", "async", true);
+
+    await expect(
+      waitForPipe(
+        create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: parentSub.fd }),
+      ),
+    ).rejects.toMatchObject({ code: Code.FailedPrecondition });
+  });
+
+  it("resolves with the message content and senderSessionId (happy path)", async () => {
+    const stream = streamRegistry.createStream("pipe:child");
+    const parentSub = streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+    streamRegistry.subscribe(stream.id, "child", "rw", "async", false);
+
+    // Start waitForPipe — it blocks on consumeSync.
+    const waitPromise = waitForPipe(
+      create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: parentSub.fd }),
+    );
+
+    // Publish from the child — this enqueues the message on the parent's sync queue,
+    // unblocking consumeSync.
+    streamRegistry.publish(stream.id, "child", "hello from child");
+
+    const result = await waitPromise;
+    expect(result.content).toBe("hello from child");
+    expect(result.senderSessionId).toBe("child");
+  });
+
+  it("calls cleanupSyncPipeAndLifecycle in the finally block after success", async () => {
+    const stream = streamRegistry.createStream("pipe:sess-abc");
+    const parentSub = streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+    streamRegistry.subscribe(stream.id, "sess-abc", "rw", "async", false);
+
+    const waitPromise = waitForPipe(
+      create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: parentSub.fd }),
+    );
+    streamRegistry.publish(stream.id, "sess-abc", "done");
+    await waitPromise;
+
+    // childSessionId is derived from the stream name "pipe:sess-abc" → "sess-abc".
+    expect(cleanupSpy).toHaveBeenCalledWith(stream.id, "sess-abc");
+  });
+
+  it("calls cleanupSyncPipeAndLifecycle even when consumeSync is cancelled (finally path)", async () => {
+    // Named "pipe:sess-xyz" so childSessionId is resolved from the name.
+    const stream = streamRegistry.createStream("pipe:sess-xyz");
+    const parentSub = streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+    const capturedStreamId = stream.id;
+
+    const waitPromise = waitForPipe(
+      create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: parentSub.fd }),
+    );
+
+    // Closing the subscription rejects the pending consumeSync ("Subscription closed").
+    streamRegistry.unsubscribe(parentSub.id);
+
+    // waitForPipe should reject, but the finally block still ran.
+    await expect(waitPromise).rejects.toBeDefined();
+
+    // childSessionId is "sess-xyz" (derived from "pipe:sess-xyz" at handler entry time,
+    // before consumeSync blocked).
+    expect(cleanupSpy).toHaveBeenCalledWith(capturedStreamId, "sess-xyz");
+  });
+
+  it("passes childSessionId=undefined for non-pipe stream names (cancellation path)", async () => {
+    // A global (non-pipe) stream — childSessionId cannot be derived from the name.
+    const stream = streamRegistry.createStream("global-channel");
+    const parentSub = streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+    const capturedStreamId = stream.id;
+
+    const waitPromise = waitForPipe(
+      create(grackle.WaitForPipeRequestSchema, { sessionId: "parent", fd: parentSub.fd }),
+    );
+
+    streamRegistry.unsubscribe(parentSub.id);
+    await expect(waitPromise).rejects.toBeDefined();
+
+    expect(cleanupSpy).toHaveBeenCalledWith(capturedStreamId, undefined);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getSessionFds
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getSessionFds", () => {
+  beforeEach(() => {
+    streamRegistry._resetForTesting();
+  });
+
+  it("returns an empty fds array when the session has no subscriptions", () => {
+    const result = getSessionFds(create(grackle.SessionIdSchema, { id: "ghost" }));
+    expect(result.fds).toEqual([]);
+  });
+
+  it("returns one FdInfo with correct field values", () => {
+    const stream = streamRegistry.createStream("pipe:child");
+    const sub = streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+
+    const result = getSessionFds(create(grackle.SessionIdSchema, { id: "parent" }));
+
+    expect(result.fds).toHaveLength(1);
+    const fd = result.fds[0];
+    expect(fd.fd).toBe(sub.fd);
+    expect(fd.streamName).toBe("pipe:child");
+    expect(fd.permission).toBe("rw");
+    expect(fd.deliveryMode).toBe("sync");
+    expect(fd.owned).toBe(true); // createdBySpawn=true
+  });
+
+  it("resolves targetSessionId to the other participant on a shared stream", () => {
+    const stream = streamRegistry.createStream("pipe:child");
+    streamRegistry.subscribe(stream.id, "parent", "rw", "sync", true);
+    streamRegistry.subscribe(stream.id, "child", "rw", "async", false);
+
+    const result = getSessionFds(create(grackle.SessionIdSchema, { id: "parent" }));
+
+    expect(result.fds[0].targetSessionId).toBe("child");
+  });
+
+  it("returns targetSessionId as empty string when the session is the sole subscriber", () => {
+    const stream = streamRegistry.createStream("solo-stream");
+    streamRegistry.subscribe(stream.id, "lone-agent", "rw", "async", false);
+
+    const result = getSessionFds(create(grackle.SessionIdSchema, { id: "lone-agent" }));
+
+    expect(result.fds[0].targetSessionId).toBe("");
+  });
+
+  it("returns multiple FdInfos when the session holds subscriptions on multiple streams", () => {
+    const streamA = streamRegistry.createStream("pipe:child-a");
+    const streamB = streamRegistry.createStream("pipe:child-b");
+    streamRegistry.subscribe(streamA.id, "parent", "rw", "sync", true);
+    streamRegistry.subscribe(streamB.id, "parent", "r", "async", true);
+
+    const result = getSessionFds(create(grackle.SessionIdSchema, { id: "parent" }));
+
+    expect(result.fds).toHaveLength(2);
+    const names = result.fds.map((f) => f.streamName).sort();
+    expect(names).toEqual(["pipe:child-a", "pipe:child-b"]);
+  });
+});

--- a/packages/plugin-core/src/write-close-fd.test.ts
+++ b/packages/plugin-core/src/write-close-fd.test.ts
@@ -183,6 +183,34 @@ describe("writeToFd + closeFd -- async delivery integration", () => {
     });
   });
 
+  // ─── writeToFd — validation branches ────────────────────────────────────────
+
+  describe("writeToFd — validation branches", () => {
+    it("throws NotFound when no subscription exists for (sessionId, fd)", async () => {
+      await expect(
+        writeToFd(
+          create(grackle.WriteToFdRequestSchema, { sessionId: "nobody", fd: 99, message: "hi" }),
+        ),
+      ).rejects.toMatchObject({ code: Code.NotFound });
+    });
+
+    it("throws FailedPrecondition when caller has read-only permission", async () => {
+      insertSession("reader-only");
+      const stream = streamRegistry.createStream("pipe:data");
+      const readerSub = streamRegistry.subscribe(stream.id, "reader-only", "r", "async", true);
+
+      await expect(
+        writeToFd(
+          create(grackle.WriteToFdRequestSchema, {
+            sessionId: "reader-only",
+            fd: readerSub.fd,
+            message: "should fail",
+          }),
+        ),
+      ).rejects.toMatchObject({ code: Code.FailedPrecondition });
+    });
+  });
+
   // ─── closeFd ─────────────────────────────────────────────────────────────────
 
   describe("closeFd", () => {
@@ -237,6 +265,36 @@ describe("writeToFd + closeFd -- async delivery integration", () => {
 
       expect((caughtErr as ConnectError).code).toBe(Code.FailedPrecondition);
       expect((caughtErr as ConnectError).message).toContain("undelivered messages");
+    });
+  });
+
+  // ─── closeFd — validation branches ──────────────────────────────────────────
+
+  describe("closeFd — validation branches", () => {
+    it("throws NotFound when no subscription exists for (sessionId, fd)", async () => {
+      await expect(
+        closeFd(create(grackle.CloseFdRequestSchema, { sessionId: "nobody", fd: 99 })),
+      ).rejects.toMatchObject({ code: Code.NotFound });
+    });
+
+    it("only unsubscribes the caller on a global (non-reserved) stream — other participants survive", async () => {
+      // Global streams: closing one fd should NOT evict other participants.
+      // (closeFd only calls sessionStore when isInternalStream is true — this stream
+      // is not reserved so no DB access occurs, no insertSession needed.)
+      const stream = streamRegistry.createStream("team-room");
+      const subA = streamRegistry.subscribe(stream.id, "session-a", "rw", "async", false);
+      const subB = streamRegistry.subscribe(stream.id, "session-b", "rw", "async", false);
+
+      const result = await closeFd(
+        create(grackle.CloseFdRequestSchema, { sessionId: "session-a", fd: subA.fd }),
+      );
+
+      // stopped=false: session-b was not auto-stopped
+      expect(result.stopped).toBe(false);
+      // session-b is still subscribed
+      expect(streamRegistry.getSubscription("session-b", subB.fd)).toBeDefined();
+      // session-a has been removed
+      expect(streamRegistry.getSubscription("session-a", subA.fd)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

- **New `wait-for-pipe.test.ts`**: covers `waitForPipe` (NotFound, FailedPrecondition for async-mode subs, happy path content/senderSessionId, `finally`-block cleanup on success and cancellation, `childSessionId` derivation from `pipe:*` stream names) and `getSessionFds` (empty, populated FdInfo fields, targetSessionId resolution, multiple fds).
- **Extended `write-close-fd.test.ts`**: adds `writeToFd` validation branches (NotFound, read-only permission rejection) and `closeFd` branches (NotFound, global-stream only-caller-unsubscribed — other participants survive).
- No production code changes. The issue was largely stale; most handlers gained tests in #1470. The only genuine gaps remaining were `waitForPipe` and `getSessionFds` (zero coverage), plus the listed validation branches.

## Test plan

- [x] `npx vitest run src/wait-for-pipe.test.ts src/write-close-fd.test.ts` — 21/21 pass
- [x] Full `packages/plugin-core` suite — 479/479 pass
- [x] `rush change --verify` passes with `patch` change file

Closes #1498