### PR TITLE
Fix AHP orphan-event rescue leaking abstraction; widen status tunnel (#1460)

### DIFF
--- a/common/api/common.public.api.md
+++ b/common/api/common.public.api.md
@@ -216,8 +216,8 @@ export const BUILTIN_COMPONENT_SCHEMAS: {
     }, z.core.$strip>;
     readonly Callout: z.ZodObject<{
         variant: z.ZodOptional<z.ZodEnum<{
-            success: "success";
             error: "error";
+            success: "success";
             info: "info";
             warning: "warning";
         }>>;
@@ -326,8 +326,8 @@ export type CalloutBuiltinProps = z.infer<typeof calloutPropsSchema>;
 // @public
 export const calloutPropsSchema: z.ZodObject<{
     variant: z.ZodOptional<z.ZodEnum<{
-        success: "success";
         error: "error";
+        success: "success";
         info: "info";
         warning: "warning";
     }>>;
@@ -339,8 +339,8 @@ export type CalloutVariant = z.infer<typeof calloutVariantSchema>;
 
 // @public
 export const calloutVariantSchema: z.ZodEnum<{
-    success: "success";
     error: "error";
+    success: "success";
     info: "info";
     warning: "warning";
 }>;

--- a/common/changes/@grackle-ai/cli/nick-pape-1460-ahp-orphan-rescue_2026-06-11-03-27.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1460-ahp-orphan-rescue_2026-06-11-03-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Move AHP orphan-event rescue into the mapper (withTurn helper); document status _meta tunnel as temporary HR8d artifact; delete hardcoded ORPHAN_RESCUABLE_TYPES and STATUS_RESCUE_CONTENTS from PowerLine forwarder",
+      "type": "minor",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/common/scripts/install-run-rush-pnpm.js
+++ b/common/scripts/install-run-rush-pnpm.js
@@ -17,9 +17,9 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
 var __webpack_exports__ = {};
-/*!*****************************************************!*\
-  !*** ./lib-esnext/scripts/install-run-rush-pnpm.js ***!
-  \*****************************************************/
+/*!***************************************************************!*\
+  !*** ./lib-intermediate-esm/scripts/install-run-rush-pnpm.js ***!
+  \***************************************************************/
 
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -16,25 +16,25 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 16928:
-/*!***********************!*\
-  !*** external "path" ***!
-  \***********************/
-/***/ ((module) => {
+/***/ 973024
+/*!**************************!*\
+  !*** external "node:fs" ***!
+  \**************************/
+(module) {
 
-module.exports = require("path");
+module.exports = require("node:fs");
 
-/***/ }),
+/***/ },
 
-/***/ 179896:
-/*!*********************!*\
-  !*** external "fs" ***!
-  \*********************/
-/***/ ((module) => {
+/***/ 176760
+/*!****************************!*\
+  !*** external "node:path" ***!
+  \****************************/
+(module) {
 
-module.exports = require("fs");
+module.exports = require("node:path");
 
-/***/ })
+/***/ }
 
 /******/ 	});
 /************************************************************************/
@@ -47,6 +47,12 @@ module.exports = require("fs");
 /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
 /******/ 		if (cachedModule !== undefined) {
 /******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Check if module exists (development only)
+/******/ 		if (__webpack_modules__[moduleId] === undefined) {
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
@@ -107,14 +113,14 @@ module.exports = require("fs");
 var __webpack_exports__ = {};
 // This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
-/*!************************************************!*\
-  !*** ./lib-esnext/scripts/install-run-rush.js ***!
-  \************************************************/
+/*!**********************************************************!*\
+  !*** ./lib-intermediate-esm/scripts/install-run-rush.js ***!
+  \**********************************************************/
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! path */ 16928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! fs */ 179896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! node:path */ 176760);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(node_path__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! node:fs */ 973024);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(node_fs__WEBPACK_IMPORTED_MODULE_1__);
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 /* eslint-disable no-console */
@@ -131,9 +137,9 @@ function _getRushVersion(logger) {
         return rushPreviewVersion;
     }
     const rushJsonFolder = findRushJsonFolder();
-    const rushJsonPath = path__WEBPACK_IMPORTED_MODULE_0__.join(rushJsonFolder, RUSH_JSON_FILENAME);
+    const rushJsonPath = node_path__WEBPACK_IMPORTED_MODULE_0__.join(rushJsonFolder, RUSH_JSON_FILENAME);
     try {
-        const rushJsonContents = fs__WEBPACK_IMPORTED_MODULE_1__.readFileSync(rushJsonPath, 'utf-8');
+        const rushJsonContents = node_fs__WEBPACK_IMPORTED_MODULE_1__.readFileSync(rushJsonPath, 'utf-8');
         // Use a regular expression to parse out the rushVersion value because rush.json supports comments,
         // but JSON.parse does not and we don't want to pull in more dependencies than we need to in this script.
         const rushJsonMatches = rushJsonContents.match(/\"rushVersion\"\s*\:\s*\"([0-9a-zA-Z.+\-]+)\"/);
@@ -159,7 +165,7 @@ function _run() {
     const [nodePath /* Ex: /bin/node */, scriptPath /* /repo/common/scripts/install-run-rush.js */, ...packageBinArgs /* [build, --to, myproject] */] = process.argv;
     // Detect if this script was directly invoked, or if the install-run-rushx script was invokved to select the
     // appropriate binary inside the rush package to run
-    const scriptName = path__WEBPACK_IMPORTED_MODULE_0__.basename(scriptPath);
+    const scriptName = node_path__WEBPACK_IMPORTED_MODULE_0__.basename(scriptPath);
     const bin = _getBin(scriptName);
     if (!nodePath || !scriptPath) {
         throw new Error('Unexpected exception: could not detect node path or script path');

--- a/common/scripts/install-run-rushx.js
+++ b/common/scripts/install-run-rushx.js
@@ -17,9 +17,9 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
 var __webpack_exports__ = {};
-/*!*************************************************!*\
-  !*** ./lib-esnext/scripts/install-run-rushx.js ***!
-  \*************************************************/
+/*!***********************************************************!*\
+  !*** ./lib-intermediate-esm/scripts/install-run-rushx.js ***!
+  \***********************************************************/
 
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -16,51 +16,44 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 16928:
-/*!***********************!*\
-  !*** external "path" ***!
-  \***********************/
-/***/ ((module) => {
+/***/ 953844
+/*!**************************************************************!*\
+  !*** ./lib-intermediate-esm/utilities/executionUtilities.js ***!
+  \**************************************************************/
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-module.exports = require("path");
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   IS_WINDOWS: () => (/* binding */ IS_WINDOWS),
+/* harmony export */   escapeArgumentIfNeeded: () => (/* binding */ escapeArgumentIfNeeded)
+/* harmony export */ });
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+const IS_WINDOWS = process.platform === 'win32';
+function escapeArgumentIfNeeded(command, isWindows = IS_WINDOWS) {
+    if (command.includes(' ')) {
+        if (isWindows) {
+            // Windows: use double quotes and escape internal double quotes
+            return `"${command.replace(/"/g, '""')}"`;
+        }
+        else {
+            // Unix: use JSON.stringify for proper escaping
+            return JSON.stringify(command);
+        }
+    }
+    else {
+        return command;
+    }
+}
+//# sourceMappingURL=executionUtilities.js.map
 
-/***/ }),
+/***/ },
 
-/***/ 179896:
-/*!*********************!*\
-  !*** external "fs" ***!
-  \*********************/
-/***/ ((module) => {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 370857:
-/*!*********************!*\
-  !*** external "os" ***!
-  \*********************/
-/***/ ((module) => {
-
-module.exports = require("os");
-
-/***/ }),
-
-/***/ 535317:
-/*!********************************!*\
-  !*** external "child_process" ***!
-  \********************************/
-/***/ ((module) => {
-
-module.exports = require("child_process");
-
-/***/ }),
-
-/***/ 832286:
-/*!************************************************!*\
-  !*** ./lib-esnext/utilities/npmrcUtilities.js ***!
-  \************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ 359480
+/*!**********************************************************!*\
+  !*** ./lib-intermediate-esm/utilities/npmrcUtilities.js ***!
+  \**********************************************************/
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -68,10 +61,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   syncNpmrc: () => (/* binding */ syncNpmrc),
 /* harmony export */   trimNpmrcFileLines: () => (/* binding */ trimNpmrcFileLines)
 /* harmony export */ });
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! fs */ 179896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! path */ 16928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! node:fs */ 973024);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(node_fs__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! node:path */ 176760);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(node_path__WEBPACK_IMPORTED_MODULE_1__);
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 // IMPORTANT - do not use any non-built-in libraries in this file
@@ -84,40 +77,74 @@ __webpack_require__.r(__webpack_exports__);
  * @returns
  * The text of the the .npmrc.
  */
-// create a global _combinedNpmrc for cache purpose
-const _combinedNpmrcMap = new Map();
 function _trimNpmrcFile(options) {
-    const { sourceNpmrcPath, linesToPrepend, linesToAppend, supportEnvVarFallbackSyntax } = options;
-    const combinedNpmrcFromCache = _combinedNpmrcMap.get(sourceNpmrcPath);
-    if (combinedNpmrcFromCache !== undefined) {
-        return combinedNpmrcFromCache;
-    }
+    const { sourceNpmrcPath, linesToPrepend, linesToAppend, supportEnvVarFallbackSyntax, filterNpmIncompatibleProperties, env = process.env } = options;
     let npmrcFileLines = [];
     if (linesToPrepend) {
         npmrcFileLines.push(...linesToPrepend);
     }
-    if (fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath)) {
-        npmrcFileLines.push(...fs__WEBPACK_IMPORTED_MODULE_0__.readFileSync(sourceNpmrcPath).toString().split('\n'));
+    if (node_fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath)) {
+        npmrcFileLines.push(...node_fs__WEBPACK_IMPORTED_MODULE_0__.readFileSync(sourceNpmrcPath).toString().split('\n'));
     }
     if (linesToAppend) {
         npmrcFileLines.push(...linesToAppend);
     }
     npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
-    const resultLines = trimNpmrcFileLines(npmrcFileLines, process.env, supportEnvVarFallbackSyntax);
+    const resultLines = trimNpmrcFileLines(npmrcFileLines, env, supportEnvVarFallbackSyntax, filterNpmIncompatibleProperties);
     const combinedNpmrc = resultLines.join('\n');
-    //save the cache
-    _combinedNpmrcMap.set(sourceNpmrcPath, combinedNpmrc);
     return combinedNpmrc;
 }
+/**
+ * List of npmrc properties that are not supported by npm but may be present in the config.
+ * These include pnpm-specific properties and deprecated npm properties.
+ */
+const NPM_INCOMPATIBLE_PROPERTIES = new Set([
+    // pnpm-specific hoisting configuration
+    'hoist',
+    'hoist-pattern',
+    'public-hoist-pattern',
+    'shamefully-hoist',
+    // Deprecated or unknown npm properties that cause warnings
+    'email',
+    'publish-branch'
+]);
+/**
+ * List of registry-scoped npmrc property suffixes that are pnpm-specific.
+ * These are properties like "//registry.example.com/:tokenHelper" where "tokenHelper"
+ * is the suffix after the last colon.
+ */
+const NPM_INCOMPATIBLE_REGISTRY_SCOPED_PROPERTIES = new Set([
+    // pnpm-specific token helper properties
+    'tokenHelper',
+    'urlTokenHelper'
+]);
+/**
+ * Regular expression to extract property names from .npmrc lines.
+ * Matches everything before '=', '[', or whitespace to capture the property name.
+ * Note: The 'g' flag is intentionally omitted since we only need the first match.
+ * Examples:
+ *   "registry=https://..." -> matches "registry"
+ *   "hoist-pattern[]=..." -> matches "hoist-pattern"
+ */
+const PROPERTY_NAME_REGEX = /^([^=\[\s]+)/;
+/**
+ * Regular expression to extract environment variable names and optional fallback values.
+ * Matches patterns like:
+ *   nameString                 -> group 1: nameString,    group 2: undefined
+ *   nameString-fallbackString  -> group 1: nameString,    group 2: fallbackString
+ *   nameString:-fallbackString -> group 1: nameString,    group 2: fallbackString
+ */
+const ENV_VAR_WITH_FALLBACK_REGEX = /^(?<name>[^:-]+)(?::?-(?<fallback>.+))?$/;
 /**
  *
  * @param npmrcFileLines The npmrc file's lines
  * @param env The environment variables object
  * @param supportEnvVarFallbackSyntax Whether to support fallback values in the form of `${VAR_NAME:-fallback}`
- * @returns
+ * @param filterNpmIncompatibleProperties Whether to filter out properties that npm doesn't understand
+ * @returns An array of processed npmrc file lines with undefined environment variables and npm-incompatible properties commented out
  */
-function trimNpmrcFileLines(npmrcFileLines, env, supportEnvVarFallbackSyntax) {
-    var _a;
+function trimNpmrcFileLines(npmrcFileLines, env, supportEnvVarFallbackSyntax, filterNpmIncompatibleProperties = false) {
+    var _a, _b, _c;
     const resultLines = [];
     // This finds environment variable tokens that look like "${VAR_NAME}"
     const expansionRegExp = /\$\{([^\}]+)\}/g;
@@ -126,6 +153,7 @@ function trimNpmrcFileLines(npmrcFileLines, env, supportEnvVarFallbackSyntax) {
     // Trim out lines that reference environment variables that aren't defined
     for (let line of npmrcFileLines) {
         let lineShouldBeTrimmed = false;
+        let trimReason = '';
         //remove spaces before or after key and value
         line = line
             .split('=')
@@ -133,49 +161,89 @@ function trimNpmrcFileLines(npmrcFileLines, env, supportEnvVarFallbackSyntax) {
             .join('=');
         // Ignore comment lines
         if (!commentRegExp.test(line)) {
-            const environmentVariables = line.match(expansionRegExp);
-            if (environmentVariables) {
-                for (const token of environmentVariables) {
-                    /**
-                     * Remove the leading "${" and the trailing "}" from the token
-                     *
-                     * ${nameString}                  -> nameString
-                     * ${nameString-fallbackString}   -> name-fallbackString
-                     * ${nameString:-fallbackString}  -> name:-fallbackString
-                     */
-                    const nameWithFallback = token.substring(2, token.length - 1);
-                    let environmentVariableName;
-                    let fallback;
-                    if (supportEnvVarFallbackSyntax) {
-                        /**
-                         * Get the environment variable name and fallback value.
-                         *
-                         *                                name          fallback
-                         * nameString                 ->  nameString    undefined
-                         * nameString-fallbackString  ->  nameString    fallbackString
-                         * nameString:-fallbackString ->  nameString    fallbackString
-                         */
-                        const matched = nameWithFallback.match(/^([^:-]+)(?:\:?-(.+))?$/);
-                        // matched: [originStr, variableName, fallback]
-                        environmentVariableName = (_a = matched === null || matched === void 0 ? void 0 : matched[1]) !== null && _a !== void 0 ? _a : nameWithFallback;
-                        fallback = matched === null || matched === void 0 ? void 0 : matched[2];
+            // Check if this is a property that npm doesn't understand
+            if (filterNpmIncompatibleProperties) {
+                // Extract the property name (everything before the '=' or '[')
+                const match = line.match(PROPERTY_NAME_REGEX);
+                if (match) {
+                    const propertyName = match[1];
+                    // Check if this is a registry-scoped property (starts with "//" like "//registry.npmjs.org/:_authToken")
+                    const isRegistryScoped = propertyName.startsWith('//');
+                    if (isRegistryScoped) {
+                        // For registry-scoped properties, check if the suffix (after the last colon) is npm-incompatible
+                        // Example: "//registry.example.com/:tokenHelper" -> suffix is "tokenHelper"
+                        const lastColonIndex = propertyName.lastIndexOf(':');
+                        if (lastColonIndex !== -1) {
+                            const registryPropertySuffix = propertyName.substring(lastColonIndex + 1);
+                            if (NPM_INCOMPATIBLE_REGISTRY_SCOPED_PROPERTIES.has(registryPropertySuffix)) {
+                                lineShouldBeTrimmed = true;
+                                trimReason = 'NPM_INCOMPATIBLE_PROPERTY';
+                            }
+                        }
                     }
                     else {
-                        environmentVariableName = nameWithFallback;
+                        // For non-registry-scoped properties, check the full property name
+                        if (NPM_INCOMPATIBLE_PROPERTIES.has(propertyName)) {
+                            lineShouldBeTrimmed = true;
+                            trimReason = 'NPM_INCOMPATIBLE_PROPERTY';
+                        }
                     }
-                    // Is the environment variable and fallback value defined.
-                    if (!env[environmentVariableName] && !fallback) {
-                        // No, so trim this line
-                        lineShouldBeTrimmed = true;
-                        break;
+                }
+            }
+            // Check for undefined environment variables
+            if (!lineShouldBeTrimmed) {
+                const environmentVariables = line.match(expansionRegExp);
+                if (environmentVariables) {
+                    for (const token of environmentVariables) {
+                        /**
+                         * Remove the leading "${" and the trailing "}" from the token
+                         *
+                         * ${nameString}                  -> nameString
+                         * ${nameString-fallbackString}   -> name-fallbackString
+                         * ${nameString:-fallbackString}  -> name:-fallbackString
+                         */
+                        const nameWithFallback = token.slice(2, -1);
+                        let environmentVariableName;
+                        let fallback;
+                        if (supportEnvVarFallbackSyntax) {
+                            /**
+                             * Get the environment variable name and fallback value.
+                             *
+                             *                                name          fallback
+                             * nameString                 ->  nameString    undefined
+                             * nameString-fallbackString  ->  nameString    fallbackString
+                             * nameString:-fallbackString ->  nameString    fallbackString
+                             */
+                            const matched = nameWithFallback.match(ENV_VAR_WITH_FALLBACK_REGEX);
+                            environmentVariableName = (_b = (_a = matched === null || matched === void 0 ? void 0 : matched.groups) === null || _a === void 0 ? void 0 : _a.name) !== null && _b !== void 0 ? _b : nameWithFallback;
+                            fallback = (_c = matched === null || matched === void 0 ? void 0 : matched.groups) === null || _c === void 0 ? void 0 : _c.fallback;
+                        }
+                        else {
+                            environmentVariableName = nameWithFallback;
+                        }
+                        // Is the environment variable and fallback value defined.
+                        if (!env[environmentVariableName] && !fallback) {
+                            // No, so trim this line
+                            lineShouldBeTrimmed = true;
+                            trimReason = 'MISSING_ENVIRONMENT_VARIABLE';
+                            break;
+                        }
                     }
                 }
             }
         }
         if (lineShouldBeTrimmed) {
-            // Example output:
-            // "; MISSING ENVIRONMENT VARIABLE: //my-registry.com/npm/:_authToken=${MY_AUTH_TOKEN}"
-            resultLines.push('; MISSING ENVIRONMENT VARIABLE: ' + line);
+            // Comment out the line with appropriate reason
+            if (trimReason === 'NPM_INCOMPATIBLE_PROPERTY') {
+                // Example output:
+                // "; UNSUPPORTED BY NPM: email=test@example.com"
+                resultLines.push('; UNSUPPORTED BY NPM: ' + line);
+            }
+            else {
+                // Example output:
+                // "; MISSING ENVIRONMENT VARIABLE: //my-registry.com/npm/:_authToken=${MY_AUTH_TOKEN}"
+                resultLines.push('; MISSING ENVIRONMENT VARIABLE: ' + line);
+            }
         }
         else {
             resultLines.push(line);
@@ -188,7 +256,7 @@ function _copyAndTrimNpmrcFile(options) {
     logger.info(`Transforming ${sourceNpmrcPath}`); // Verbose
     logger.info(`  --> "${targetNpmrcPath}"`);
     const combinedNpmrc = _trimNpmrcFile(options);
-    fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(targetNpmrcPath, combinedNpmrc);
+    node_fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(targetNpmrcPath, combinedNpmrc);
     return combinedNpmrc;
 }
 function syncNpmrc(options) {
@@ -198,13 +266,13 @@ function syncNpmrc(options) {
         // eslint-disable-next-line no-console
         error: console.error
     }, createIfMissing = false } = options;
-    const sourceNpmrcPath = path__WEBPACK_IMPORTED_MODULE_1__.join(sourceNpmrcFolder, !useNpmrcPublish ? '.npmrc' : '.npmrc-publish');
-    const targetNpmrcPath = path__WEBPACK_IMPORTED_MODULE_1__.join(targetNpmrcFolder, '.npmrc');
+    const sourceNpmrcPath = node_path__WEBPACK_IMPORTED_MODULE_1__.join(sourceNpmrcFolder, !useNpmrcPublish ? '.npmrc' : '.npmrc-publish');
+    const targetNpmrcPath = node_path__WEBPACK_IMPORTED_MODULE_1__.join(targetNpmrcFolder, '.npmrc');
     try {
-        if (fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath) || createIfMissing) {
+        if (node_fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath) || createIfMissing) {
             // Ensure the target folder exists
-            if (!fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(targetNpmrcFolder)) {
-                fs__WEBPACK_IMPORTED_MODULE_0__.mkdirSync(targetNpmrcFolder, { recursive: true });
+            if (!node_fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(targetNpmrcFolder)) {
+                node_fs__WEBPACK_IMPORTED_MODULE_0__.mkdirSync(targetNpmrcFolder, { recursive: true });
             }
             return _copyAndTrimNpmrcFile({
                 sourceNpmrcPath,
@@ -213,10 +281,10 @@ function syncNpmrc(options) {
                 ...options
             });
         }
-        else if (fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(targetNpmrcPath)) {
+        else if (node_fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(targetNpmrcPath)) {
             // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
             logger.info(`Deleting ${targetNpmrcPath}`); // Verbose
-            fs__WEBPACK_IMPORTED_MODULE_0__.unlinkSync(targetNpmrcPath);
+            node_fs__WEBPACK_IMPORTED_MODULE_0__.unlinkSync(targetNpmrcPath);
         }
     }
     catch (e) {
@@ -226,16 +294,60 @@ function syncNpmrc(options) {
 function isVariableSetInNpmrcFile(sourceNpmrcFolder, variableKey, supportEnvVarFallbackSyntax) {
     const sourceNpmrcPath = `${sourceNpmrcFolder}/.npmrc`;
     //if .npmrc file does not exist, return false directly
-    if (!fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath)) {
+    if (!node_fs__WEBPACK_IMPORTED_MODULE_0__.existsSync(sourceNpmrcPath)) {
         return false;
     }
-    const trimmedNpmrcFile = _trimNpmrcFile({ sourceNpmrcPath, supportEnvVarFallbackSyntax });
+    const trimmedNpmrcFile = _trimNpmrcFile({
+        sourceNpmrcPath,
+        supportEnvVarFallbackSyntax,
+        filterNpmIncompatibleProperties: false
+    });
     const variableKeyRegExp = new RegExp(`^${variableKey}=`, 'm');
     return trimmedNpmrcFile.match(variableKeyRegExp) !== null;
 }
 //# sourceMappingURL=npmrcUtilities.js.map
 
-/***/ })
+/***/ },
+
+/***/ 731421
+/*!*************************************!*\
+  !*** external "node:child_process" ***!
+  \*************************************/
+(module) {
+
+module.exports = require("node:child_process");
+
+/***/ },
+
+/***/ 973024
+/*!**************************!*\
+  !*** external "node:fs" ***!
+  \**************************/
+(module) {
+
+module.exports = require("node:fs");
+
+/***/ },
+
+/***/ 848161
+/*!**************************!*\
+  !*** external "node:os" ***!
+  \**************************/
+(module) {
+
+module.exports = require("node:os");
+
+/***/ },
+
+/***/ 176760
+/*!****************************!*\
+  !*** external "node:path" ***!
+  \****************************/
+(module) {
+
+module.exports = require("node:path");
+
+/***/ }
 
 /******/ 	});
 /************************************************************************/
@@ -248,6 +360,12 @@ function isVariableSetInNpmrcFile(sourceNpmrcFolder, variableKey, supportEnvVarF
 /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
 /******/ 		if (cachedModule !== undefined) {
 /******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Check if module exists (development only)
+/******/ 		if (__webpack_modules__[moduleId] === undefined) {
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
@@ -308,9 +426,9 @@ function isVariableSetInNpmrcFile(sourceNpmrcFolder, variableKey, supportEnvVarF
 var __webpack_exports__ = {};
 // This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
-/*!*******************************************!*\
-  !*** ./lib-esnext/scripts/install-run.js ***!
-  \*******************************************/
+/*!*****************************************************!*\
+  !*** ./lib-intermediate-esm/scripts/install-run.js ***!
+  \*****************************************************/
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   RUSH_JSON_FILENAME: () => (/* binding */ RUSH_JSON_FILENAME),
@@ -319,18 +437,20 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   installAndRun: () => (/* binding */ installAndRun),
 /* harmony export */   runWithErrorAndStatusCode: () => (/* binding */ runWithErrorAndStatusCode)
 /* harmony export */ });
-/* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! child_process */ 535317);
-/* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(child_process__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! fs */ 179896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! os */ 370857);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(os__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! path */ 16928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var _utilities_npmrcUtilities__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../utilities/npmrcUtilities */ 832286);
+/* harmony import */ var node_child_process__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! node:child_process */ 731421);
+/* harmony import */ var node_child_process__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(node_child_process__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! node:fs */ 973024);
+/* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(node_fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! node:os */ 848161);
+/* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(node_os__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! node:path */ 176760);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(node_path__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _utilities_npmrcUtilities__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../utilities/npmrcUtilities */ 359480);
+/* harmony import */ var _utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../utilities/executionUtilities */ 953844);
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 /* eslint-disable no-console */
+
 
 
 
@@ -374,34 +494,34 @@ let _npmPath = undefined;
 function getNpmPath() {
     if (!_npmPath) {
         try {
-            if (_isWindows()) {
+            if (_utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.IS_WINDOWS) {
                 // We're on Windows
-                const whereOutput = child_process__WEBPACK_IMPORTED_MODULE_0__.execSync('where npm', { stdio: [] }).toString();
-                const lines = whereOutput.split(os__WEBPACK_IMPORTED_MODULE_2__.EOL).filter((line) => !!line);
+                const whereOutput = node_child_process__WEBPACK_IMPORTED_MODULE_0__.execSync('where npm', { stdio: [] }).toString();
+                const lines = whereOutput.split(node_os__WEBPACK_IMPORTED_MODULE_2__.EOL).filter((line) => !!line);
                 // take the last result, we are looking for a .cmd command
                 // see https://github.com/microsoft/rushstack/issues/759
                 _npmPath = lines[lines.length - 1];
             }
             else {
                 // We aren't on Windows - assume we're on *NIX or Darwin
-                _npmPath = child_process__WEBPACK_IMPORTED_MODULE_0__.execSync('command -v npm', { stdio: [] }).toString();
+                _npmPath = node_child_process__WEBPACK_IMPORTED_MODULE_0__.execSync('command -v npm', { stdio: [] }).toString();
             }
         }
         catch (e) {
             throw new Error(`Unable to determine the path to the NPM tool: ${e}`);
         }
         _npmPath = _npmPath.trim();
-        if (!fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(_npmPath)) {
+        if (!node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(_npmPath)) {
             throw new Error('The NPM executable does not exist');
         }
     }
     return _npmPath;
 }
 function _ensureFolder(folderPath) {
-    if (!fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(folderPath)) {
-        const parentDir = path__WEBPACK_IMPORTED_MODULE_3__.dirname(folderPath);
+    if (!node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(folderPath)) {
+        const parentDir = node_path__WEBPACK_IMPORTED_MODULE_3__.dirname(folderPath);
         _ensureFolder(parentDir);
-        fs__WEBPACK_IMPORTED_MODULE_1__.mkdirSync(folderPath);
+        node_fs__WEBPACK_IMPORTED_MODULE_1__.mkdirSync(folderPath);
     }
 }
 /**
@@ -415,14 +535,14 @@ function _ensureAndJoinPath(baseFolder, ...pathSegments) {
     try {
         for (let pathSegment of pathSegments) {
             pathSegment = pathSegment.replace(/[\\\/]/g, '+');
-            joinedPath = path__WEBPACK_IMPORTED_MODULE_3__.join(joinedPath, pathSegment);
-            if (!fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(joinedPath)) {
-                fs__WEBPACK_IMPORTED_MODULE_1__.mkdirSync(joinedPath);
+            joinedPath = node_path__WEBPACK_IMPORTED_MODULE_3__.join(joinedPath, pathSegment);
+            if (!node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(joinedPath)) {
+                node_fs__WEBPACK_IMPORTED_MODULE_1__.mkdirSync(joinedPath);
             }
         }
     }
     catch (e) {
-        throw new Error(`Error building local installation folder (${path__WEBPACK_IMPORTED_MODULE_3__.join(baseFolder, ...pathSegments)}): ${e}`);
+        throw new Error(`Error building local installation folder (${node_path__WEBPACK_IMPORTED_MODULE_3__.join(baseFolder, ...pathSegments)}): ${e}`);
     }
     return joinedPath;
 }
@@ -469,14 +589,16 @@ function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
         // version resolves to
         try {
             const rushTempFolder = _getRushTempFolder(rushCommonFolder);
-            const sourceNpmrcFolder = path__WEBPACK_IMPORTED_MODULE_3__.join(rushCommonFolder, 'config', 'rush');
+            const sourceNpmrcFolder = node_path__WEBPACK_IMPORTED_MODULE_3__.join(rushCommonFolder, 'config', 'rush');
             (0,_utilities_npmrcUtilities__WEBPACK_IMPORTED_MODULE_4__.syncNpmrc)({
                 sourceNpmrcFolder,
                 targetNpmrcFolder: rushTempFolder,
                 logger,
-                supportEnvVarFallbackSyntax: false
+                supportEnvVarFallbackSyntax: false,
+                // Always filter npm-incompatible properties in install-run scripts.
+                // Any warnings will be shown when running Rush commands directly.
+                filterNpmIncompatibleProperties: true
             });
-            const npmPath = getNpmPath();
             // This returns something that looks like:
             // ```
             // [
@@ -494,16 +616,11 @@ function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
             // ```
             //
             // if only a single version matches.
-            const spawnSyncOptions = {
+            const npmVersionSpawnResult = _runNpmConfirmSuccess(['view', `${name}@${version}`, 'version', '--no-update-notifier', '--json'], {
                 cwd: rushTempFolder,
                 stdio: [],
-                shell: _isWindows()
-            };
-            const platformNpmPath = _getPlatformPath(npmPath);
-            const npmVersionSpawnResult = child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(platformNpmPath, ['view', `${name}@${version}`, 'version', '--no-update-notifier', '--json'], spawnSyncOptions);
-            if (npmVersionSpawnResult.status !== 0) {
-                throw new Error(`"npm view" returned error code ${npmVersionSpawnResult.status}`);
-            }
+                env: process.env
+            }, 'npm view');
             const npmViewVersionOutput = npmVersionSpawnResult.stdout.toString();
             const parsedVersionOutput = JSON.parse(npmViewVersionOutput);
             const versions = Array.isArray(parsedVersionOutput)
@@ -535,15 +652,15 @@ function findRushJsonFolder() {
         let basePath = __dirname;
         let tempPath = __dirname;
         do {
-            const testRushJsonPath = path__WEBPACK_IMPORTED_MODULE_3__.join(basePath, RUSH_JSON_FILENAME);
-            if (fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(testRushJsonPath)) {
+            const testRushJsonPath = node_path__WEBPACK_IMPORTED_MODULE_3__.join(basePath, RUSH_JSON_FILENAME);
+            if (node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(testRushJsonPath)) {
                 _rushJsonFolder = basePath;
                 break;
             }
             else {
                 basePath = tempPath;
             }
-        } while (basePath !== (tempPath = path__WEBPACK_IMPORTED_MODULE_3__.dirname(basePath))); // Exit the loop when we hit the disk root
+        } while (basePath !== (tempPath = node_path__WEBPACK_IMPORTED_MODULE_3__.dirname(basePath))); // Exit the loop when we hit the disk root
         if (!_rushJsonFolder) {
             throw new Error(`Unable to find ${RUSH_JSON_FILENAME}.`);
         }
@@ -555,11 +672,11 @@ function findRushJsonFolder() {
  */
 function _isPackageAlreadyInstalled(packageInstallFolder) {
     try {
-        const flagFilePath = path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, INSTALLED_FLAG_FILENAME);
-        if (!fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(flagFilePath)) {
+        const flagFilePath = node_path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, INSTALLED_FLAG_FILENAME);
+        if (!node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(flagFilePath)) {
             return false;
         }
-        const fileContents = fs__WEBPACK_IMPORTED_MODULE_1__.readFileSync(flagFilePath).toString();
+        const fileContents = node_fs__WEBPACK_IMPORTED_MODULE_1__.readFileSync(flagFilePath).toString();
         return fileContents.trim() === process.version;
     }
     catch (e) {
@@ -571,7 +688,7 @@ function _isPackageAlreadyInstalled(packageInstallFolder) {
  */
 function _deleteFile(file) {
     try {
-        fs__WEBPACK_IMPORTED_MODULE_1__.unlinkSync(file);
+        node_fs__WEBPACK_IMPORTED_MODULE_1__.unlinkSync(file);
     }
     catch (err) {
         if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
@@ -587,19 +704,19 @@ function _deleteFile(file) {
  */
 function _cleanInstallFolder(rushTempFolder, packageInstallFolder, lockFilePath) {
     try {
-        const flagFile = path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, INSTALLED_FLAG_FILENAME);
+        const flagFile = node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, INSTALLED_FLAG_FILENAME);
         _deleteFile(flagFile);
-        const packageLockFile = path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, 'package-lock.json');
+        const packageLockFile = node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, 'package-lock.json');
         if (lockFilePath) {
-            fs__WEBPACK_IMPORTED_MODULE_1__.copyFileSync(lockFilePath, packageLockFile);
+            node_fs__WEBPACK_IMPORTED_MODULE_1__.copyFileSync(lockFilePath, packageLockFile);
         }
         else {
             // Not running `npm ci`, so need to cleanup
             _deleteFile(packageLockFile);
-            const nodeModulesFolder = path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME);
-            if (fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(nodeModulesFolder)) {
+            const nodeModulesFolder = node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME);
+            if (node_fs__WEBPACK_IMPORTED_MODULE_1__.existsSync(nodeModulesFolder)) {
                 const rushRecyclerFolder = _ensureAndJoinPath(rushTempFolder, 'rush-recycler');
-                fs__WEBPACK_IMPORTED_MODULE_1__.renameSync(nodeModulesFolder, path__WEBPACK_IMPORTED_MODULE_3__.join(rushRecyclerFolder, `install-run-${Date.now().toString()}`));
+                node_fs__WEBPACK_IMPORTED_MODULE_1__.renameSync(nodeModulesFolder, node_path__WEBPACK_IMPORTED_MODULE_3__.join(rushRecyclerFolder, `install-run-${Date.now().toString()}`));
             }
         }
     }
@@ -619,8 +736,8 @@ function _createPackageJson(packageInstallFolder, name, version) {
             repository: "DON'T WARN",
             license: 'MIT'
         };
-        const packageJsonPath = path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, PACKAGE_JSON_FILENAME);
-        fs__WEBPACK_IMPORTED_MODULE_1__.writeFileSync(packageJsonPath, JSON.stringify(packageJsonContents, undefined, 2));
+        const packageJsonPath = node_path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, PACKAGE_JSON_FILENAME);
+        node_fs__WEBPACK_IMPORTED_MODULE_1__.writeFileSync(packageJsonPath, JSON.stringify(packageJsonContents, undefined, 2));
     }
     catch (e) {
         throw new Error(`Unable to create package.json: ${e}`);
@@ -629,20 +746,14 @@ function _createPackageJson(packageInstallFolder, name, version) {
 /**
  * Run "npm install" in the package install folder.
  */
-function _installPackage(logger, packageInstallFolder, name, version, command) {
+function _installPackage(logger, packageInstallFolder, name, version, npmCommand) {
     try {
         logger.info(`Installing ${name}...`);
-        const npmPath = getNpmPath();
-        const platformNpmPath = _getPlatformPath(npmPath);
-        const result = child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(platformNpmPath, [command], {
+        _runNpmConfirmSuccess([npmCommand], {
             stdio: 'inherit',
             cwd: packageInstallFolder,
-            env: process.env,
-            shell: _isWindows()
-        });
-        if (result.status !== 0) {
-            throw new Error(`"npm ${command}" encountered an error`);
-        }
+            env: process.env
+        }, `npm ${npmCommand}`);
         logger.info(`Successfully installed ${name}@${version}`);
     }
     catch (e) {
@@ -653,72 +764,113 @@ function _installPackage(logger, packageInstallFolder, name, version, command) {
  * Get the ".bin" path for the package.
  */
 function _getBinPath(packageInstallFolder, binName) {
-    const binFolderPath = path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
-    const resolvedBinName = _isWindows() ? `${binName}.cmd` : binName;
-    return path__WEBPACK_IMPORTED_MODULE_3__.resolve(binFolderPath, resolvedBinName);
+    const binFolderPath = node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
+    const resolvedBinName = _utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.IS_WINDOWS ? `${binName}.cmd` : binName;
+    return node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(binFolderPath, resolvedBinName);
 }
-/**
- * Returns a cross-platform path - windows must enclose any path containing spaces within double quotes.
- */
-function _getPlatformPath(platformPath) {
-    return _isWindows() && platformPath.includes(' ') ? `"${platformPath}"` : platformPath;
-}
-function _isWindows() {
-    return os__WEBPACK_IMPORTED_MODULE_2__.platform() === 'win32';
+function _buildShellCommand(command, args) {
+    const escapedCommand = (0,_utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.escapeArgumentIfNeeded)(command);
+    const escapedArgs = args.map((arg) => (0,_utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.escapeArgumentIfNeeded)(arg));
+    return [escapedCommand, ...escapedArgs].join(' ');
 }
 /**
  * Write a flag file to the package's install directory, signifying that the install was successful.
  */
 function _writeFlagFile(packageInstallFolder) {
     try {
-        const flagFilePath = path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, INSTALLED_FLAG_FILENAME);
-        fs__WEBPACK_IMPORTED_MODULE_1__.writeFileSync(flagFilePath, process.version);
+        const flagFilePath = node_path__WEBPACK_IMPORTED_MODULE_3__.join(packageInstallFolder, INSTALLED_FLAG_FILENAME);
+        node_fs__WEBPACK_IMPORTED_MODULE_1__.writeFileSync(flagFilePath, process.version);
     }
     catch (e) {
         throw new Error(`Unable to create installed.flag file in ${packageInstallFolder}`);
     }
 }
+/**
+ * Run npm under the platform's shell and throw if it didn't succeed.
+ */
+function _runNpmConfirmSuccess(args, options, commandNameForLogging) {
+    const command = getNpmPath();
+    let result;
+    if (_utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.IS_WINDOWS) {
+        result = node_child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(_buildShellCommand(command, args), {
+            ...options,
+            shell: true,
+            windowsVerbatimArguments: false
+        });
+    }
+    else {
+        result = node_child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(command, args, options);
+    }
+    if (result.status !== 0) {
+        if (!result.status) {
+            // Is status null or undefined?
+            if (result.error) {
+                throw new Error(`"${commandNameForLogging}" failed: ${result.error.message.toString()}`);
+            }
+            else if (result.signal) {
+                throw new Error(`"${commandNameForLogging}" was terminated by signal: ${result.signal}`);
+            }
+            else {
+                throw new Error(`"${commandNameForLogging}" failed for an unknown reason`);
+            }
+        }
+        else {
+            throw new Error(`"${commandNameForLogging}" returned error code ${result.status}`);
+        }
+    }
+    return result;
+}
 function installAndRun(logger, packageName, packageVersion, packageBinName, packageBinArgs, lockFilePath = process.env[INSTALL_RUN_LOCKFILE_PATH_VARIABLE]) {
     const rushJsonFolder = findRushJsonFolder();
-    const rushCommonFolder = path__WEBPACK_IMPORTED_MODULE_3__.join(rushJsonFolder, 'common');
+    const rushCommonFolder = node_path__WEBPACK_IMPORTED_MODULE_3__.join(rushJsonFolder, 'common');
     const rushTempFolder = _getRushTempFolder(rushCommonFolder);
     const packageInstallFolder = _ensureAndJoinPath(rushTempFolder, 'install-run', `${packageName}@${packageVersion}`);
     if (!_isPackageAlreadyInstalled(packageInstallFolder)) {
         // The package isn't already installed
         _cleanInstallFolder(rushTempFolder, packageInstallFolder, lockFilePath);
-        const sourceNpmrcFolder = path__WEBPACK_IMPORTED_MODULE_3__.join(rushCommonFolder, 'config', 'rush');
+        const sourceNpmrcFolder = node_path__WEBPACK_IMPORTED_MODULE_3__.join(rushCommonFolder, 'config', 'rush');
         (0,_utilities_npmrcUtilities__WEBPACK_IMPORTED_MODULE_4__.syncNpmrc)({
             sourceNpmrcFolder,
             targetNpmrcFolder: packageInstallFolder,
             logger,
-            supportEnvVarFallbackSyntax: false
+            supportEnvVarFallbackSyntax: false,
+            // Always filter npm-incompatible properties in install-run scripts.
+            // Any warnings will be shown when running Rush commands directly.
+            filterNpmIncompatibleProperties: true
         });
         _createPackageJson(packageInstallFolder, packageName, packageVersion);
-        const command = lockFilePath ? 'ci' : 'install';
-        _installPackage(logger, packageInstallFolder, packageName, packageVersion, command);
+        const installCommand = lockFilePath ? 'ci' : 'install';
+        _installPackage(logger, packageInstallFolder, packageName, packageVersion, installCommand);
         _writeFlagFile(packageInstallFolder);
     }
     const statusMessage = `Invoking "${packageBinName} ${packageBinArgs.join(' ')}"`;
     const statusMessageLine = new Array(statusMessage.length + 1).join('-');
     logger.info('\n' + statusMessage + '\n' + statusMessageLine + '\n');
     const binPath = _getBinPath(packageInstallFolder, packageBinName);
-    const binFolderPath = path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
+    const binFolderPath = node_path__WEBPACK_IMPORTED_MODULE_3__.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
     // Windows environment variables are case-insensitive.  Instead of using SpawnSyncOptions.env, we need to
     // assign via the process.env proxy to ensure that we append to the right PATH key.
     const originalEnvPath = process.env.PATH || '';
     let result;
     try {
-        // `npm` bin stubs on Windows are `.cmd` files
-        // Node.js will not directly invoke a `.cmd` file unless `shell` is set to `true`
-        const platformBinPath = _getPlatformPath(binPath);
-        process.env.PATH = [binFolderPath, originalEnvPath].join(path__WEBPACK_IMPORTED_MODULE_3__.delimiter);
-        result = child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(platformBinPath, packageBinArgs, {
+        process.env.PATH = [binFolderPath, originalEnvPath].join(node_path__WEBPACK_IMPORTED_MODULE_3__.delimiter);
+        const spawnOptions = {
             stdio: 'inherit',
-            windowsVerbatimArguments: false,
-            shell: _isWindows(),
             cwd: process.cwd(),
             env: process.env
-        });
+        };
+        if (_utilities_executionUtilities__WEBPACK_IMPORTED_MODULE_5__.IS_WINDOWS) {
+            result = node_child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(_buildShellCommand(binPath, packageBinArgs), {
+                ...spawnOptions,
+                windowsVerbatimArguments: false,
+                // `npm` bin stubs on Windows are `.cmd` files
+                // Node.js will not directly invoke a `.cmd` file unless `shell` is set to `true`
+                shell: true
+            });
+        }
+        else {
+            result = node_child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(binPath, packageBinArgs, spawnOptions);
+        }
     }
     finally {
         process.env.PATH = originalEnvPath;
@@ -743,9 +895,10 @@ function runWithErrorAndStatusCode(logger, fn) {
 function _run() {
     const [nodePath /* Ex: /bin/node */, scriptPath /* /repo/common/scripts/install-run-rush.js */, rawPackageSpecifier /* qrcode@^1.2.0 */, packageBinName /* qrcode */, ...packageBinArgs /* [-f, myproject/lib] */] = process.argv;
     if (!nodePath) {
-        throw new Error('Unexpected exception: could not detect node path');
+        throw new Error('Could not detect node path');
     }
-    if (path__WEBPACK_IMPORTED_MODULE_3__.basename(scriptPath).toLowerCase() !== 'install-run.js') {
+    const scriptFileName = node_path__WEBPACK_IMPORTED_MODULE_3__.basename(scriptPath).toLowerCase();
+    if (scriptFileName !== 'install-run.js' && scriptFileName !== 'install-run') {
         // If install-run.js wasn't directly invoked, don't execute the rest of this function. Return control
         // to the script that (presumably) imported this file
         return;

--- a/packages/common/src/ahp-mapper.test.ts
+++ b/packages/common/src/ahp-mapper.test.ts
@@ -158,13 +158,33 @@ describe("text", () => {
     expect(result.note?.disposition).toBe("mapped");
   });
 
-  it("drops when no active turn", () => {
+  it("orphan-wraps when no active turn", () => {
     const context = makeContext();
     const event = makeEvent("text", { content: "Hello" });
     const result = mapAgentEvent(event, 3, context);
 
-    expect(result.actions.length).toBe(0);
-    expect(result.note?.disposition).toBe("dropped");
+    // [TurnStarted, ResponsePart, TurnComplete]
+    expect(result.actions.length).toBe(3);
+    assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnStarted,
+      0,
+    );
+    const part = assertActionType<{ type: string; turnId: string; part: { content: string } }>(
+      result.actions,
+      ActionType.SessionResponsePart,
+      1,
+    );
+    expect(part.part.content).toBe("Hello");
+    assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnComplete,
+      2,
+    );
+    expect(result.note?.disposition).toBe("mapped");
+    expect(result.note?.detail).toContain("turn-orphan-3");
+    // Orphan turn is self-contained — context cleared afterward
+    expect(context.turnId).toBeUndefined();
   });
 });
 
@@ -218,13 +238,32 @@ describe("tool_use", () => {
     expect(context.openToolCalls).toEqual(["tc-10"]);
   });
 
-  it("drops when no active turn", () => {
+  it("orphan-wraps when no active turn", () => {
     const context = makeContext();
-    const event = makeEvent("tool_use", { content: "{}" });
+    const event = makeEvent("tool_use", {
+      content: JSON.stringify({ tool_name: "read_file" }),
+    });
     const result = mapAgentEvent(event, 4, context);
 
-    expect(result.actions.length).toBe(0);
-    expect(result.note?.disposition).toBe("dropped");
+    // [TurnStarted, ToolCallStart, ToolCallReady, TurnComplete]
+    expect(result.actions.length).toBe(4);
+    const started = assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnStarted,
+      0,
+    );
+    expect(started.turnId).toBe("turn-orphan-4");
+    assertActionType<{ type: string }>(result.actions, ActionType.SessionToolCallStart, 1);
+    assertActionType<{ type: string }>(result.actions, ActionType.SessionToolCallReady, 2);
+    assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnComplete,
+      3,
+    );
+    expect(result.note?.disposition).toBe("mapped");
+    // Orphan turn clears context
+    expect(context.turnId).toBeUndefined();
+    expect(context.openToolCalls).toEqual([]);
   });
 });
 
@@ -311,13 +350,34 @@ describe("tool_result", () => {
     expect(result.note?.disposition).toBe("mapped");
   });
 
-  it("drops when no active turn", () => {
-    const context = makeContext({ openToolCalls: ["tc-xyz"] });
-    const event = makeEvent("tool_result", { toolCallId: "tc-xyz", content: "{}" });
+  it("orphan-wraps when no active turn", () => {
+    // No active turn — synthesizes a complete orphan turn containing the tool result.
+    // Use toolError:true so no system notification is appended (clean 3-action sequence).
+    const context = makeContext({ openToolCalls: [], partCounter: 0 });
+    const event = makeEvent("tool_result", { toolError: true });
     const result = mapAgentEvent(event, 5, context);
 
-    expect(result.actions.length).toBe(0);
-    expect(result.note?.disposition).toBe("dropped");
+    // [TurnStarted, ToolCallComplete, TurnComplete]
+    expect(result.actions.length).toBe(3);
+    assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnStarted,
+      0,
+    );
+    const complete = assertActionType<{ type: string; toolCallId: string }>(
+      result.actions,
+      ActionType.SessionToolCallComplete,
+      1,
+    );
+    // Synthesized tc-orphan-result-* id (no prior tool_use to pair with)
+    expect(complete.toolCallId).toMatch(/^tc-orphan-result-/);
+    assertActionType<{ type: string; turnId: string }>(
+      result.actions,
+      ActionType.SessionTurnComplete,
+      2,
+    );
+    expect(result.note?.disposition).toBe("mapped");
+    expect(context.turnId).toBeUndefined();
   });
 });
 
@@ -424,13 +484,20 @@ describe("error", () => {
     expect(context.turnId).toBeUndefined();
   });
 
-  it("clears context.turnId so subsequent text events are dropped after in-turn error", () => {
+  it("clears context.turnId so subsequent text events are orphan-wrapped (not attributed to defunct turn) after in-turn error", () => {
     const context = makeContext({ turnId: "turn-abc" });
     mapAgentEvent(makeEvent("error", { content: "Oops" }), 7, context);
+    // turnId must be undefined after the error — text must NOT map into the defunct turn
+    expect(context.turnId).toBeUndefined();
 
     const textResult = mapAgentEvent(makeEvent("text", { content: "After error" }), 8, context);
-    expect(textResult.actions.length).toBe(0);
-    expect(textResult.note?.disposition).toBe("dropped");
+    // Orphan-wrapped in its own synthetic turn (not dropped — content is preserved)
+    expect(textResult.actions.length).toBe(3); // TurnStarted + ResponsePart + TurnComplete
+    const turnStarted = textResult.actions[0] as { turnId: string };
+    // The orphan turn id is derived from the event index, NOT the defunct "turn-abc"
+    expect(turnStarted.turnId).toMatch(/^turn-orphan-/);
+    expect(turnStarted.turnId).not.toBe("turn-abc");
+    expect(textResult.note?.disposition).toBe("mapped");
   });
 
   it("maps to SessionCreationFailed when pre-turn", () => {
@@ -535,13 +602,38 @@ describe("system", () => {
     expect(result.note?.detail).toContain("diagnostic");
   });
 
-  it("drops non-diagnostic system when no active turn", () => {
+  it("orphan-wraps non-diagnostic system when no active turn", () => {
     const context = makeContext();
     const event = makeEvent("system", { content: "Subagent completed" });
     const result = mapAgentEvent(event, 11, context);
 
+    // [TurnStarted, ResponsePart(systemNotification), TurnComplete]
+    expect(result.actions.length).toBe(3);
+    assertActionType<{ type: string }>(result.actions, ActionType.SessionTurnStarted, 0);
+    const part = assertActionType<{ type: string; part: { kind: string; content: string } }>(
+      result.actions,
+      ActionType.SessionResponsePart,
+      1,
+    );
+    expect(part.part.kind).toBe("systemNotification");
+    expect(part.part.content).toBe("Subagent completed");
+    assertActionType<{ type: string }>(result.actions, ActionType.SessionTurnComplete, 2);
+    expect(result.note?.disposition).toBe("mapped");
+    expect(context.turnId).toBeUndefined();
+  });
+
+  it("drops diagnostic system even when no active turn (never orphan-wrapped)", () => {
+    const context = makeContext();
+    const event = makeEvent("system", {
+      diagnostic: true,
+      content: JSON.stringify({ level: "info", msg: "diagnostic" }),
+    });
+    const result = mapAgentEvent(event, 12, context);
+
     expect(result.actions.length).toBe(0);
-    expect(result.note?.disposition).toBe("dropped");
+    expect(result.note?.disposition).toBe("carried");
+    // Context unchanged — no synthetic turn was created
+    expect(context.turnId).toBeUndefined();
   });
 });
 

--- a/packages/common/src/ahp-mapper.ts
+++ b/packages/common/src/ahp-mapper.ts
@@ -214,6 +214,66 @@ function str(parsed: Record<string, unknown>, fields: string[], fallback: string
 }
 
 /**
+ * Resolve the active turn for a substantive content event, synthesizing an orphan
+ * turn when none is present.
+ *
+ * - **Active-turn path:** calls `build(turnId)` against the existing turn and returns
+ *   the result as-is.
+ * - **Orphan path:** when no turn is active (`eventTurnId` and `context.turnId` are both
+ *   absent), synthesizes a complete one-shot turn (`turn-orphan-${index}`), runs `build`
+ *   inside it, and wraps the actions as
+ *   `[SessionTurnStarted, ...build.actions, SessionTurnComplete]`. `context.turnId` and
+ *   `context.openToolCalls` are cleared afterward (turn-complete semantics).
+ *
+ * This replaces PowerLine's former forwarder-side orphan rescue (HR8d), moving the
+ * lossless-translation concern into the mapper where it belongs.
+ *
+ * Invariant (content events): the mapper never silently drops a substantive content
+ * event. Only advisory events (`input_needed`) and diagnostic `system` events
+ * (OTLP-routed) may be dropped/carried. Status events are intercepted by the
+ * forwarder's `_meta` tunnel before reaching the mapper in production; their
+ * mapper-side drop branches are a temporary artifact of the HR8d tunnel (#1348/#1343).
+ */
+function withTurn(
+  index: number,
+  type: string,
+  context: MapperContext,
+  eventTurnId: string | undefined,
+  build: (turnId: string) => { actions: StateAction[]; detail: string },
+): MapResult {
+  const active = eventTurnId || context.turnId;
+  if (active) {
+    const { actions, detail } = build(active);
+    return { actions, note: { index, type, disposition: "mapped", detail } };
+  }
+  // No active turn — synthesize a complete one-shot orphan turn to contain the event.
+  const orphanTurnId = `turn-orphan-${index}`;
+  context.turnId = orphanTurnId;
+  context.openToolCalls = []; // turn_started semantics
+  const { actions, detail } = build(orphanTurnId);
+  const wrapped: StateAction[] = [
+    {
+      type: ActionType.SessionTurnStarted,
+      turnId: orphanTurnId,
+      message: { text: "", origin: { kind: MessageKind.User } },
+    },
+    ...actions,
+    { type: ActionType.SessionTurnComplete, turnId: orphanTurnId },
+  ];
+  context.turnId = undefined; // turn_complete semantics
+  context.openToolCalls = [];
+  return {
+    actions: wrapped,
+    note: {
+      index,
+      type,
+      disposition: "mapped",
+      detail: `Orphan-wrapped in ${orphanTurnId}: ${detail}`,
+    },
+  };
+}
+
+/**
  * Map a PowerLine `AgentEvent` into AHP `SessionAction` payloads.
  *
  * | AgentEvent type | AHP action(s) | Disposition |
@@ -221,17 +281,21 @@ function str(parsed: Record<string, unknown>, fields: string[], fallback: string
  * | `turn_started` | `SessionTurnStarted` | mapped |
  * | `turn_complete` | `SessionTurnComplete` | mapped |
  * | `input_needed` | advisory only | dropped |
- * | `text` | `SessionResponsePart(markdown)` | mapped |
- * | `tool_use` | `SessionToolCallStart` + `SessionToolCallReady` | mapped |
- * | `tool_result` | `SessionToolCallComplete` | mapped |
+ * | `text` (with turn) | `SessionResponsePart(markdown)` | mapped |
+ * | `text` (no turn) | `SessionTurnStarted` + part + `SessionTurnComplete` | mapped (orphan) |
+ * | `tool_use` (with turn) | `SessionToolCallStart` + `SessionToolCallReady` | mapped |
+ * | `tool_use` (no turn) | orphan-wrapped Start + Ready | mapped (orphan) |
+ * | `tool_result` (with turn) | `SessionToolCallComplete` | mapped |
+ * | `tool_result` (no turn) | orphan-wrapped Complete | mapped (orphan) |
  * | `usage` | (none — cost accumulated in `_meta`) | carried |
  * | `error` (in-turn) | `SessionError` | mapped |
  * | `error` (pre-turn) | `SessionCreationFailed` | mapped |
- * | `status: failed` | `SessionError` or `SessionCreationFailed` | mapped |
- * | `status: killed/terminated` | `SessionError` (abandoned turn) | conditional |
- * | `status: completed/waiting_input/running` | dropped | dropped |
+ * | `status: failed` | `SessionError` or `SessionCreationFailed` | mapped (dead — forwarder tunnel intercepts) |
+ * | `status: killed/terminated` | `SessionError` (abandoned turn) | conditional (dead — forwarder tunnel intercepts) |
+ * | `status: completed/waiting_input/running` | dropped (dead — forwarder tunnel intercepts) | dropped |
  * | `system` (diagnostic) | dropped (OTLP telemetry) | carried |
- * | `system` (non-diagnostic) | `SessionResponsePart(systemNotification)` | mapped |
+ * | `system` (non-diagnostic, with turn) | `SessionResponsePart(systemNotification)` | mapped |
+ * | `system` (non-diagnostic, no turn) | orphan-wrapped systemNotification | mapped (orphan) |
  * | `runtime_session_id` | `_meta.runtimeSessionId` | carried |
  */
 export function mapAgentEvent(
@@ -319,196 +383,162 @@ export function mapAgentEvent(
     // ─── Response parts ────────────────────────────────────────────
 
     case "text": {
-      const turnId = eventTurnId || context.turnId;
-      if (!turnId) {
-        note = {
-          index,
-          type: "text",
-          disposition: "dropped",
-          detail: "No active turn for text part",
+      const wt = withTurn(index, "text", context, eventTurnId, (tid) => {
+        const partId = `part-${context.partCounter++}`;
+        return {
+          actions: [
+            {
+              type: ActionType.SessionResponsePart,
+              turnId: tid,
+              part: { kind: ResponsePartKind.Markdown, id: partId, content: content || "" },
+            } as StateAction,
+          ],
+          detail: `Mapped to SessionResponsePart (partId=${partId})`,
         };
-        break;
-      }
-
-      const partId = `part-${context.partCounter++}`;
-      actions.push({
-        type: ActionType.SessionResponsePart,
-        turnId,
-        part: {
-          kind: ResponsePartKind.Markdown,
-          id: partId,
-          content: content || "",
-        },
       });
-
-      note = {
-        index,
-        type: "text",
-        disposition: "mapped",
-        detail: `Mapped to SessionResponsePart (partId=${partId})`,
-      };
+      actions.push(...wt.actions);
+      note = wt.note;
       break;
     }
 
     // ─── Tool calls ────────────────────────────────────────────────
 
     case "tool_use": {
-      const turnId = eventTurnId || context.turnId;
-      if (!turnId) {
-        note = {
-          index,
-          type: "tool_use",
-          disposition: "dropped",
-          detail: "No active turn for tool_use",
-        };
-        break;
-      }
-
-      const toolCallIdValue = toolCallId || `tc-${context.partCounter++}`;
-      // Accept the legacy `tool` key alongside `tool_name`/`name`. Production
-      // runtimes (Claude Code, Copilot, Codex) serialize their tool_use content
-      // as `{tool, args}` — only the runScenario stub fixture uses `tool_name`.
-      // Without this fallback the reverse mapper sees "unknown_tool" for every
-      // real runtime, losing the actual tool identity on the wire.
-      const toolName = hasParsed
-        ? str(parsed, ["tool_name", "name", "tool"], "unknown_tool")
-        : "unknown_tool";
-      const displayName = hasParsed ? str(parsed, ["display_name"], toolName) : toolName;
-      const invocationMessage = hasParsed
-        ? str(parsed, ["invocation_message"], `Running ${toolName}`)
-        : `Running ${toolName}`;
-      // Serialize args as `toolInput` (AHP-spec field on SessionToolCallReady)
-      // so the consumer can rehydrate them. The mapper sees several arg shapes:
-      // `args` (stub + Claude Code), `input` (Claude Code raw form on some
-      // paths), `arguments` (Copilot). Preserve the first that's present.
-      let toolInput: string | undefined;
-      if (hasParsed) {
-        const argsValue =
-          (parsed as Record<string, unknown>).args ??
-          (parsed as Record<string, unknown>).input ??
-          (parsed as Record<string, unknown>).arguments;
-        if (argsValue !== undefined) {
-          try {
-            toolInput = JSON.stringify(argsValue);
-          } catch {
-            /* circular / unserializable — skip the toolInput field. */
+      const wt = withTurn(index, "tool_use", context, eventTurnId, (tid) => {
+        const toolCallIdValue = toolCallId || `tc-${context.partCounter++}`;
+        // Accept the legacy `tool` key alongside `tool_name`/`name`. Production
+        // runtimes (Claude Code, Copilot, Codex) serialize their tool_use content
+        // as `{tool, args}` — only the runScenario stub fixture uses `tool_name`.
+        // Without this fallback the reverse mapper sees "unknown_tool" for every
+        // real runtime, losing the actual tool identity on the wire.
+        const toolName = hasParsed
+          ? str(parsed, ["tool_name", "name", "tool"], "unknown_tool")
+          : "unknown_tool";
+        const displayName = hasParsed ? str(parsed, ["display_name"], toolName) : toolName;
+        const invocationMessage = hasParsed
+          ? str(parsed, ["invocation_message"], `Running ${toolName}`)
+          : `Running ${toolName}`;
+        // Serialize args as `toolInput` (AHP-spec field on SessionToolCallReady)
+        // so the consumer can rehydrate them. The mapper sees several arg shapes:
+        // `args` (stub + Claude Code), `input` (Claude Code raw form on some
+        // paths), `arguments` (Copilot). Preserve the first that's present.
+        let toolInput: string | undefined;
+        if (hasParsed) {
+          const argsValue =
+            (parsed as Record<string, unknown>).args ??
+            (parsed as Record<string, unknown>).input ??
+            (parsed as Record<string, unknown>).arguments;
+          if (argsValue !== undefined) {
+            try {
+              toolInput = JSON.stringify(argsValue);
+            } catch {
+              /* circular / unserializable — skip the toolInput field. */
+            }
           }
         }
-      }
-
-      // SessionToolCallStart
-      actions.push({
-        type: ActionType.SessionToolCallStart,
-        turnId,
-        toolCallId: toolCallIdValue,
-        toolName,
-        displayName,
+        context.openToolCalls.push(toolCallIdValue);
+        return {
+          actions: [
+            // SessionToolCallStart
+            {
+              type: ActionType.SessionToolCallStart,
+              turnId: tid,
+              toolCallId: toolCallIdValue,
+              toolName,
+              displayName,
+            } as StateAction,
+            // SessionToolCallReady with auto-confirmation
+            {
+              type: ActionType.SessionToolCallReady,
+              turnId: tid,
+              toolCallId: toolCallIdValue,
+              invocationMessage,
+              confirmed: ToolCallConfirmationReason.NotNeeded,
+              ...(toolInput !== undefined ? { toolInput } : {}),
+            } as StateAction,
+          ],
+          detail: `Mapped to SessionToolCallStart + SessionToolCallReady (toolCallId=${toolCallIdValue})`,
+        };
       });
-
-      // SessionToolCallReady with auto-confirmation
-      actions.push({
-        type: ActionType.SessionToolCallReady,
-        turnId,
-        toolCallId: toolCallIdValue,
-        invocationMessage,
-        confirmed: ToolCallConfirmationReason.NotNeeded,
-        ...(toolInput !== undefined ? { toolInput } : {}),
-      });
-
-      context.openToolCalls.push(toolCallIdValue);
-
-      note = {
-        index,
-        type: "tool_use",
-        disposition: "mapped",
-        detail: `Mapped to SessionToolCallStart + SessionToolCallReady (toolCallId=${toolCallIdValue})`,
-      };
+      actions.push(...wt.actions);
+      note = wt.note;
       break;
     }
 
     case "tool_result": {
-      const turnId = eventTurnId || context.turnId;
-      if (!turnId) {
-        note = {
-          index,
-          type: "tool_result",
-          disposition: "dropped",
-          detail: "No active turn for tool_result",
-        };
-        break;
-      }
+      const wt = withTurn(index, "tool_result", context, eventTurnId, (tid) => {
+        // Pair by first-class toolCallId (HR3), with LIFO stack fallback.
+        // HR8d: when no tool_use precedes (an "unpaired tool_result" — legal
+        // under the gRPC wire and exercised by the tool-result-accordion
+        // E2E test), synthesize an id rather than dropping. The reverse
+        // mapper emits a tool_result with the synthetic id, the UI's
+        // pairToolEvents finds no matching tool_use in `toolUseById`, and
+        // the event falls through to the unpaired tool-card render path
+        // (GenericToolCard). Dropping silently masked the event entirely.
+        const pairedToolCallId =
+          toolCallId || context.openToolCalls.pop() || `tc-orphan-result-${context.partCounter++}`;
 
-      // Pair by first-class toolCallId (HR3), with LIFO stack fallback.
-      // HR8d: when no tool_use precedes (an "unpaired tool_result" — legal
-      // under the gRPC wire and exercised by the tool-result-accordion
-      // E2E test), synthesize an id rather than dropping. The reverse
-      // mapper emits a tool_result with the synthetic id, the UI's
-      // pairToolEvents finds no matching tool_use in `toolUseById`, and
-      // the event falls through to the unpaired tool-card render path
-      // (GenericToolCard). Dropping silently masked the event entirely.
-      const pairedToolCallId =
-        toolCallId || context.openToolCalls.pop() || `tc-orphan-result-${context.partCounter++}`;
-
-      // Remove matched id from stack when first-class toolCallId is provided
-      if (toolCallId) {
-        const idx = context.openToolCalls.indexOf(toolCallId);
-        if (idx !== -1) {
-          context.openToolCalls.splice(idx, 1);
+        // Remove matched id from stack when first-class toolCallId is provided
+        if (toolCallId) {
+          const idx = context.openToolCalls.indexOf(toolCallId);
+          if (idx !== -1) {
+            context.openToolCalls.splice(idx, 1);
+          }
         }
-      }
 
-      // The first-class `toolError` field (#1362) is authoritative — every
-      // runtime adapter sets it from its native outcome signal, which the AHP
-      // wire would otherwise lose (it doesn't carry `raw`). Fall back to the
-      // content `is_ok`/`success` keys only when `toolError` is absent (e.g.
-      // legacy/replayed events reconstructed from `content` by the reverse
-      // mapper), defaulting to success when nothing indicates failure.
-      const isOk =
-        event.toolError !== undefined
-          ? !event.toolError
-          : hasParsed
-            ? "is_ok" in parsed
-              ? parsed.is_ok === true
-              : "success" in parsed
-                ? parsed.success === true
-                : true
-            : true;
-      const pastTenseMessage = hasParsed
-        ? str(parsed, ["past_tense_message"], content || "")
-        : content || "";
-      const resultText = hasParsed ? str(parsed, ["content"], content || "") : content || "";
+        // The first-class `toolError` field (#1362) is authoritative — every
+        // runtime adapter sets it from its native outcome signal, which the AHP
+        // wire would otherwise lose (it doesn't carry `raw`). Fall back to the
+        // content `is_ok`/`success` keys only when `toolError` is absent (e.g.
+        // legacy/replayed events reconstructed from `content` by the reverse
+        // mapper), defaulting to success when nothing indicates failure.
+        const isOk =
+          event.toolError !== undefined
+            ? !event.toolError
+            : hasParsed
+              ? "is_ok" in parsed
+                ? parsed.is_ok === true
+                : "success" in parsed
+                  ? parsed.success === true
+                  : true
+              : true;
+        const pastTenseMessage = hasParsed
+          ? str(parsed, ["past_tense_message"], content || "")
+          : content || "";
+        const resultText = hasParsed ? str(parsed, ["content"], content || "") : content || "";
 
-      actions.push({
-        type: ActionType.SessionToolCallComplete,
-        turnId,
-        toolCallId: pairedToolCallId,
-        result: {
-          success: isOk,
-          pastTenseMessage,
-          content: isOk ? [makeTextResult(resultText)] : undefined,
-          error: isOk ? undefined : { message: pastTenseMessage },
-        },
-      });
-
-      // System notification for successful result
-      if (isOk && content) {
-        const displayText = resultText.length > 200 ? resultText.slice(0, 200) + "..." : resultText;
-        actions.push({
-          type: ActionType.SessionResponsePart,
-          turnId,
-          part: {
-            kind: ResponsePartKind.SystemNotification,
-            content: displayText,
+        const partActions: StateAction[] = [
+          {
+            type: ActionType.SessionToolCallComplete,
+            turnId: tid,
+            toolCallId: pairedToolCallId,
+            result: {
+              success: isOk,
+              pastTenseMessage,
+              content: isOk ? [makeTextResult(resultText)] : undefined,
+              error: isOk ? undefined : { message: pastTenseMessage },
+            },
           },
-        });
-      }
+        ];
 
-      note = {
-        index,
-        type: "tool_result",
-        disposition: "mapped",
-        detail: `Mapped to SessionToolCallComplete (toolCallId=${pairedToolCallId})`,
-      };
+        // System notification for successful result
+        if (isOk && content) {
+          const displayText =
+            resultText.length > 200 ? resultText.slice(0, 200) + "..." : resultText;
+          partActions.push({
+            type: ActionType.SessionResponsePart,
+            turnId: tid,
+            part: { kind: ResponsePartKind.SystemNotification, content: displayText },
+          });
+        }
+
+        return {
+          actions: partActions,
+          detail: `Mapped to SessionToolCallComplete (toolCallId=${pairedToolCallId})`,
+        };
+      });
+      actions.push(...wt.actions);
+      note = wt.note;
       break;
     }
 
@@ -675,8 +705,7 @@ export function mapAgentEvent(
     // ─── System events ─────────────────────────────────────────────
 
     case "system": {
-      const turnId = eventTurnId || context.turnId;
-
+      // Diagnostic events (HR7) route to OTLP telemetry — never orphan-wrap.
       if (isDiagnosticEvent(event)) {
         note = {
           index,
@@ -687,29 +716,18 @@ export function mapAgentEvent(
         break;
       }
 
-      if (turnId) {
-        actions.push({
-          type: ActionType.SessionResponsePart,
-          turnId,
-          part: {
-            kind: ResponsePartKind.SystemNotification,
-            content: content || "",
-          },
-        });
-        note = {
-          index,
-          type: "system",
-          disposition: "mapped",
-          detail: "Mapped to SessionResponsePart(systemNotification)",
-        };
-      } else {
-        note = {
-          index,
-          type: "system",
-          disposition: "dropped",
-          detail: "No active turn for system event",
-        };
-      }
+      const wt = withTurn(index, "system", context, eventTurnId, (tid) => ({
+        actions: [
+          {
+            type: ActionType.SessionResponsePart,
+            turnId: tid,
+            part: { kind: ResponsePartKind.SystemNotification, content: content || "" },
+          } as StateAction,
+        ],
+        detail: "Mapped to SessionResponsePart(systemNotification)",
+      }));
+      actions.push(...wt.actions);
+      note = wt.note;
       break;
     }
 

--- a/packages/powerline/src/ahp-handlers.test.ts
+++ b/packages/powerline/src/ahp-handlers.test.ts
@@ -575,6 +575,32 @@ describe("ahp-handlers: subscribe", () => {
       await lb.cleanup();
     }
   });
+
+  it("[status rescue] passes through an unrecognized status value without dropping (#1460)", async () => {
+    // Before #1460, STATUS_RESCUE_CONTENTS was a hardcoded allowlist — any new runtime
+    // status value not in the set was silently dropped. Now the forwarder passes through
+    // ANY non-empty status content so new values aren't lost.
+    const lb = await spinUpLoopback();
+    const client = await openClient(lb.port);
+    try {
+      const sessionId = `s-newstatus-${String(Date.now())}`;
+      await client.socket.request("createSession", {
+        channel: `ahp-session:/${sessionId}`,
+        provider: TEST_RUNTIME.name,
+        config: {},
+      });
+      const session = TEST_RUNTIME.lastSession!;
+      await client.socket.request("subscribe", { channel: `ahp-session:/${sessionId}` });
+      session.push({ type: "status", content: "paused" });
+      await waitForCount(client.received, 1);
+      const action = client.received[0]!.action as { type: unknown; _meta?: { status?: string } };
+      expect(action.type).toBe(ActionType.SessionMetaChanged);
+      expect(action._meta?.status).toBe("paused");
+    } finally {
+      await client.cleanup();
+      await lb.cleanup();
+    }
+  });
 });
 
 describe("ahp-handlers: dispatchAction", () => {

--- a/packages/powerline/src/forwarder.ts
+++ b/packages/powerline/src/forwarder.ts
@@ -6,7 +6,7 @@
  */
 
 import type { StateAction } from "@grackle-ai/ahp";
-import { ActionType, MessageKind } from "@grackle-ai/ahp";
+import { ActionType } from "@grackle-ai/ahp";
 import type { AhpServerConnection } from "@grackle-ai/ahp-transport";
 import { mapAgentEvent } from "@grackle-ai/common";
 import type { AgentEvent } from "@grackle-ai/runtime-sdk";
@@ -19,35 +19,6 @@ import {
   registerPumpForwarder,
   unregisterPumpForwarder,
 } from "./session-mgr.js";
-
-/**
- * Status-event contents that PowerLine rescues by synthesizing a
- * `SessionMetaChangedAction` with `_meta.status`. mapAgentEvent drops these
- * as "redundant with turn_* events", but Grackle's consumer relies on them
- * to flip `session.status` in the UI.
- */
-export const STATUS_RESCUE_CONTENTS: ReadonlySet<string> = new Set([
-  "running",
-  "waiting_input",
-  "completed",
-  "idle",
-  "killed",
-  "terminated",
-  "failed",
-]);
-
-/**
- * Event types whose mapper-drop ("no active turn") should be rescued by
- * synthesizing an orphan turn-started. These are runtime-emitted content
- * events that, under the gRPC wire, flowed through regardless of turn
- * context.
- */
-const ORPHAN_RESCUABLE_TYPES: ReadonlySet<string> = new Set([
-  "text",
-  "tool_use",
-  "tool_result",
-  "system",
-]);
 
 /**
  * Drive the parked-event replay + live-buffer tail loop for a single
@@ -139,7 +110,16 @@ export function emitActionsForEvent(
     raw: event.raw !== undefined ? JSON.stringify(event.raw) : undefined,
   };
 
-  if (event.type === "status" && STATUS_RESCUE_CONTENTS.has(event.content)) {
+  // TEMPORARY HR8d tunnel: Grackle's native session status is smuggled through
+  // AHP's `_meta` side-channel rather than reconstructed from the action stream.
+  // Pass through ANY non-empty status content so new runtime status values aren't
+  // silently dropped (#1460). The mapper's own status branches are dead code on
+  // the production wire — the forwarder intercepts all statuses here before they
+  // reach mapAgentEvent.
+  //
+  // SUNSET: replace with reducer-derived status reconstruction under epic #1348
+  // (specifically sub-issue #1343 "Flatten event-processor onto AHP actions").
+  if (event.type === "status" && event.content) {
     forwarder.serverSeq += 1;
     const statusAction: StateAction = {
       type: ActionType.SessionMetaChanged,
@@ -154,32 +134,10 @@ export function emitActionsForEvent(
     return;
   }
 
-  let result = mapAgentEvent(normalized, idx, forwarder.mapperContext);
-  let synthesizedOrphanTurnId: string | undefined;
-
-  if (
-    result.actions.length === 0 &&
-    result.note?.disposition === "dropped" &&
-    ORPHAN_RESCUABLE_TYPES.has(normalized.type) &&
-    forwarder.mapperContext.turnId === undefined
-  ) {
-    synthesizedOrphanTurnId = `turn-orphan-${String(idx)}`;
-    const startAction: StateAction = {
-      type: ActionType.SessionTurnStarted,
-      turnId: synthesizedOrphanTurnId,
-      message: { text: "", origin: { kind: MessageKind.User } },
-    };
-    forwarder.serverSeq += 1;
-    conn.session.notify("action", {
-      channel: sessionChannel(sessionId),
-      serverSeq: forwarder.serverSeq,
-      action: startAction,
-      origin: undefined,
-    });
-    forwarder.mapperContext.turnId = synthesizedOrphanTurnId;
-    const reIdx = forwarder.mapperContext.eventIndex++;
-    result = mapAgentEvent(normalized, reIdx, forwarder.mapperContext);
-  }
+  // The mapper now handles orphan-turn synthesis internally (see `withTurn` in
+  // ahp-mapper.ts). Content events emitted without an active turn are wrapped in
+  // a synthetic `turn-orphan-${index}` turn — no forwarder-side rescue needed.
+  const result = mapAgentEvent(normalized, idx, forwarder.mapperContext);
 
   for (const action of result.actions) {
     forwarder.serverSeq += 1;
@@ -189,21 +147,6 @@ export function emitActionsForEvent(
       action,
       origin: undefined,
     });
-  }
-
-  if (synthesizedOrphanTurnId !== undefined) {
-    const completeAction: StateAction = {
-      type: ActionType.SessionTurnComplete,
-      turnId: synthesizedOrphanTurnId,
-    };
-    forwarder.serverSeq += 1;
-    conn.session.notify("action", {
-      channel: sessionChannel(sessionId),
-      serverSeq: forwarder.serverSeq,
-      action: completeAction,
-      origin: undefined,
-    });
-    forwarder.mapperContext.turnId = undefined;
   }
 
   const metaSnapshot: Record<string, unknown> = {};

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.158.1",
+  "rushVersion": "5.169.3",
   "pnpmVersion": "10.11.0",
   "nodeSupportedVersionRange": ">=22.0.0 <24.0.0",
   "projectFolderMinDepth": 2,


### PR DESCRIPTION
## Summary

- **Move orphan-event rescue into `mapAgentEvent`**: Content events (`text`, `tool_use`, `tool_result`, non-diagnostic `system`) emitted without an active turn are now wrapped in a synthetic one-shot turn (`turn-orphan-${index}`) inside the mapper via a new `withTurn` helper, rather than in PowerLine's forwarder. This puts the lossless-translation logic where it belongs (the mapper) and ensures every substantive event produces valid AHP action sequences regardless of which transport calls the mapper.

- **Widen the HR8d status tunnel**: Replace the hardcoded `STATUS_RESCUE_CONTENTS` allowlist in the forwarder with a non-empty check so any unrecognized status value passes through as `SessionMetaChanged{_meta.status}` instead of being silently dropped. Adds a `// TEMPORARY HR8d tunnel … SUNSET under epic #1348 / #1343` comment to mark this as intentional tech-debt with a clear owner.

- **Delete dead forwarder exports**: Removes `ORPHAN_RESCUABLE_TYPES` and `STATUS_RESCUE_CONTENTS` from `forwarder.ts` — neither is referenced outside that file, and the rescue logic is now either inside the mapper or trivially inlined.

## Test plan

- [x] `ahp-mapper.test.ts`: Flipped four "drops when no active turn" cases to orphan-wrap assertions (3–4 actions, `disposition: "mapped"`, `context.turnId` cleared); added diagnostic-`system`-stays-carried guard test
- [x] `ahp-handlers.test.ts`: Existing `[orphan rescue]` and `[status rescue]` wire tests stay green unchanged; added `[status rescue] passes through an unrecognized status value without dropping (#1460)` to verify the silent-drop fix
- [x] `rush test -t @grackle-ai/common -t @grackle-ai/powerline` passes

Closes #1460