### PR TITLE
DI: migrate plugin-core to store registry (#1550)

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1550-plugin-core-registry_2026-06-10-23-25.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1550-plugin-core-registry_2026-06-10-23-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "DI: migrate plugin-core store consumers to getDatabaseStores() registry; export additional store types from database barrel",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -110,7 +110,7 @@ export type { ComponentStore } from "./component-store.js";
 export type { SettingsStore } from "./settings-store.js";
 export type { TokenStore } from "./token-store.js";
 export type { CredentialProviderStore } from "./credential-providers.js";
-export type { ScheduleStore } from "./schedule-store.js";
+export type { ScheduleStore, ScheduleUpdate } from "./schedule-store.js";
 export type { EscalationStore } from "./escalation-store.js";
 export type { WorkspaceEnvironmentLinkStore } from "./workspace-environment-link-store.js";
 export type { DispatchQueueStore } from "./dispatch-queue-store.js";

--- a/packages/plugin-core/src/agent-handlers.test.ts
+++ b/packages/plugin-core/src/agent-handlers.test.ts
@@ -24,148 +24,155 @@ const mockDb: {
   schedules: new Map(),
 };
 
-vi.mock("@grackle-ai/database", () => ({
-  agentStore: {
-    listAgents: (): Array<Record<string, unknown>> =>
-      [...mockDb.agents.values()].sort((a, b) =>
-        (a as { name: string }).name.localeCompare((b as { name: string }).name),
-      ),
-    getAgent: (id: string): Record<string, unknown> | undefined => mockDb.agents.get(id),
-    getAgentByName: (name: string): Record<string, unknown> | undefined =>
-      [...mockDb.agents.values()].find((a) => (a as { name: string }).name === name),
-    createAgent: (
-      id: string,
-      name: string,
-      avatar: string,
-      primaryPersonaId: string,
-      environmentId: string,
-    ): void => {
-      mockDb.agents.set(id, {
-        id,
-        name,
-        avatar,
-        primaryPersonaId,
-        environmentId,
-        createdAt: "2024-01-01",
-        updatedAt: "2024-01-01",
-      });
-    },
-    updateAgent: (
-      id: string,
-      fields: {
-        name?: string;
-        avatar?: string;
-        primaryPersonaId?: string;
-        environmentId?: string;
-      },
-    ): void => {
-      const existing = mockDb.agents.get(id);
-      if (existing) {
+vi.mock("@grackle-ai/database", () => {
+  const stores = {
+    agentStore: {
+      listAgents: (): Array<Record<string, unknown>> =>
+        [...mockDb.agents.values()].sort((a, b) =>
+          (a as { name: string }).name.localeCompare((b as { name: string }).name),
+        ),
+      getAgent: (id: string): Record<string, unknown> | undefined => mockDb.agents.get(id),
+      getAgentByName: (name: string): Record<string, unknown> | undefined =>
+        [...mockDb.agents.values()].find((a) => (a as { name: string }).name === name),
+      createAgent: (
+        id: string,
+        name: string,
+        avatar: string,
+        primaryPersonaId: string,
+        environmentId: string,
+      ): void => {
         mockDb.agents.set(id, {
-          ...existing,
-          name: fields.name ?? (existing as { name: string }).name,
-          avatar: fields.avatar ?? (existing as { avatar: string }).avatar,
-          primaryPersonaId:
-            fields.primaryPersonaId ?? (existing as { primaryPersonaId: string }).primaryPersonaId,
-          environmentId:
-            fields.environmentId ?? (existing as { environmentId: string }).environmentId,
+          id,
+          name,
+          avatar,
+          primaryPersonaId,
+          environmentId,
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
         });
-      }
-    },
-    deleteAgent: (id: string): void => {
-      mockDb.agents.delete(id);
-    },
-  },
-  envRegistry: {
-    getEnvironment: (id: string): Record<string, unknown> | undefined =>
-      mockDb.environments.get(id),
-  },
-  sessionStore: {
-    listSessionsForTask: (taskId: string): Array<Record<string, unknown>> =>
-      mockDb.taskSessions.get(taskId) ?? [],
-  },
-  taskStore: {
-    getTasksForAgent: (agentId: string): Array<Record<string, unknown>> =>
-      mockDb.agentTasks.get(agentId) ?? [],
-    deleteTask: (id: string): void => {
-      mockDb.deletedTaskIds.push(id);
-    },
-    getRootTaskForAgent: (agentId: string): Record<string, unknown> | undefined =>
-      mockDb.agentRootTasks.get(agentId),
-  },
-  scheduleStore: {
-    getSchedule: (id: string): Record<string, unknown> | undefined => mockDb.schedules.get(id),
-    getHeartbeatForTask: (taskId: string): Record<string, unknown> | undefined => {
-      for (const s of mockDb.schedules.values()) {
-        if ((s as { taskId: string | null }).taskId === taskId) {
-          return s;
+      },
+      updateAgent: (
+        id: string,
+        fields: {
+          name?: string;
+          avatar?: string;
+          primaryPersonaId?: string;
+          environmentId?: string;
+        },
+      ): void => {
+        const existing = mockDb.agents.get(id);
+        if (existing) {
+          mockDb.agents.set(id, {
+            ...existing,
+            name: fields.name ?? (existing as { name: string }).name,
+            avatar: fields.avatar ?? (existing as { avatar: string }).avatar,
+            primaryPersonaId:
+              fields.primaryPersonaId ??
+              (existing as { primaryPersonaId: string }).primaryPersonaId,
+            environmentId:
+              fields.environmentId ?? (existing as { environmentId: string }).environmentId,
+          });
         }
-      }
-      return undefined;
+      },
+      deleteAgent: (id: string): void => {
+        mockDb.agents.delete(id);
+      },
     },
-    createSchedule: (
-      id: string,
-      title: string,
-      description: string,
-      scheduleExpression: string,
-      personaId: string,
-      workspaceId: string,
-      parentTaskId: string,
-      nextRunAt: string | null,
-      taskId: string | null = null,
-    ): void => {
-      // Mirror partial-unique behavior of the real DB.
-      if (taskId !== null) {
+    envRegistry: {
+      getEnvironment: (id: string): Record<string, unknown> | undefined =>
+        mockDb.environments.get(id),
+    },
+    sessionStore: {
+      listSessionsForTask: (taskId: string): Array<Record<string, unknown>> =>
+        mockDb.taskSessions.get(taskId) ?? [],
+    },
+    taskStore: {
+      getTasksForAgent: (agentId: string): Array<Record<string, unknown>> =>
+        mockDb.agentTasks.get(agentId) ?? [],
+      deleteTask: (id: string): void => {
+        mockDb.deletedTaskIds.push(id);
+      },
+      getRootTaskForAgent: (agentId: string): Record<string, unknown> | undefined =>
+        mockDb.agentRootTasks.get(agentId),
+    },
+    scheduleStore: {
+      getSchedule: (id: string): Record<string, unknown> | undefined => mockDb.schedules.get(id),
+      getHeartbeatForTask: (taskId: string): Record<string, unknown> | undefined => {
         for (const s of mockDb.schedules.values()) {
           if ((s as { taskId: string | null }).taskId === taskId) {
-            throw new Error("UNIQUE constraint failed: schedules.task_id");
+            return s;
           }
         }
-      }
-      mockDb.schedules.set(id, {
-        id,
-        title,
-        description,
-        scheduleExpression,
-        personaId,
-        workspaceId,
-        parentTaskId,
-        enabled: true,
-        lastRunAt: null,
-        nextRunAt,
-        runCount: 0,
-        taskId,
-        createdAt: "2024-01-01",
-        updatedAt: "2024-01-01",
-      });
-    },
-    updateSchedule: (
-      id: string,
-      fields: {
-        scheduleExpression?: string;
-        description?: string;
-        enabled?: boolean;
-        nextRunAt?: string | null;
+        return undefined;
       },
-    ): void => {
-      const existing = mockDb.schedules.get(id);
-      if (!existing) return;
-      mockDb.schedules.set(id, {
-        ...existing,
-        ...(fields.scheduleExpression !== undefined
-          ? { scheduleExpression: fields.scheduleExpression }
-          : {}),
-        ...(fields.description !== undefined ? { description: fields.description } : {}),
-        ...(fields.enabled !== undefined ? { enabled: fields.enabled } : {}),
-        ...(fields.nextRunAt !== undefined ? { nextRunAt: fields.nextRunAt } : {}),
-      });
+      createSchedule: (
+        id: string,
+        title: string,
+        description: string,
+        scheduleExpression: string,
+        personaId: string,
+        workspaceId: string,
+        parentTaskId: string,
+        nextRunAt: string | null,
+        taskId: string | null = null,
+      ): void => {
+        // Mirror partial-unique behavior of the real DB.
+        if (taskId !== null) {
+          for (const s of mockDb.schedules.values()) {
+            if ((s as { taskId: string | null }).taskId === taskId) {
+              throw new Error("UNIQUE constraint failed: schedules.task_id");
+            }
+          }
+        }
+        mockDb.schedules.set(id, {
+          id,
+          title,
+          description,
+          scheduleExpression,
+          personaId,
+          workspaceId,
+          parentTaskId,
+          enabled: true,
+          lastRunAt: null,
+          nextRunAt,
+          runCount: 0,
+          taskId,
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+        });
+      },
+      updateSchedule: (
+        id: string,
+        fields: {
+          scheduleExpression?: string;
+          description?: string;
+          enabled?: boolean;
+          nextRunAt?: string | null;
+        },
+      ): void => {
+        const existing = mockDb.schedules.get(id);
+        if (!existing) return;
+        mockDb.schedules.set(id, {
+          ...existing,
+          ...(fields.scheduleExpression !== undefined
+            ? { scheduleExpression: fields.scheduleExpression }
+            : {}),
+          ...(fields.description !== undefined ? { description: fields.description } : {}),
+          ...(fields.enabled !== undefined ? { enabled: fields.enabled } : {}),
+          ...(fields.nextRunAt !== undefined ? { nextRunAt: fields.nextRunAt } : {}),
+        });
+      },
+      deleteSchedule: (id: string): void => {
+        mockDb.schedules.delete(id);
+      },
     },
-    deleteSchedule: (id: string): void => {
-      mockDb.schedules.delete(id);
-    },
-  },
-  slugify: (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-}));
+  };
+  return {
+    ...stores,
+    slugify: (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    getDatabaseStores: () => stores,
+  };
+});
 
 // killSessionAndCleanup is imported from grpc-shared. Mock the module to
 // record calls without pulling in the real streamHub / lifecycle plumbing.

--- a/packages/plugin-core/src/agent-handlers.ts
+++ b/packages/plugin-core/src/agent-handlers.ts
@@ -11,7 +11,8 @@
 
 import { create } from "@bufbuild/protobuf";
 import { grackle, ConflictError, ValidationError, PreconditionError } from "@grackle-ai/common";
-import { agentStore, scheduleStore, sessionStore, taskStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
+import type { ScheduleRow, ScheduleUpdate } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { slugify } from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
@@ -29,7 +30,8 @@ import {
  * Resolve the heartbeat schedule for an agent (#1438). Returns undefined when
  * the agent has no root task or no schedule attached to it.
  */
-function getHeartbeatForAgent(agentId: string): scheduleStore.ScheduleRow | undefined {
+function getHeartbeatForAgent(agentId: string): ScheduleRow | undefined {
+  const { taskStore, scheduleStore } = getDatabaseStores();
   const root = taskStore.getRootTaskForAgent(agentId);
   if (!root) {
     return undefined;
@@ -39,6 +41,7 @@ function getHeartbeatForAgent(agentId: string): scheduleStore.ScheduleRow | unde
 
 /** List all agents. Each agent's `heartbeat` field is populated when set (#1438). */
 export async function listAgents(): Promise<grackle.AgentList> {
+  const { agentStore } = getDatabaseStores();
   const rows = agentStore.listAgents();
   return create(grackle.AgentListSchema, {
     agents: rows.map((row) => agentRowToProto(row, getHeartbeatForAgent(row.id))),
@@ -47,6 +50,7 @@ export async function listAgents(): Promise<grackle.AgentList> {
 
 /** Create a new agent. */
 export async function createAgent(req: grackle.CreateAgentRequest): Promise<grackle.Agent> {
+  const { agentStore } = getDatabaseStores();
   const name = requireTrimmed(req.name, "Agent name");
   if (agentStore.getAgentByName(name)) {
     throw new ConflictError(`Agent with name "${name}" already exists`);
@@ -80,6 +84,7 @@ export async function getAgent(req: grackle.AgentId): Promise<grackle.Agent> {
 
 /** Update an existing agent. Optional fields left unset preserve the stored value. */
 export async function updateAgent(req: grackle.UpdateAgentRequest): Promise<grackle.Agent> {
+  const { agentStore } = getDatabaseStores();
   const existing = requireAgent(req.id);
 
   if (
@@ -139,6 +144,7 @@ export async function updateAgent(req: grackle.UpdateAgentRequest): Promise<grac
  * `ON DELETE CASCADE` (project convention; see `db.ts` migration comments).
  */
 export async function deleteAgent(req: grackle.AgentId): Promise<grackle.Empty> {
+  const { agentStore, taskStore, sessionStore } = getDatabaseStores();
   const agentTasks = taskStore.getTasksForAgent(req.id);
   for (const task of agentTasks) {
     for (const session of sessionStore.listSessionsForTask(task.id)) {
@@ -169,6 +175,7 @@ export async function deleteAgent(req: grackle.AgentId): Promise<grackle.Empty> 
 export async function setAgentHeartbeat(
   req: grackle.SetAgentHeartbeatRequest,
 ): Promise<grackle.Schedule> {
+  const { agentStore, taskStore, scheduleStore } = getDatabaseStores();
   const agent = requireAgent(req.agentId);
   const rootTask = taskStore.getRootTaskForAgent(req.agentId);
   if (!rootTask) {
@@ -208,7 +215,7 @@ export async function setAgentHeartbeat(
   //   - cadence change on an enabled row recomputes nextRunAt
   // Otherwise leave nextRunAt alone (advanceSchedule keeps it current).
   if (existing) {
-    const updates: scheduleStore.ScheduleUpdate = {};
+    const updates: ScheduleUpdate = {};
     if (req.cadence !== undefined) {
       updates.scheduleExpression = req.cadence;
     }

--- a/packages/plugin-core/src/channel-handlers.ts
+++ b/packages/plugin-core/src/channel-handlers.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, ValidationError } from "@grackle-ai/common";
-import { channelGrantStore, sessionStore, type ChannelGrantRow } from "@grackle-ai/database";
+import { getDatabaseStores, type ChannelGrantRow } from "@grackle-ai/database";
 import { createChannelToken, verifyChannelToken } from "@grackle-ai/auth";
 import { ulid } from "ulid";
 import { getChannelConfig } from "./channel-config.js";
@@ -34,6 +34,7 @@ function grantRowToProto(row: ChannelGrantRow): grackle.ChannelGrant {
 export async function exposeChannel(
   req: grackle.ExposeChannelRequest,
 ): Promise<grackle.ExposeChannelResponse> {
+  const { channelGrantStore } = getDatabaseStores();
   if (req.target.case !== "sessionId" || !req.target.value) {
     throw new ValidationError("sessionId target is required");
   }
@@ -72,6 +73,7 @@ export async function exposeChannel(
 export async function listChannelGrants(
   _req: grackle.ListChannelGrantsRequest,
 ): Promise<grackle.ChannelGrantList> {
+  const { channelGrantStore } = getDatabaseStores();
   const rows = channelGrantStore.listGrants();
   return create(grackle.ChannelGrantListSchema, { grants: rows.map(grantRowToProto) });
 }
@@ -80,6 +82,7 @@ export async function listChannelGrants(
 export async function revokeChannelGrant(
   req: grackle.RevokeChannelGrantRequest,
 ): Promise<grackle.Empty> {
+  const { channelGrantStore } = getDatabaseStores();
   requireChannelGrant(req.grantId);
   channelGrantStore.revokeGrant(req.grantId);
   return create(grackle.EmptySchema, {});

--- a/packages/plugin-core/src/channel-ingest.test.ts
+++ b/packages/plugin-core/src/channel-ingest.test.ts
@@ -4,7 +4,10 @@ import { grackle, NotFoundError, PreconditionError } from "@grackle-ai/common";
 
 // ── Mock the leaf dependencies so we can drive every branch ──────────────────
 vi.mock("@grackle-ai/auth", () => ({ verifyChannelToken: vi.fn() }));
-vi.mock("@grackle-ai/database", () => ({ channelGrantStore: { getGrant: vi.fn() } }));
+vi.mock("@grackle-ai/database", () => {
+  const stores = { channelGrantStore: { getGrant: vi.fn() } };
+  return { ...stores, getDatabaseStores: () => stores };
+});
 vi.mock("./channel-config.js", () => ({
   getChannelConfig: vi.fn(() => ({
     signingSecret: "secret",

--- a/packages/plugin-core/src/channel-ingest.ts
+++ b/packages/plugin-core/src/channel-ingest.ts
@@ -10,7 +10,7 @@
 import { createHash } from "node:crypto";
 import { create } from "@bufbuild/protobuf";
 import { grackle, GrackleError, Code } from "@grackle-ai/common";
-import { channelGrantStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { verifyChannelToken } from "@grackle-ai/auth";
 import { getChannelConfig } from "./channel-config.js";
 import { sendInput } from "./session-handlers.js";
@@ -71,6 +71,7 @@ function alreadySeen(key: string): boolean {
  * @returns An {@link IngestResult} the web server maps to an HTTP status.
  */
 export async function ingestChannelMessage(token: string, body: IngestBody): Promise<IngestResult> {
+  const { channelGrantStore } = getDatabaseStores();
   const { signingSecret } = getChannelConfig();
 
   const claims = verifyChannelToken(token, signingSecret);

--- a/packages/plugin-core/src/codespace-handlers.ts
+++ b/packages/plugin-core/src/codespace-handlers.ts
@@ -1,7 +1,7 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, UnavailableError } from "@grackle-ai/common";
 import { exec } from "@grackle-ai/core";
-import { githubAccountStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { formatGhError } from "./utils/format-gh-error.js";
 import { logger } from "@grackle-ai/core";
 import { requireTrimmed } from "./require-helpers.js";
@@ -19,6 +19,7 @@ const GH_CODESPACE_LIST_LIMIT: number = 50;
 export async function listCodespaces(
   req: grackle.ListCodespacesRequest,
 ): Promise<grackle.CodespaceList> {
+  const { githubAccountStore } = getDatabaseStores();
   const ghToken = githubAccountStore.resolveStoredGitHubToken(req.githubAccountId || undefined);
   const execEnv: NodeJS.ProcessEnv | undefined = ghToken
     ? { ...process.env, GH_TOKEN: ghToken }

--- a/packages/plugin-core/src/component-handlers.ts
+++ b/packages/plugin-core/src/component-handlers.ts
@@ -8,7 +8,8 @@ import {
   NotFoundError,
   ValidationError,
 } from "@grackle-ai/common";
-import { componentStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
+import type { ComponentRow } from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
 import { v4 as uuid } from "uuid";
 import { componentRowToProto } from "./grpc-proto-converters.js";
@@ -23,6 +24,7 @@ function asInvalidArgument(err: unknown): never {
 export async function registerComponent(
   req: grackle.RegisterComponentRequest,
 ): Promise<grackle.Component> {
+  const { componentStore } = getDatabaseStores();
   requireWorkspace(req.workspaceId);
   requireField(req.name, "name");
   requireField(req.body, "body");
@@ -52,6 +54,7 @@ export async function registerComponent(
 export async function updateComponent(
   req: grackle.UpdateComponentRequest,
 ): Promise<grackle.Component> {
+  const { componentStore } = getDatabaseStores();
   requireField(req.id, "id");
   const existing = componentStore.getComponent(req.id);
   // Workspace isolation: treat a component in another workspace as not found.
@@ -79,7 +82,8 @@ export async function updateComponent(
 
 /** Resolve a component by id (precedence) or by name within a workspace. */
 export async function getComponent(req: grackle.GetComponentRequest): Promise<grackle.Component> {
-  let row: componentStore.ComponentRow | undefined;
+  const { componentStore } = getDatabaseStores();
+  let row: ComponentRow | undefined;
   if (req.id) {
     row = componentStore.getComponent(req.id);
     // Workspace isolation: hide components that belong to another workspace.
@@ -108,6 +112,7 @@ export async function getComponent(req: grackle.GetComponentRequest): Promise<gr
 export async function listComponents(
   req: grackle.ListComponentsRequest,
 ): Promise<grackle.ComponentList> {
+  const { componentStore } = getDatabaseStores();
   requireWorkspace(req.workspaceId);
   return create(grackle.ComponentListSchema, {
     components: componentStore.listComponents(req.workspaceId).map(componentRowToProto),
@@ -148,6 +153,7 @@ interface SearchableComponent {
 export async function searchComponents(
   req: grackle.SearchComponentsRequest,
 ): Promise<grackle.SearchComponentsResponse> {
+  const { componentStore } = getDatabaseStores();
   const query = requireTrimmed(req.query, "query");
   const limit = req.limit > 0 ? req.limit : DEFAULT_COMPONENT_SEARCH_LIMIT;
 
@@ -203,8 +209,9 @@ export async function searchComponents(
 export async function setComponentPromotion(
   req: grackle.SetComponentPromotionRequest,
 ): Promise<grackle.Component> {
+  const { componentStore } = getDatabaseStores();
   requireWorkspace(req.workspaceId);
-  let row: componentStore.ComponentRow | undefined;
+  let row: ComponentRow | undefined;
   if (req.id) {
     row = componentStore.getComponent(req.id);
     // Workspace isolation: a component in another workspace is not found.
@@ -256,9 +263,10 @@ const BUILTIN_COMPONENT_NAMES: ReadonlySet<string> = new Set(BUILTIN_COMPONENTS.
 export async function resolveComponentGraph(
   req: grackle.ResolveComponentGraphRequest,
 ): Promise<grackle.ResolveComponentGraphResponse> {
+  const { componentStore } = getDatabaseStores();
   requireWorkspace(req.workspaceId);
 
-  let root: componentStore.ComponentRow | undefined;
+  let root: ComponentRow | undefined;
   let rootBody: string;
   if (req.source) {
     rootBody = req.source;
@@ -282,7 +290,7 @@ export async function resolveComponentGraph(
     rootBody = ""; // unreachable — requireOneOf throws
   }
 
-  const ordered: componentStore.ComponentRow[] = [];
+  const ordered: ComponentRow[] = [];
   const visited = new Set<string>(); // component ids already resolved (cycle-safe + dedupe)
   let totalBytes = 0;
 

--- a/packages/plugin-core/src/environment-handlers.ts
+++ b/packages/plugin-core/src/environment-handlers.ts
@@ -1,13 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, ValidationError, PreconditionError } from "@grackle-ai/common";
-import {
-  envRegistry,
-  workspaceStore,
-  workspaceEnvironmentLinkStore,
-  sessionStore,
-  sqlite,
-  agentStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores, sqlite } from "@grackle-ai/database";
 import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
 import { adapterManager } from "@grackle-ai/core";
 import { parseAdapterConfig } from "@grackle-ai/core";
@@ -22,6 +15,7 @@ import { requireEnvironment, requireField, requireNonEmpty } from "./require-hel
 
 /** List all registered environments. */
 export async function listEnvironments(): Promise<grackle.EnvironmentList> {
+  const { envRegistry } = getDatabaseStores();
   const rows = envRegistry.listEnvironments();
   return create(grackle.EnvironmentListSchema, {
     environments: rows.map(envRowToProto),
@@ -32,6 +26,7 @@ export async function listEnvironments(): Promise<grackle.EnvironmentList> {
 export async function addEnvironment(
   req: grackle.AddEnvironmentRequest,
 ): Promise<grackle.Environment> {
+  const { envRegistry } = getDatabaseStores();
   requireField(req.displayName, "displayName");
   requireField(req.adapterType, "adapterType");
   const id = req.displayName.toLowerCase().replace(/[^a-z0-9-]/g, "-");
@@ -52,6 +47,7 @@ export async function addEnvironment(
 export async function updateEnvironment(
   req: grackle.UpdateEnvironmentRequest,
 ): Promise<grackle.Environment> {
+  const { envRegistry } = getDatabaseStores();
   const existing = requireEnvironment(req.id);
   const displayName = req.displayName !== undefined ? req.displayName : undefined;
   if (displayName !== undefined) {
@@ -89,6 +85,8 @@ export async function updateEnvironment(
 
 /** Remove an environment after disconnecting it and cleaning up references. */
 export async function removeEnvironment(req: grackle.EnvironmentId): Promise<grackle.Empty> {
+  const { workspaceStore, agentStore, workspaceEnvironmentLinkStore, sessionStore, envRegistry } =
+    getDatabaseStores();
   // Block deletion if workspaces still reference this environment as primary
   const wsCount = workspaceStore.countWorkspacesByEnvironment(req.id);
   if (wsCount > 0) {
@@ -153,6 +151,7 @@ export async function removeEnvironment(req: grackle.EnvironmentId): Promise<gra
 export async function* provisionEnvironment(
   req: grackle.ProvisionEnvironmentRequest,
 ): AsyncGenerator<grackle.ProvisionEvent> {
+  const { sessionStore, envRegistry } = getDatabaseStores();
   // Manual provision overrides auto-reconnect
   clearReconnectState(req.id);
   const env = envRegistry.getEnvironment(req.id);
@@ -268,6 +267,7 @@ export async function* provisionEnvironment(
 
 /** Stop (disconnect) an environment. */
 export async function stopEnvironment(req: grackle.EnvironmentId): Promise<grackle.Empty> {
+  const { sessionStore, envRegistry } = getDatabaseStores();
   const env = requireEnvironment(req.id);
 
   // Suspend active sessions before tearing down the adapter. Stop is a
@@ -291,6 +291,7 @@ export async function stopEnvironment(req: grackle.EnvironmentId): Promise<grack
 
 /** Destroy an environment and its underlying resources. */
 export async function destroyEnvironment(req: grackle.EnvironmentId): Promise<grackle.Empty> {
+  const { sessionStore, envRegistry } = getDatabaseStores();
   const env = requireEnvironment(req.id);
 
   // Kill active sessions BEFORE tearing down the adapter so the kill signal

--- a/packages/plugin-core/src/escalation-handlers.ts
+++ b/packages/plugin-core/src/escalation-handlers.ts
@@ -1,7 +1,7 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle, serverTimestamp } from "@grackle-ai/common";
-import { escalationStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { ulid } from "ulid";
 import { routeEscalation, toEscalationModel } from "@grackle-ai/core";
 import { escalationRowToProto } from "./grpc-proto-converters.js";
@@ -14,6 +14,7 @@ const VALID_URGENCY: ReadonlySet<string> = new Set(["low", "normal", "high"]);
 export async function createEscalation(
   req: grackle.CreateEscalationRequest,
 ): Promise<grackle.Escalation> {
+  const { escalationStore } = getDatabaseStores();
   requireField(req.message, "message");
   const urgency = VALID_URGENCY.has(req.urgency) ? req.urgency : "normal";
   const id = ulid();
@@ -59,6 +60,7 @@ export async function createEscalation(
 export async function listEscalations(
   req: grackle.ListEscalationsRequest,
 ): Promise<grackle.EscalationList> {
+  const { escalationStore } = getDatabaseStores();
   const rows = escalationStore.listEscalations(
     req.workspaceId || undefined,
     req.status || undefined,
@@ -73,6 +75,7 @@ export async function listEscalations(
 export async function acknowledgeEscalation(
   req: grackle.AcknowledgeEscalationRequest,
 ): Promise<grackle.Escalation> {
+  const { escalationStore } = getDatabaseStores();
   const row = requireEscalation(req.id);
   escalationStore.updateEscalationStatus(req.id, "acknowledged");
   const updated = escalationStore.getEscalation(req.id);

--- a/packages/plugin-core/src/event-handlers.test.ts
+++ b/packages/plugin-core/src/event-handlers.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
 
-vi.mock("@grackle-ai/database", () => ({
-  queryDomainEvents: vi.fn(() => []),
-  queryStreamMessages: vi.fn(() => []),
-  querySessionActions: vi.fn(() => []),
-}));
+vi.mock("@grackle-ai/database", () => {
+  const queryDomainEvents = vi.fn(() => []);
+  const queryStreamMessages = vi.fn(() => []);
+  const querySessionActions = vi.fn(() => []);
+  return {
+    queryDomainEvents,
+    queryStreamMessages,
+    querySessionActions,
+    getDatabaseStores: () => ({
+      eventStore: { queryDomainEvents },
+      streamMessageStore: { queryStreamMessages },
+      sessionActionStore: { querySessionActions },
+    }),
+  };
+});
 
 import {
   queryDomainEvents as storeQuery,

--- a/packages/plugin-core/src/event-handlers.ts
+++ b/packages/plugin-core/src/event-handlers.ts
@@ -1,12 +1,10 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import {
-  queryDomainEvents as queryDomainEventsStore,
-  type DomainEventQuery,
-  queryStreamMessages as queryStreamMessagesStore,
-  type StreamMessageQuery,
-  querySessionActions as querySessionActionsStore,
-  type SessionActionQuery,
+import { getDatabaseStores } from "@grackle-ai/database";
+import type {
+  DomainEventQuery,
+  StreamMessageQuery,
+  SessionActionQuery,
 } from "@grackle-ai/database";
 
 /** Map a `domain_events` row to the proto {@link grackle.DomainEvent} message. */
@@ -35,6 +33,7 @@ function rowToProto(row: {
 export async function queryDomainEvents(
   req: grackle.QueryDomainEventsRequest,
 ): Promise<grackle.DomainEventList> {
+  const { eventStore } = getDatabaseStores();
   const query: DomainEventQuery = {};
   if (req.beforeId) {
     query.beforeId = req.beforeId;
@@ -52,7 +51,7 @@ export async function queryDomainEvents(
     query.limit = req.limit;
   }
 
-  const rows = queryDomainEventsStore(query);
+  const rows = eventStore.queryDomainEvents(query);
   return create(grackle.DomainEventListSchema, { events: rows.map(rowToProto) });
 }
 
@@ -83,6 +82,7 @@ function streamRowToProto(row: {
 export async function getStreamTranscript(
   req: grackle.GetStreamTranscriptRequest,
 ): Promise<grackle.StreamTranscript> {
+  const { streamMessageStore } = getDatabaseStores();
   const query: StreamMessageQuery = { streamId: req.streamId };
   if (req.beforeSeq) {
     query.beforeSeq = req.beforeSeq;
@@ -91,7 +91,7 @@ export async function getStreamTranscript(
     query.limit = req.limit;
   }
 
-  const rows = queryStreamMessagesStore(query);
+  const rows = streamMessageStore.queryStreamMessages(query);
   return create(grackle.StreamTranscriptSchema, { messages: rows.map(streamRowToProto) });
 }
 
@@ -125,6 +125,7 @@ function sessionActionRowToProto(row: {
 export async function getSessionActions(
   req: grackle.GetSessionActionsRequest,
 ): Promise<grackle.SessionActionList> {
+  const { sessionActionStore } = getDatabaseStores();
   const query: SessionActionQuery = { sessionId: req.sessionId };
   if (req.fromSeq) {
     query.fromSeq = req.fromSeq;
@@ -133,6 +134,6 @@ export async function getSessionActions(
     query.limit = req.limit;
   }
 
-  const rows = querySessionActionsStore(query);
+  const rows = sessionActionStore.querySessionActions(query);
   return create(grackle.SessionActionListSchema, { actions: rows.map(sessionActionRowToProto) });
 }

--- a/packages/plugin-core/src/github-account-handlers.ts
+++ b/packages/plugin-core/src/github-account-handlers.ts
@@ -7,7 +7,8 @@
  */
 import { create } from "@bufbuild/protobuf";
 import { grackle, ConflictError, PreconditionError } from "@grackle-ai/common";
-import { githubAccountStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
+import type { GitHubAccountInfo, UpdateGitHubAccountFields } from "@grackle-ai/database";
 import { exec } from "@grackle-ai/core";
 import { emit } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
@@ -34,7 +35,7 @@ async function resolveGitHubUsername(token: string): Promise<string> {
 }
 
 /** Convert a GitHubAccountInfo record to its proto representation. */
-function accountToProto(info: githubAccountStore.GitHubAccountInfo): grackle.GitHubAccount {
+function accountToProto(info: GitHubAccountInfo): grackle.GitHubAccount {
   return create(grackle.GitHubAccountSchema, {
     id: info.id,
     label: info.label,
@@ -46,6 +47,7 @@ function accountToProto(info: githubAccountStore.GitHubAccountInfo): grackle.Git
 
 /** List all registered GitHub accounts (tokens are never returned). */
 export async function listGitHubAccounts(): Promise<grackle.GitHubAccountList> {
+  const { githubAccountStore } = getDatabaseStores();
   const accounts = githubAccountStore.listGitHubAccounts();
   return create(grackle.GitHubAccountListSchema, {
     accounts: accounts.map(accountToProto),
@@ -56,6 +58,7 @@ export async function listGitHubAccounts(): Promise<grackle.GitHubAccountList> {
 export async function addGitHubAccount(
   req: grackle.AddGitHubAccountRequest,
 ): Promise<grackle.GitHubAccount> {
+  const { githubAccountStore } = getDatabaseStores();
   requireTrimmed(req.label, "label");
   const token = requireTrimmed(req.token, "token");
   let { username } = req;
@@ -88,9 +91,10 @@ export async function addGitHubAccount(
 export async function updateGitHubAccount(
   req: grackle.UpdateGitHubAccountRequest,
 ): Promise<grackle.GitHubAccount> {
+  const { githubAccountStore } = getDatabaseStores();
   const existing = requireGitHubAccount(req.id);
 
-  const fields: githubAccountStore.UpdateGitHubAccountFields = {};
+  const fields: UpdateGitHubAccountFields = {};
   if (req.label !== undefined) {
     fields.label = requireNonEmpty(req.label, "label");
   }
@@ -116,6 +120,7 @@ export async function updateGitHubAccount(
 export async function removeGitHubAccount(
   req: grackle.RemoveGitHubAccountRequest,
 ): Promise<grackle.Empty> {
+  const { githubAccountStore } = getDatabaseStores();
   const existing = requireGitHubAccount(req.id);
 
   githubAccountStore.removeGitHubAccount(req.id);

--- a/packages/plugin-core/src/grpc-get-session.test.ts
+++ b/packages/plugin-core/src/grpc-get-session.test.ts
@@ -9,7 +9,9 @@ import { ConnectError, Code } from "@connectrpc/connect";
 
 vi.mock("@grackle-ai/database", async () => {
   const { createDatabaseMock } = await import("@grackle-ai/test-utils");
-  return createDatabaseMock();
+  const mock = createDatabaseMock();
+  mock.wire();
+  return mock;
 });
 
 vi.mock("@grackle-ai/core", async (importOriginal) => {

--- a/packages/plugin-core/src/grpc-list-tasks.test.ts
+++ b/packages/plugin-core/src/grpc-list-tasks.test.ts
@@ -10,8 +10,7 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@grackle-ai/database")>();
   actual.openDatabase(":memory:");
   actual.initDatabase();
-  return {
-    ...actual,
+  const overrides = {
     tokenStore: {
       listTokens: vi.fn(() => []),
       setToken: vi.fn(),
@@ -46,6 +45,38 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
       updatePersona: vi.fn(),
       deletePersona: vi.fn(),
     },
+  };
+  actual.setDatabaseStores({
+    sessionStore: overrides.sessionStore,
+    taskStore: actual.taskStore,
+    envRegistry: overrides.envRegistry,
+    workspaceStore: actual.workspaceStore,
+    personaStore: overrides.personaStore,
+    agentStore: actual.agentStore,
+    componentStore: actual.componentStore,
+    settingsStore: actual.settingsStore,
+    tokenStore: overrides.tokenStore,
+    credentialProviders: actual.credentialProviders,
+    scheduleStore: actual.scheduleStore,
+    escalationStore: actual.escalationStore,
+    workspaceEnvironmentLinkStore: actual.workspaceEnvironmentLinkStore,
+    dispatchQueueStore: actual.dispatchQueueStore,
+    pluginStore: actual.pluginStore,
+    githubAccountStore: actual.githubAccountStore,
+    channelGrantStore: actual.channelGrantStore,
+    eventStore: { persistEvent: actual.persistEvent, queryDomainEvents: actual.queryDomainEvents },
+    streamMessageStore: {
+      persistStreamMessage: actual.persistStreamMessage,
+      queryStreamMessages: actual.queryStreamMessages,
+    },
+    sessionActionStore: {
+      persistSessionAction: actual.persistSessionAction,
+      querySessionActions: actual.querySessionActions,
+    },
+  });
+  return {
+    ...actual,
+    ...overrides,
   };
 });
 

--- a/packages/plugin-core/src/grpc-proto-converters.ts
+++ b/packages/plugin-core/src/grpc-proto-converters.ts
@@ -3,16 +3,15 @@ import { grackle, scheduleRowToProto } from "@grackle-ai/common";
 import { workspaceStatusToEnum, taskStatusToEnum } from "@grackle-ai/common";
 import type { EnvironmentRow, SessionRow } from "@grackle-ai/database";
 import type { SessionModel } from "@grackle-ai/core";
-import {
-  workspaceStore,
-  taskStore,
-  personaStore,
-  agentStore,
-  componentStore,
-  escalationStore,
-  scheduleStore,
-  workspaceEnvironmentLinkStore,
-  safeParseJsonArray,
+import { getDatabaseStores, safeParseJsonArray } from "@grackle-ai/database";
+import type {
+  WorkspaceRow,
+  TaskRow,
+  ComponentRow,
+  EscalationRow,
+  AgentRow,
+  ScheduleRow,
+  PersonaRow,
 } from "@grackle-ai/database";
 
 /** Convert an environment database row to its proto representation. */
@@ -63,9 +62,10 @@ export function sessionRowToProto(row: SessionRow | SessionModel): grackle.Sessi
  * linkedEnvMap to avoid N+1 queries. When omitted, falls back to a per-row query.
  */
 export function workspaceRowToProto(
-  row: workspaceStore.WorkspaceRow,
+  row: WorkspaceRow,
   linkedEnvMap?: Map<string, string[]>,
 ): grackle.Workspace {
+  const { workspaceEnvironmentLinkStore } = getDatabaseStores();
   const linkedIds = linkedEnvMap
     ? (linkedEnvMap.get(row.id) ?? [])
     : workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(row.id);
@@ -88,11 +88,12 @@ export function workspaceRowToProto(
 
 /** Convert a task database row to its proto representation. */
 export function taskRowToProto(
-  row: taskStore.TaskRow,
+  row: TaskRow,
   childIds?: string[],
   computedStatus?: string,
   latestSessionId?: string,
 ): grackle.Task {
+  const { taskStore } = getDatabaseStores();
   return create(grackle.TaskSchema, {
     id: row.id,
     workspaceId: row.workspaceId ?? undefined,
@@ -123,12 +124,12 @@ export function taskRowToProto(
 }
 
 /** Convert a component database row to its proto representation. */
-export function componentRowToProto(row: componentStore.ComponentRow): grackle.Component {
+export function componentRowToProto(row: ComponentRow): grackle.Component {
   return create(grackle.ComponentSchema, { ...row });
 }
 
 /** Convert an escalation database row to its proto representation. */
-export function escalationRowToProto(row: escalationStore.EscalationRow): grackle.Escalation {
+export function escalationRowToProto(row: EscalationRow): grackle.Escalation {
   return create(grackle.EscalationSchema, {
     id: row.id,
     workspaceId: row.workspaceId,
@@ -164,10 +165,7 @@ export function safeParseJson<T>(value: string | undefined, fallback: T): T {
  * for resolving the agent's root task and looking up the schedule. Pass it
  * via the second arg to embed it on the returned proto.
  */
-export function agentRowToProto(
-  row: agentStore.AgentRow,
-  heartbeat?: scheduleStore.ScheduleRow,
-): grackle.Agent {
+export function agentRowToProto(row: AgentRow, heartbeat?: ScheduleRow): grackle.Agent {
   return create(grackle.AgentSchema, {
     id: row.id,
     name: row.name,
@@ -181,7 +179,7 @@ export function agentRowToProto(
 }
 
 /** Convert a persona database row to a Persona proto message. */
-export function personaRowToProto(row: personaStore.PersonaRow): grackle.Persona {
+export function personaRowToProto(row: PersonaRow): grackle.Persona {
   const toolConfig = safeParseJson<{
     allowedTools?: string[];
     disallowedTools?: string[];

--- a/packages/plugin-core/src/grpc-proto-converters.ts
+++ b/packages/plugin-core/src/grpc-proto-converters.ts
@@ -65,10 +65,9 @@ export function workspaceRowToProto(
   row: WorkspaceRow,
   linkedEnvMap?: Map<string, string[]>,
 ): grackle.Workspace {
-  const { workspaceEnvironmentLinkStore } = getDatabaseStores();
   const linkedIds = linkedEnvMap
     ? (linkedEnvMap.get(row.id) ?? [])
-    : workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(row.id);
+    : getDatabaseStores().workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(row.id);
   return create(grackle.WorkspaceSchema, {
     id: row.id,
     name: row.name,
@@ -93,7 +92,6 @@ export function taskRowToProto(
   computedStatus?: string,
   latestSessionId?: string,
 ): grackle.Task {
-  const { taskStore } = getDatabaseStores();
   return create(grackle.TaskSchema, {
     id: row.id,
     workspaceId: row.workspaceId ?? undefined,
@@ -110,7 +108,11 @@ export function taskRowToProto(
     sortOrder: row.sortOrder,
     parentTaskId: row.parentTaskId,
     depth: row.depth,
-    childTaskIds: childIds ?? taskStore.getChildren(row.id).map((c) => c.id),
+    childTaskIds:
+      childIds ??
+      getDatabaseStores()
+        .taskStore.getChildren(row.id)
+        .map((c) => c.id),
     canDecompose: row.canDecompose,
     injectKnowledge: row.injectKnowledge,
     defaultPersonaId: row.defaultPersonaId,

--- a/packages/plugin-core/src/grpc-resume.test.ts
+++ b/packages/plugin-core/src/grpc-resume.test.ts
@@ -9,7 +9,9 @@ import { GrackleError, NotFoundError, PreconditionError, Code } from "@grackle-a
 
 vi.mock("@grackle-ai/database", async () => {
   const { createDatabaseMock } = await import("@grackle-ai/test-utils");
-  return createDatabaseMock();
+  const mock = createDatabaseMock();
+  mock.wire();
+  return mock;
 });
 
 vi.mock("@grackle-ai/core", async (importOriginal) => {

--- a/packages/plugin-core/src/grpc-search-tasks.test.ts
+++ b/packages/plugin-core/src/grpc-search-tasks.test.ts
@@ -11,8 +11,7 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@grackle-ai/database")>();
   actual.openDatabase(":memory:");
   actual.initDatabase();
-  return {
-    ...actual,
+  const overrides = {
     tokenStore: {
       listTokens: vi.fn(() => []),
       setToken: vi.fn(),
@@ -47,6 +46,38 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
       updatePersona: vi.fn(),
       deletePersona: vi.fn(),
     },
+  };
+  actual.setDatabaseStores({
+    sessionStore: overrides.sessionStore,
+    taskStore: actual.taskStore,
+    envRegistry: overrides.envRegistry,
+    workspaceStore: actual.workspaceStore,
+    personaStore: overrides.personaStore,
+    agentStore: actual.agentStore,
+    componentStore: actual.componentStore,
+    settingsStore: actual.settingsStore,
+    tokenStore: overrides.tokenStore,
+    credentialProviders: actual.credentialProviders,
+    scheduleStore: actual.scheduleStore,
+    escalationStore: actual.escalationStore,
+    workspaceEnvironmentLinkStore: actual.workspaceEnvironmentLinkStore,
+    dispatchQueueStore: actual.dispatchQueueStore,
+    pluginStore: actual.pluginStore,
+    githubAccountStore: actual.githubAccountStore,
+    channelGrantStore: actual.channelGrantStore,
+    eventStore: { persistEvent: actual.persistEvent, queryDomainEvents: actual.queryDomainEvents },
+    streamMessageStore: {
+      persistStreamMessage: actual.persistStreamMessage,
+      queryStreamMessages: actual.queryStreamMessages,
+    },
+    sessionActionStore: {
+      persistSessionAction: actual.persistSessionAction,
+      querySessionActions: actual.querySessionActions,
+    },
+  });
+  return {
+    ...actual,
+    ...overrides,
   };
 });
 

--- a/packages/plugin-core/src/grpc-send-input.test.ts
+++ b/packages/plugin-core/src/grpc-send-input.test.ts
@@ -10,7 +10,9 @@ import { ConnectError, Code } from "@connectrpc/connect";
 
 vi.mock("@grackle-ai/database", async () => {
   const { createDatabaseMock } = await import("@grackle-ai/test-utils");
-  return createDatabaseMock();
+  const mock = createDatabaseMock();
+  mock.wire();
+  return mock;
 });
 
 vi.mock("@grackle-ai/core", async (importOriginal) => {

--- a/packages/plugin-core/src/grpc-shared.ts
+++ b/packages/plugin-core/src/grpc-shared.ts
@@ -20,7 +20,7 @@ import {
 } from "@grackle-ai/common";
 import { transferAllPipeSubscriptions } from "./signals/orphan-reparent.js";
 import type { SessionRow } from "@grackle-ai/database";
-import { sessionStore, taskStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   adapterManager,
   streamHub,
@@ -49,6 +49,7 @@ export { toDialableHost, validatePipeInputs, resolveAncestorEnvironmentId, VALID
  * No-op if the session is already terminal or already suspended.
  */
 export function suspendSessionAndPublish(session: SessionRow): void {
+  const { sessionStore, taskStore } = getDatabaseStores();
   if (
     TERMINAL_SESSION_STATUSES.has(session.status as SessionStatus) ||
     session.status === SESSION_STATUS.SUSPENDED
@@ -81,6 +82,7 @@ export function suspendSessionAndPublish(session: SessionRow): void {
  * do not accumulate.
  */
 export function killSessionAndCleanup(session: SessionRow): void {
+  const { sessionStore, taskStore } = getDatabaseStores();
   if (!TERMINAL_SESSION_STATUSES.has(session.status as SessionStatus)) {
     sessionStore.updateSession(
       session.id,

--- a/packages/plugin-core/src/lifecycle-cleanup.test.ts
+++ b/packages/plugin-core/src/lifecycle-cleanup.test.ts
@@ -9,8 +9,10 @@ vi.mock("@grackle-ai/core", async (importOriginal) => {
 });
 
 import { openDatabase, initDatabase, sqlite as _sqlite, sessionStore } from "@grackle-ai/database";
+import { initRealDatabaseStores } from "@grackle-ai/test-utils/db";
 openDatabase(":memory:");
 initDatabase();
+initRealDatabaseStores();
 const sqlite = _sqlite!;
 import { streamRegistry } from "@grackle-ai/core";
 import { lifecycleCleanupPhase } from "./lifecycle-cleanup.js";

--- a/packages/plugin-core/src/lifecycle-cleanup.ts
+++ b/packages/plugin-core/src/lifecycle-cleanup.ts
@@ -8,7 +8,7 @@
  * @module
  */
 
-import { sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import type { ReconciliationPhase } from "@grackle-ai/core";
 import { streamRegistry } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
@@ -20,6 +20,7 @@ const LIFECYCLE_PREFIX: string = "lifecycle:";
 export const lifecycleCleanupPhase: ReconciliationPhase = {
   name: "lifecycle-cleanup",
   execute: async (): Promise<void> => {
+    const { sessionStore } = getDatabaseStores();
     let cleaned: number = 0;
     for (const stream of streamRegistry.listStreams()) {
       if (!stream.name.startsWith(LIFECYCLE_PREFIX)) {

--- a/packages/plugin-core/src/lifecycle.ts
+++ b/packages/plugin-core/src/lifecycle.ts
@@ -21,7 +21,7 @@ import {
   serverTimestamp,
 } from "@grackle-ai/common";
 import type { SessionStatus, EndReason } from "@grackle-ai/common";
-import { sessionStore, taskStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   streamRegistry,
   adapterManager,
@@ -49,6 +49,7 @@ export { cleanupLifecycleStream, ensureLifecycleStream };
  */
 export function createLifecycleSubscriber(ctx: PluginContext): Disposable {
   const unsubOrphan = streamRegistry.onSessionOrphaned((sessionId: string) => {
+    const { sessionStore, taskStore } = getDatabaseStores();
     const session = sessionStore.getSession(sessionId);
     if (!session) {
       return;
@@ -126,6 +127,7 @@ export function createLifecycleSubscriber(ctx: PluginContext): Disposable {
   // "open() IS reanimate" model from the streams IPC spec.
   const unsubRevived = streamRegistry.onSessionRevived(
     (targetSessionId: string, _subscriberSessionId: string) => {
+      const { sessionStore } = getDatabaseStores();
       const session = sessionStore.getSession(targetSessionId);
       if (!session) {
         return;

--- a/packages/plugin-core/src/operator-stream-handlers.ts
+++ b/packages/plugin-core/src/operator-stream-handlers.ts
@@ -14,7 +14,7 @@ import {
   NotFoundError,
   PreconditionError,
 } from "@grackle-ai/common";
-import { sessionStore, taskStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   streamRegistry,
   pipeDelivery,
@@ -32,6 +32,7 @@ import { requireField, requireTask } from "./require-helpers.js";
  * task is unknown. Shared by the operator attach/detach/list handlers.
  */
 function resolveLiveSessionForTask(taskId: string): string {
+  const { sessionStore } = getDatabaseStores();
   requireTask(taskId);
   return getLatestLiveSessionId(sessionStore.listSessionsForTask(taskId));
 }

--- a/packages/plugin-core/src/operator-streams.test.ts
+++ b/packages/plugin-core/src/operator-streams.test.ts
@@ -14,10 +14,41 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@grackle-ai/database")>();
   actual.openDatabase(":memory:");
   actual.initDatabase();
-  return {
-    ...actual,
+  const overrides = {
     taskStore: { ...actual.taskStore, getTask: vi.fn() },
     sessionStore: { ...actual.sessionStore, listSessionsForTask: vi.fn(() => []) },
+  };
+  actual.setDatabaseStores({
+    sessionStore: overrides.sessionStore,
+    taskStore: overrides.taskStore,
+    envRegistry: actual.envRegistry,
+    workspaceStore: actual.workspaceStore,
+    personaStore: actual.personaStore,
+    agentStore: actual.agentStore,
+    componentStore: actual.componentStore,
+    settingsStore: actual.settingsStore,
+    tokenStore: actual.tokenStore,
+    credentialProviders: actual.credentialProviders,
+    scheduleStore: actual.scheduleStore,
+    escalationStore: actual.escalationStore,
+    workspaceEnvironmentLinkStore: actual.workspaceEnvironmentLinkStore,
+    dispatchQueueStore: actual.dispatchQueueStore,
+    pluginStore: actual.pluginStore,
+    githubAccountStore: actual.githubAccountStore,
+    channelGrantStore: actual.channelGrantStore,
+    eventStore: { persistEvent: actual.persistEvent, queryDomainEvents: actual.queryDomainEvents },
+    streamMessageStore: {
+      persistStreamMessage: actual.persistStreamMessage,
+      queryStreamMessages: actual.queryStreamMessages,
+    },
+    sessionActionStore: {
+      persistSessionAction: actual.persistSessionAction,
+      querySessionActions: actual.querySessionActions,
+    },
+  });
+  return {
+    ...actual,
+    ...overrides,
   };
 });
 

--- a/packages/plugin-core/src/persona-handlers.ts
+++ b/packages/plugin-core/src/persona-handlers.ts
@@ -1,7 +1,7 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, ConflictError, ValidationError } from "@grackle-ai/common";
 import { ALL_MCP_TOOL_NAMES } from "@grackle-ai/common";
-import { personaStore, settingsStore, envRegistry } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { slugify } from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
@@ -10,6 +10,7 @@ import { requireField, requirePersona } from "./require-helpers.js";
 
 /** List all personas. */
 export async function listPersonas(): Promise<grackle.PersonaList> {
+  const { personaStore } = getDatabaseStores();
   const rows = personaStore.listPersonas();
   return create(grackle.PersonaListSchema, {
     personas: rows.map(personaRowToProto),
@@ -18,6 +19,7 @@ export async function listPersonas(): Promise<grackle.PersonaList> {
 
 /** Create a new persona. */
 export async function createPersona(req: grackle.CreatePersonaRequest): Promise<grackle.Persona> {
+  const { personaStore } = getDatabaseStores();
   requireField(req.name, "name");
   const personaType = req.type || "agent";
   if (personaType !== "agent" && personaType !== "script") {
@@ -90,6 +92,7 @@ export async function getPersona(req: grackle.PersonaId): Promise<grackle.Person
 
 /** Update an existing persona. */
 export async function updatePersona(req: grackle.UpdatePersonaRequest): Promise<grackle.Persona> {
+  const { personaStore, settingsStore, envRegistry } = getDatabaseStores();
   const existing = requirePersona(req.id);
 
   // Only update toolConfig/mcpServers if the request provides non-empty values;
@@ -183,6 +186,7 @@ export async function updatePersona(req: grackle.UpdatePersonaRequest): Promise<
 
 /** Delete a persona by ID. */
 export async function deletePersona(req: grackle.PersonaId): Promise<grackle.Empty> {
+  const { personaStore } = getDatabaseStores();
   personaStore.deletePersona(req.id);
   emit("persona.deleted", { personaId: req.id });
   return create(grackle.EmptySchema, {});

--- a/packages/plugin-core/src/pipe-handlers.ts
+++ b/packages/plugin-core/src/pipe-handlers.ts
@@ -8,7 +8,7 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, NotFoundError, PreconditionError } from "@grackle-ai/common";
 import { SESSION_STATUS } from "@grackle-ai/common";
-import { sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { streamRegistry, pipeDelivery } from "@grackle-ai/core";
 import { isReservedStreamName } from "@grackle-ai/core";
 
@@ -97,6 +97,7 @@ export async function writeToFd(req: grackle.WriteToFdRequest): Promise<grackle.
 
 /** Close a pipe file descriptor, optionally stopping child sessions. */
 export async function closeFd(req: grackle.CloseFdRequest): Promise<grackle.CloseFdResponse> {
+  const { sessionStore } = getDatabaseStores();
   const sub = streamRegistry.getSubscription(req.sessionId, req.fd);
   if (!sub) {
     throw new NotFoundError(`No subscription found for session ${req.sessionId} fd ${req.fd}`);

--- a/packages/plugin-core/src/plugin-handlers.ts
+++ b/packages/plugin-core/src/plugin-handlers.ts
@@ -1,11 +1,12 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, NotFoundError, PreconditionError } from "@grackle-ai/common";
-import { pluginStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
 import { getPluginRegistry, isPluginLoaded } from "./plugin-registry.js";
 
 /** Build a PluginInfo message from registry metadata and DB state. */
 function buildPluginInfo(name: string): grackle.PluginInfo {
+  const { pluginStore } = getDatabaseStores();
   const entry = getPluginRegistry().find((p) => p.name === name);
   const row = pluginStore.getPlugin(name);
 
@@ -39,6 +40,7 @@ export async function setPluginEnabled(
     throw new PreconditionError(`Plugin "${req.name}" is required and cannot be disabled`);
   }
 
+  const { pluginStore } = getDatabaseStores();
   pluginStore.setPluginEnabled(req.name, req.enabled);
   emit("plugin.changed", { name: req.name, enabled: req.enabled });
 

--- a/packages/plugin-core/src/require-helpers.ts
+++ b/packages/plugin-core/src/require-helpers.ts
@@ -26,18 +26,7 @@ import type {
   WorkspaceRow,
 } from "@grackle-ai/database";
 import type { GitHubAccountInfo } from "@grackle-ai/database";
-import {
-  agentStore,
-  componentStore,
-  envRegistry,
-  escalationStore,
-  githubAccountStore,
-  channelGrantStore,
-  personaStore,
-  sessionStore,
-  taskStore,
-  workspaceStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 
 // ── Required Field Helpers ──────────────────────────────────────
 
@@ -104,6 +93,7 @@ export function requireOneOf<T extends Record<string, unknown>>(fields: T): keyo
 
 /** Look up a workspace by ID; throw `NotFoundError` if missing. */
 export function requireWorkspace(id: string, context?: Record<string, unknown>): WorkspaceRow {
+  const { workspaceStore } = getDatabaseStores();
   requireField(id, "workspaceId");
   const row = workspaceStore.getWorkspace(id);
   if (!row) {
@@ -114,6 +104,7 @@ export function requireWorkspace(id: string, context?: Record<string, unknown>):
 
 /** Look up an environment by ID; throw `NotFoundError` if missing. */
 export function requireEnvironment(id: string, context?: Record<string, unknown>): EnvironmentRow {
+  const { envRegistry } = getDatabaseStores();
   requireField(id, "environmentId");
   const row = envRegistry.getEnvironment(id);
   if (!row) {
@@ -124,6 +115,7 @@ export function requireEnvironment(id: string, context?: Record<string, unknown>
 
 /** Look up a session by ID; throw `NotFoundError` if missing. */
 export function requireSession(id: string, context?: Record<string, unknown>): SessionRow {
+  const { sessionStore } = getDatabaseStores();
   requireField(id, "sessionId");
   const row = sessionStore.getSession(id);
   if (!row) {
@@ -134,6 +126,7 @@ export function requireSession(id: string, context?: Record<string, unknown>): S
 
 /** Look up a task by ID; throw `NotFoundError` if missing. */
 export function requireTask(id: string, context?: Record<string, unknown>): TaskRow {
+  const { taskStore } = getDatabaseStores();
   requireField(id, "taskId");
   const row = taskStore.getTask(id);
   if (!row) {
@@ -144,6 +137,7 @@ export function requireTask(id: string, context?: Record<string, unknown>): Task
 
 /** Look up an agent by ID; throw `NotFoundError` if missing. */
 export function requireAgent(id: string, context?: Record<string, unknown>): AgentRow {
+  const { agentStore } = getDatabaseStores();
   requireField(id, "agentId");
   const row = agentStore.getAgent(id);
   if (!row) {
@@ -154,6 +148,7 @@ export function requireAgent(id: string, context?: Record<string, unknown>): Age
 
 /** Look up a persona by ID; throw `NotFoundError` if missing. */
 export function requirePersona(id: string, context?: Record<string, unknown>): PersonaRow {
+  const { personaStore } = getDatabaseStores();
   requireField(id, "personaId");
   const row = personaStore.getPersona(id);
   if (!row) {
@@ -164,6 +159,7 @@ export function requirePersona(id: string, context?: Record<string, unknown>): P
 
 /** Look up a component by ID; throw `NotFoundError` if missing. */
 export function requireComponent(id: string, context?: Record<string, unknown>): ComponentRow {
+  const { componentStore } = getDatabaseStores();
   requireField(id, "componentId");
   const row = componentStore.getComponent(id);
   if (!row) {
@@ -174,6 +170,7 @@ export function requireComponent(id: string, context?: Record<string, unknown>):
 
 /** Look up an escalation by ID; throw `NotFoundError` if missing. */
 export function requireEscalation(id: string, context?: Record<string, unknown>): EscalationRow {
+  const { escalationStore } = getDatabaseStores();
   requireField(id, "escalationId");
   const row = escalationStore.getEscalation(id);
   if (!row) {
@@ -187,6 +184,7 @@ export function requireGitHubAccount(
   id: string,
   context?: Record<string, unknown>,
 ): GitHubAccountInfo {
+  const { githubAccountStore } = getDatabaseStores();
   requireField(id, "id");
   const row = githubAccountStore.getGitHubAccount(id);
   if (!row) {
@@ -200,6 +198,7 @@ export function requireChannelGrant(
   id: string,
   context?: Record<string, unknown>,
 ): ChannelGrantRow {
+  const { channelGrantStore } = getDatabaseStores();
   requireField(id, "grantId");
   const row = channelGrantStore.getGrant(id);
   if (!row) {

--- a/packages/plugin-core/src/runtime-handlers.test.ts
+++ b/packages/plugin-core/src/runtime-handlers.test.ts
@@ -12,8 +12,7 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@grackle-ai/database")>();
   actual.openDatabase(":memory:");
   actual.initDatabase();
-  return {
-    ...actual,
+  const overrides = {
     credentialProviders: {
       ...actual.credentialProviders,
       getCredentialProviders: vi.fn(() => ({
@@ -24,6 +23,38 @@ vi.mock("@grackle-ai/database", async (importOriginal) => {
         goose: "off",
       })),
     },
+  };
+  actual.setDatabaseStores({
+    sessionStore: actual.sessionStore,
+    taskStore: actual.taskStore,
+    envRegistry: actual.envRegistry,
+    workspaceStore: actual.workspaceStore,
+    personaStore: actual.personaStore,
+    agentStore: actual.agentStore,
+    componentStore: actual.componentStore,
+    settingsStore: actual.settingsStore,
+    tokenStore: actual.tokenStore,
+    credentialProviders: overrides.credentialProviders,
+    scheduleStore: actual.scheduleStore,
+    escalationStore: actual.escalationStore,
+    workspaceEnvironmentLinkStore: actual.workspaceEnvironmentLinkStore,
+    dispatchQueueStore: actual.dispatchQueueStore,
+    pluginStore: actual.pluginStore,
+    githubAccountStore: actual.githubAccountStore,
+    channelGrantStore: actual.channelGrantStore,
+    eventStore: { persistEvent: actual.persistEvent, queryDomainEvents: actual.queryDomainEvents },
+    streamMessageStore: {
+      persistStreamMessage: actual.persistStreamMessage,
+      queryStreamMessages: actual.queryStreamMessages,
+    },
+    sessionActionStore: {
+      persistSessionAction: actual.persistSessionAction,
+      querySessionActions: actual.querySessionActions,
+    },
+  });
+  return {
+    ...actual,
+    ...overrides,
   };
 });
 

--- a/packages/plugin-core/src/runtime-handlers.ts
+++ b/packages/plugin-core/src/runtime-handlers.ts
@@ -9,7 +9,7 @@
  */
 import { create } from "@bufbuild/protobuf";
 import { grackle, RUNTIME_CATALOG } from "@grackle-ai/common";
-import { credentialProviders } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { deriveCredentialNeeds } from "@grackle-ai/core";
 
 /**
@@ -17,6 +17,7 @@ import { deriveCredentialNeeds } from "@grackle-ai/core";
  * the current credential-provider config (AHP `RootState.agents`).
  */
 export async function listRuntimes(): Promise<grackle.ListRuntimesResponse> {
+  const { credentialProviders } = getDatabaseStores();
   const config = credentialProviders.getCredentialProviders();
   const runtimes = Object.entries(RUNTIME_CATALOG).map(([provider, entry]) =>
     create(grackle.RuntimeInfoSchema, {

--- a/packages/plugin-core/src/session-handlers.ts
+++ b/packages/plugin-core/src/session-handlers.ts
@@ -7,14 +7,7 @@ import {
   type SessionStatus,
   LOGS_DIR,
 } from "@grackle-ai/common";
-import {
-  envRegistry,
-  sessionStore,
-  taskStore,
-  personaStore,
-  settingsStore,
-  grackleHome,
-} from "@grackle-ai/database";
+import { getDatabaseStores, grackleHome } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
 import { reconnectOrProvision } from "@grackle-ai/adapter-sdk";
@@ -48,6 +41,7 @@ import { isReconnecting } from "@grackle-ai/core";
 
 /** Spawn a new agent session in the given environment. */
 export async function spawnAgent(req: grackle.SpawnRequest): Promise<grackle.Session> {
+  const { envRegistry, sessionStore, taskStore, personaStore, settingsStore } = getDatabaseStores();
   const env = requireEnvironment(req.environmentId);
 
   let conn = adapterManager.getConnection(req.environmentId);
@@ -308,6 +302,7 @@ export async function sendInput(req: grackle.InputMessage): Promise<grackle.Empt
 
 /** Kill (or gracefully stop) an agent session. */
 export async function killAgent(req: grackle.KillAgentRequest): Promise<grackle.Empty> {
+  const { sessionStore } = getDatabaseStores();
   const session = requireSession(req.id);
 
   if (req.graceful) {
@@ -349,6 +344,7 @@ export async function killAgent(req: grackle.KillAgentRequest): Promise<grackle.
 
 /** Get aggregated usage stats for a session, task, task tree, workspace, or environment. */
 export async function getUsage(req: grackle.GetUsageRequest): Promise<grackle.UsageStats> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   requireField(req.id, "id");
   switch (req.scope) {
     case "session": {

--- a/packages/plugin-core/src/session-query-handlers.ts
+++ b/packages/plugin-core/src/session-query-handlers.ts
@@ -10,7 +10,7 @@ import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
 import { eventTypeToEnum } from "@grackle-ai/common";
-import { sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   streamHub,
   logWriter,
@@ -23,6 +23,7 @@ import { requireField, requireSession } from "./require-helpers.js";
 
 /** List sessions with optional filters. */
 export async function listSessions(req: grackle.SessionFilter): Promise<grackle.SessionList> {
+  const { sessionStore } = getDatabaseStores();
   const rows = sessionStore.listSessions(req.environmentId, req.status);
   return create(grackle.SessionListSchema, {
     sessions: rows.map(sessionRowToProto),
@@ -65,6 +66,7 @@ export async function getSessionEvents(req: grackle.SessionId): Promise<grackle.
 
 /** Get all sessions for a task. */
 export async function getTaskSessions(req: grackle.TaskId): Promise<grackle.SessionList> {
+  const { sessionStore } = getDatabaseStores();
   requireField(req.id, "task id");
   const rows = sessionStore.listSessionsForTask(req.id);
   return create(grackle.SessionListSchema, {

--- a/packages/plugin-core/src/settings-handlers.ts
+++ b/packages/plugin-core/src/settings-handlers.ts
@@ -6,12 +6,7 @@ import {
   ValidationError,
 } from "@grackle-ai/common";
 import { DEFAULT_WEB_PORT } from "@grackle-ai/common";
-import {
-  settingsStore,
-  personaStore,
-  envRegistry,
-  isAllowedSettingKey,
-} from "@grackle-ai/database";
+import { getDatabaseStores, isAllowedSettingKey } from "@grackle-ai/database";
 import { generatePairingCode as authGeneratePairingCode } from "@grackle-ai/auth";
 import { checkVersionStatus } from "@grackle-ai/core";
 import { detectLanIp } from "@grackle-ai/core";
@@ -20,6 +15,7 @@ import { requirePersona } from "./require-helpers.js";
 
 /** Get the value of a setting by key. */
 export async function getSetting(req: grackle.GetSettingRequest): Promise<grackle.SettingResponse> {
+  const { settingsStore } = getDatabaseStores();
   if (!isAllowedSettingKey(req.key)) {
     throw new ValidationError(`Setting key not allowed: ${req.key}`);
   }
@@ -32,6 +28,7 @@ export async function getSetting(req: grackle.GetSettingRequest): Promise<grackl
 
 /** Set the value of a setting. */
 export async function setSetting(req: grackle.SetSettingRequest): Promise<grackle.SettingResponse> {
+  const { settingsStore, personaStore, envRegistry } = getDatabaseStores();
   if (!isAllowedSettingKey(req.key)) {
     throw new ValidationError(`Setting key not allowed: ${req.key}`);
   }

--- a/packages/plugin-core/src/signals/escalation-auto.ts
+++ b/packages/plugin-core/src/signals/escalation-auto.ts
@@ -9,7 +9,7 @@
 
 import { SESSION_STATUS, ROOT_TASK_ID, serverTimestamp } from "@grackle-ai/common";
 import type { GrackleEvent } from "@grackle-ai/core";
-import { taskStore, sessionStore, escalationStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { readLastTextEntry } from "@grackle-ai/core";
 import { routeEscalation } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
@@ -60,6 +60,7 @@ export function createEscalationAutoSubscriber(ctx: PluginContext): Disposable {
  * whose latest session has gone IDLE, and if so, auto-escalate.
  */
 async function handleTaskUpdated(delivered: Map<string, number>, taskId: string): Promise<void> {
+  const { taskStore, sessionStore, escalationStore } = getDatabaseStores();
   const task = taskStore.getTask(taskId);
   if (!task) {
     return;

--- a/packages/plugin-core/src/signals/orphan-reparent.ts
+++ b/packages/plugin-core/src/signals/orphan-reparent.ts
@@ -9,7 +9,7 @@
 
 import { ROOT_TASK_ID, TASK_STATUS } from "@grackle-ai/common";
 import type { GrackleEvent } from "@grackle-ai/core";
-import { taskStore, sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { streamRegistry } from "@grackle-ai/core";
 import { ensureAsyncDeliveryListener } from "@grackle-ai/core";
 import { deliverSignalToTask } from "@grackle-ai/core";
@@ -72,6 +72,7 @@ async function handleParentTerminal(
   processed: Map<string, number>,
   parentTaskId: string,
 ): Promise<void> {
+  const { taskStore } = getDatabaseStores();
   const parentTask = taskStore.getTask(parentTaskId);
   if (!parentTask) {
     return;
@@ -171,6 +172,7 @@ export function transferAllPipeSubscriptions(
   deadParentTaskId: string,
   grandparentTaskId: string,
 ): void {
+  const { sessionStore } = getDatabaseStores();
   const grandparentSessions = sessionStore.getActiveSessionsForTask(grandparentTaskId);
   if (grandparentSessions.length === 0) {
     logger.debug(

--- a/packages/plugin-core/src/signals/sigchld.ts
+++ b/packages/plugin-core/src/signals/sigchld.ts
@@ -1,6 +1,6 @@
 import { SESSION_STATUS } from "@grackle-ai/common";
 import type { GrackleEvent } from "@grackle-ai/core";
-import { taskStore, sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { readLastTextEntry } from "@grackle-ai/core";
 import { deliverSignalToTask } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
@@ -81,6 +81,7 @@ async function handleTaskUpdated(
   delivered: Map<string, number>,
   childTaskId: string,
 ): Promise<void> {
+  const { taskStore, sessionStore } = getDatabaseStores();
   const childTask = taskStore.getTask(childTaskId);
   if (!childTask) {
     return;

--- a/packages/plugin-core/src/spawn-orchestration.ts
+++ b/packages/plugin-core/src/spawn-orchestration.ts
@@ -10,7 +10,7 @@
 import type { PipeMode } from "@grackle-ai/common";
 import { DEFAULT_MCP_PORT } from "@grackle-ai/common";
 import type { ServerActionEnvelope } from "@grackle-ai/adapter-sdk";
-import { sessionStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   streamRegistry,
   pipeDelivery,
@@ -44,6 +44,7 @@ export interface SpawnTailParams {
  * `startTask` call this after creating the session row and transport stream.
  */
 export function executeSpawnTail(params: SpawnTailParams): grackle.Session {
+  const { sessionStore } = getDatabaseStores();
   const { sessionId, parentSessionId, pipeMode, transportStream, eventContext } = params;
 
   const lifecycleStream = streamRegistry.createStream(`lifecycle:${sessionId}`);

--- a/packages/plugin-core/src/task-handlers.ts
+++ b/packages/plugin-core/src/task-handlers.ts
@@ -10,7 +10,7 @@ import {
   type FuzzyKey,
 } from "@grackle-ai/common";
 import type { WorkspaceRow } from "@grackle-ai/database";
-import { sessionStore, taskStore, slugify, safeParseJsonArray } from "@grackle-ai/database";
+import { getDatabaseStores, slugify, safeParseJsonArray } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { emit } from "@grackle-ai/core";
 import { processorRegistry } from "@grackle-ai/core";
@@ -37,6 +37,7 @@ const DEFAULT_SEARCH_LIMIT = 10;
 
 /** List tasks, optionally filtered by workspace, search query, or status. */
 export async function listTasks(req: grackle.ListTasksRequest): Promise<grackle.TaskList> {
+  const { taskStore, sessionStore } = getDatabaseStores();
   const rows = taskStore.listTasks(req.workspaceId || undefined, {
     search: req.search || undefined,
     status: req.status || undefined,
@@ -66,6 +67,7 @@ export async function listTasks(req: grackle.ListTasksRequest): Promise<grackle.
 export async function searchTasks(
   req: grackle.SearchTasksRequest,
 ): Promise<grackle.SearchTasksResponse> {
+  const { taskStore, sessionStore } = getDatabaseStores();
   const query = requireTrimmed(req.query, "query");
   const limit = req.limit > 0 ? req.limit : DEFAULT_SEARCH_LIMIT;
 
@@ -104,6 +106,7 @@ export async function searchTasks(
 
 /** Create a new task. */
 export async function createTask(req: grackle.CreateTaskRequest): Promise<grackle.Task> {
+  const { taskStore } = getDatabaseStores();
   requireField(req.title, "title");
   const workspaceId = req.workspaceId || undefined;
   let workspace: WorkspaceRow | undefined;
@@ -156,6 +159,7 @@ export async function createTask(req: grackle.CreateTaskRequest): Promise<grackl
 
 /** Get a task by ID with computed status. */
 export async function getTask(req: grackle.TaskId): Promise<grackle.Task> {
+  const { taskStore, sessionStore } = getDatabaseStores();
   const row = requireTask(req.id);
   const taskSessions = sessionStore.listSessionsForTask(req.id);
   const { status, latestSessionId } = computeTaskStatus(row.status, taskSessions);
@@ -164,6 +168,7 @@ export async function getTask(req: grackle.TaskId): Promise<grackle.Task> {
 
 /** Update task fields or late-bind a session to a task. */
 export async function updateTask(req: grackle.UpdateTaskRequest): Promise<grackle.Task> {
+  const { taskStore, sessionStore } = getDatabaseStores();
   const existing = requireTask(req.id);
 
   let reqStatus = existing.status;

--- a/packages/plugin-core/src/task-lifecycle-handlers.ts
+++ b/packages/plugin-core/src/task-lifecycle-handlers.ts
@@ -18,7 +18,7 @@ import {
   ROOT_TASK_ID,
   LOGS_DIR,
 } from "@grackle-ai/common";
-import { sessionStore, taskStore, grackleHome } from "@grackle-ai/database";
+import { getDatabaseStores, grackleHome } from "@grackle-ai/database";
 import { join } from "node:path";
 import { adapterManager } from "@grackle-ai/core";
 import { streamHub } from "@grackle-ai/core";
@@ -36,6 +36,7 @@ import { requireTask } from "./require-helpers.js";
 
 /** Mark a task as complete and clean up active sessions. */
 export async function completeTask(req: grackle.TaskId): Promise<grackle.Task> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   if (req.id === ROOT_TASK_ID) {
     throw new AuthError("Cannot complete the system task");
   }
@@ -94,6 +95,7 @@ export async function completeTask(req: grackle.TaskId): Promise<grackle.Task> {
 
 /** Set the workpad JSON for a task. */
 export async function setWorkpad(req: grackle.SetWorkpadRequest): Promise<grackle.Task> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   const task = requireTask(req.taskId);
   // Validate workpad is a valid JSON object
   try {
@@ -121,6 +123,7 @@ export async function setWorkpad(req: grackle.SetWorkpadRequest): Promise<grackl
 
 /** Resume the latest session for a task. */
 export async function resumeTask(req: grackle.TaskId): Promise<grackle.Session> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   const task = requireTask(req.id);
 
   const latestSession = sessionStore.getLatestSessionForTask(req.id);
@@ -183,6 +186,7 @@ export async function resumeTask(req: grackle.TaskId): Promise<grackle.Session> 
 
 /** Stop a task by terminating all its active sessions. */
 export async function stopTask(req: grackle.TaskId): Promise<grackle.Task> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   const task = requireTask(req.id);
 
   // Terminate all active sessions for this task using the fd-closure pattern
@@ -234,6 +238,7 @@ export async function stopTask(req: grackle.TaskId): Promise<grackle.Task> {
 
 /** Delete a task and all its sessions. */
 export async function deleteTask(req: grackle.TaskId): Promise<grackle.Empty> {
+  const { sessionStore, taskStore } = getDatabaseStores();
   if (req.id === ROOT_TASK_ID) {
     throw new AuthError("Cannot delete the system task");
   }

--- a/packages/plugin-core/src/task-start.ts
+++ b/packages/plugin-core/src/task-start.ts
@@ -7,17 +7,7 @@ import {
 } from "@grackle-ai/common";
 import type { PipeMode } from "@grackle-ai/common";
 import { TASK_STATUS, ROOT_TASK_ID, ROOT_TASK_INITIAL_PROMPT, LOGS_DIR } from "@grackle-ai/common";
-import {
-  envRegistry,
-  sessionStore,
-  taskStore,
-  workspaceStore,
-  personaStore,
-  settingsStore,
-  dispatchQueueStore,
-  grackleHome,
-  workspaceEnvironmentLinkStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores, grackleHome } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { join } from "node:path";
 import { adapterManager } from "@grackle-ai/core";
@@ -50,6 +40,16 @@ import { buildMcpUrl, executeSpawnTail } from "./spawn-orchestration.js";
 
 /** Start a task by spawning a new agent session. */
 export async function startTask(req: grackle.StartTaskRequest): Promise<grackle.Session> {
+  const {
+    envRegistry,
+    sessionStore,
+    taskStore,
+    workspaceStore,
+    personaStore,
+    settingsStore,
+    dispatchQueueStore,
+    workspaceEnvironmentLinkStore,
+  } = getDatabaseStores();
   const task = taskStore.getTask(req.taskId);
   if (!task) {
     throw new NotFoundError(`Task not found: ${req.taskId}`);

--- a/packages/plugin-core/src/test-utils/integration-setup.ts
+++ b/packages/plugin-core/src/test-utils/integration-setup.ts
@@ -5,6 +5,7 @@
  * and a helper to extract handler methods via {@link createDefaultCollector}.
  */
 import { openDatabase, initDatabase, sqlite, seedDatabase } from "@grackle-ai/database";
+import { initRealDatabaseStores } from "@grackle-ai/test-utils/db";
 import { grackle } from "@grackle-ai/common";
 import { createDefaultCollector } from "../grpc-service.js";
 
@@ -15,6 +16,7 @@ import { createDefaultCollector } from "../grpc-service.js";
 export function initTestDatabase(): void {
   openDatabase(":memory:");
   initDatabase();
+  initRealDatabaseStores();
   seedDatabase(sqlite!);
 }
 

--- a/packages/plugin-core/src/token-handlers.ts
+++ b/packages/plugin-core/src/token-handlers.ts
@@ -1,12 +1,18 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, ValidationError } from "@grackle-ai/common";
 import { claudeProviderModeToEnum, providerToggleToEnum } from "@grackle-ai/common";
-import { tokenStore, credentialProviders } from "@grackle-ai/database";
+import {
+  getDatabaseStores,
+  VALID_PROVIDERS,
+  VALID_CLAUDE_VALUES,
+  VALID_TOGGLE_VALUES,
+} from "@grackle-ai/database";
 import { emit } from "@grackle-ai/core";
 import { requireField } from "./require-helpers.js";
 
 /** Store or update a token. */
 export async function setToken(req: grackle.TokenEntry): Promise<grackle.Empty> {
+  const { tokenStore } = getDatabaseStores();
   requireField(req.name, "name");
   requireField(req.value, "value");
   tokenStore.setToken({
@@ -24,6 +30,7 @@ export async function setToken(req: grackle.TokenEntry): Promise<grackle.Empty> 
 
 /** List all stored tokens (without values). */
 export async function listTokens(): Promise<grackle.TokenList> {
+  const { tokenStore } = getDatabaseStores();
   const items = tokenStore.listTokens();
   return create(grackle.TokenListSchema, {
     tokens: items.map((t) =>
@@ -40,6 +47,7 @@ export async function listTokens(): Promise<grackle.TokenList> {
 
 /** Delete a token by name. */
 export async function deleteToken(req: grackle.TokenName): Promise<grackle.Empty> {
+  const { tokenStore } = getDatabaseStores();
   requireField(req.name, "name");
   tokenStore.deleteToken(req.name);
   emit("token.changed", {});
@@ -48,6 +56,7 @@ export async function deleteToken(req: grackle.TokenName): Promise<grackle.Empty
 
 /** Get the current credential provider configuration. */
 export async function getCredentialProviders(): Promise<grackle.CredentialProviderConfig> {
+  const { credentialProviders } = getDatabaseStores();
   const config = credentialProviders.getCredentialProviders();
   return create(grackle.CredentialProviderConfigSchema, {
     claude: claudeProviderModeToEnum(config.claude),
@@ -62,16 +71,14 @@ export async function getCredentialProviders(): Promise<grackle.CredentialProvid
 export async function setCredentialProvider(
   req: grackle.SetCredentialProviderRequest,
 ): Promise<grackle.CredentialProviderConfig> {
-  if (!credentialProviders.VALID_PROVIDERS.includes(req.provider)) {
+  const { credentialProviders } = getDatabaseStores();
+  if (!VALID_PROVIDERS.includes(req.provider)) {
     throw new ValidationError(
-      `Invalid provider: ${req.provider}. Must be one of: ${credentialProviders.VALID_PROVIDERS.join(", ")}`,
+      `Invalid provider: ${req.provider}. Must be one of: ${VALID_PROVIDERS.join(", ")}`,
     );
   }
 
-  const allowed =
-    req.provider === "claude"
-      ? credentialProviders.VALID_CLAUDE_VALUES
-      : credentialProviders.VALID_TOGGLE_VALUES;
+  const allowed = req.provider === "claude" ? VALID_CLAUDE_VALUES : VALID_TOGGLE_VALUES;
 
   if (!allowed.has(req.value)) {
     throw new ValidationError(

--- a/packages/plugin-core/src/workspace-handlers.ts
+++ b/packages/plugin-core/src/workspace-handlers.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { grackle, ValidationError, NotFoundError, PreconditionError } from "@grackle-ai/common";
-import { workspaceStore, workspaceEnvironmentLinkStore, slugify } from "@grackle-ai/database";
+import { getDatabaseStores, slugify } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import { emit } from "@grackle-ai/core";
 import { logger } from "@grackle-ai/core";
@@ -17,6 +17,7 @@ import {
 export async function listWorkspaces(
   req: grackle.ListWorkspacesRequest,
 ): Promise<grackle.WorkspaceList> {
+  const { workspaceStore, workspaceEnvironmentLinkStore } = getDatabaseStores();
   const rows = workspaceStore.listWorkspaces(req.environmentId || undefined);
   // Batch-fetch linked environment IDs to avoid N+1 queries
   const linkedEnvMap = workspaceEnvironmentLinkStore.getLinkedEnvironmentIdsByWorkspaces(
@@ -31,6 +32,7 @@ export async function listWorkspaces(
 export async function createWorkspace(
   req: grackle.CreateWorkspaceRequest,
 ): Promise<grackle.Workspace> {
+  const { workspaceStore } = getDatabaseStores();
   requireField(req.name, "name");
   requireEnvironment(req.environmentId);
   let id = slugify(req.name) || uuid().slice(0, 8);
@@ -69,6 +71,7 @@ export async function getWorkspace(req: grackle.WorkspaceId): Promise<grackle.Wo
 
 /** Archive a workspace. */
 export async function archiveWorkspace(req: grackle.WorkspaceId): Promise<grackle.Empty> {
+  const { workspaceStore } = getDatabaseStores();
   workspaceStore.archiveWorkspace(req.id);
   emit("workspace.archived", { workspaceId: req.id });
   logger.info({ workspaceId: req.id }, "Workspace archived");
@@ -79,6 +82,7 @@ export async function archiveWorkspace(req: grackle.WorkspaceId): Promise<grackl
 export async function updateWorkspace(
   req: grackle.UpdateWorkspaceRequest,
 ): Promise<grackle.Workspace> {
+  const { workspaceStore } = getDatabaseStores();
   const existing = requireWorkspace(req.id);
   if (req.name !== undefined) {
     requireNonEmpty(req.name, "name");
@@ -108,6 +112,7 @@ export async function updateWorkspace(
 export async function linkEnvironment(
   req: grackle.LinkEnvironmentRequest,
 ): Promise<grackle.Workspace> {
+  const { workspaceEnvironmentLinkStore } = getDatabaseStores();
   const workspace = requireWorkspace(req.workspaceId);
   requireEnvironment(req.environmentId);
   if (workspaceEnvironmentLinkStore.isLinked(req.workspaceId, req.environmentId)) {
@@ -141,6 +146,7 @@ export async function linkEnvironment(
 export async function unlinkEnvironment(
   req: grackle.UnlinkEnvironmentRequest,
 ): Promise<grackle.Workspace> {
+  const { workspaceEnvironmentLinkStore } = getDatabaseStores();
   const workspace = requireWorkspace(req.workspaceId);
   if (!workspaceEnvironmentLinkStore.isLinked(req.workspaceId, req.environmentId)) {
     throw new NotFoundError(

--- a/packages/plugin-core/src/workspace-link-handlers.test.ts
+++ b/packages/plugin-core/src/workspace-link-handlers.test.ts
@@ -12,7 +12,9 @@ vi.mock("@grackle-ai/database", async () => {
       this.name = "LastEnvironmentError";
     }
   }
-  return { ...createDatabaseMock(), LastEnvironmentError };
+  const mock = createDatabaseMock();
+  mock.wire();
+  return { ...mock, LastEnvironmentError };
 });
 
 vi.mock("@grackle-ai/core", async (importOriginal) => {


### PR DESCRIPTION
## Summary

- Replaces all direct `import { storeX } from "@grackle-ai/database"` calls in `packages/plugin-core/src/` with per-function `getDatabaseStores()` destructures, following the same pattern applied to `packages/core` in #1567
- Exports additional store row types (`ScheduleUpdate`, `GitHubAccountInfo`, `UpdateGitHubAccountFields`, etc.) from the `@grackle-ai/database` barrel that plugin-core converters need as `import type`
- Wires the DI registry in shared test helpers (`integration-setup.ts`, `lifecycle-cleanup.test.ts`) and fixes `vi.mock` factories that were using a broken `() => actual.getDatabaseStores()` lambda

## Test plan

- [x] `rush test -t @grackle-ai/plugin-core` — all tests pass (0 failures)
- [x] Grep guard: no value store imports remain in prod files (`git grep` returns only `getDatabaseStores` and `import type` lines)
- [x] `rush build -t @grackle-ai/plugin-core` — clean (no warnings-as-errors)
- [x] `rush format:check` — clean

Closes #1550