### PR TITLE
Arch: deduplicate GrackleEventType/GrackleEvent between core and plugin-sdk

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1517-dedup-event-types_2026-06-11-06-30-27.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1517-dedup-event-types_2026-06-11-06-30-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Deduplicate GrackleEventType/GrackleEvent: plugin-sdk is now the single source of truth; core re-exports the types",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/core/src/event-bus.ts
+++ b/packages/core/src/event-bus.ts
@@ -4,82 +4,12 @@ import { getDatabaseStores } from "@grackle-ai/database";
 import { logger } from "./logger.js";
 
 // ─── Event Types ──────────────────────────────────────────
+// `GrackleEventType` and `GrackleEvent` are defined in `@grackle-ai/plugin-sdk`
+// (single source of truth). They are re-exported here so existing
+// `import { GrackleEvent } from "@grackle-ai/core"` statements continue to work.
 
-/** All domain event types emitted by the event bus. */
-export type GrackleEventType =
-  | "task.created"
-  | "task.updated"
-  | "task.started"
-  | "task.completed"
-  | "task.deleted"
-  | "task.reparented"
-  | "workspace.created"
-  | "workspace.archived"
-  | "workspace.updated"
-  | "persona.created"
-  | "persona.updated"
-  | "persona.deleted"
-  | "environment.added"
-  | "environment.removed"
-  | "environment.changed"
-  | "environment.provision_progress"
-  | "token.changed"
-  | "credential.providers_changed"
-  | "setting.changed"
-  | "schedule.created"
-  | "schedule.updated"
-  | "schedule.deleted"
-  | "schedule.fired"
-  | "agent.created"
-  | "agent.updated"
-  | "agent.deleted"
-  // Heartbeat schedule for an Agent's root task was created/updated/paused (#1438).
-  // payload: { agentId }
-  | "agent.heartbeat.updated"
-  // Heartbeat schedule for an Agent was deleted via SetAgentHeartbeat({ cadence: "" }).
-  // payload: { agentId }
-  | "agent.heartbeat.cleared"
-  | "notification.escalated"
-  | "plugin.changed"
-  | "github_account.changed"
-  // A workspace's promoted-component set changed (promote/demote, or a promoted
-  // component edited) — the MCP server pushes tools/list_changed to that
-  // workspace's sessions so dynamic render_<name> tools refresh (#1297). payload: { workspaceId }
-  | "component.changed"
-  // A watched resource (file/dir) changed on an environment's PowerLine-owned
-  // worktree (#1395). Forwarded from the AHP resource-watch channel; the web
-  // `useResources` hook re-reads the affected URIs. payload:
-  // { environmentId, uri, changes: [{ uri, type }] }
-  | "resource.changed"
-  // IPC stream (room) lifecycle (#1309). Emitted from the stream registry for
-  // observable (non-reserved) rooms so the Coordination roster updates live as
-  // streams are created/joined/left/closed by either agents or the operator.
-  // payloads:
-  //   stream.created  { streamId, name, selfEcho }
-  //   stream.attached { streamId, name, sessionId, permission, deliveryMode }
-  //   stream.detached { streamId, name, sessionId }
-  //   stream.closed   { streamId, name }
-  | "stream.created"
-  | "stream.attached"
-  | "stream.detached"
-  | "stream.closed"
-  // An agent asked the UI to open a read-only live view of a file (#1396 live
-  // docs v0). Emitted when the `show_file` MCP tool's result carries a document
-  // descriptor; the web `useDocuments` hook opens a tab bound to the URI
-  // reference (NOT baked content). payload: { environmentId, uri, sessionId }
-  | "document.show";
-
-/** A domain event emitted by the event bus. */
-export interface GrackleEvent {
-  /** ULID — chronologically sortable unique identifier. */
-  id: string;
-  /** Dot-notation event type (e.g. "task.created"). */
-  type: GrackleEventType;
-  /** ISO 8601 timestamp. */
-  timestamp: string;
-  /** Domain-specific payload. */
-  payload: Record<string, unknown>;
-}
+export type { GrackleEvent, GrackleEventType } from "@grackle-ai/plugin-sdk";
+import type { GrackleEvent, GrackleEventType } from "@grackle-ai/plugin-sdk";
 
 /**
  * Callback signature for event subscribers. May be sync or async; async rejections

--- a/packages/core/src/event-bus.ts
+++ b/packages/core/src/event-bus.ts
@@ -1,6 +1,7 @@
 import { ulid } from "ulid";
 import { SequencedLog, type LogSink, serverTimestamp } from "@grackle-ai/common";
 import { getDatabaseStores } from "@grackle-ai/database";
+import type { GrackleEvent, GrackleEventType } from "@grackle-ai/plugin-sdk";
 import { logger } from "./logger.js";
 
 // ─── Event Types ──────────────────────────────────────────
@@ -9,7 +10,6 @@ import { logger } from "./logger.js";
 // `import { GrackleEvent } from "@grackle-ai/core"` statements continue to work.
 
 export type { GrackleEvent, GrackleEventType } from "@grackle-ai/plugin-sdk";
-import type { GrackleEvent, GrackleEventType } from "@grackle-ai/plugin-sdk";
 
 /**
  * Callback signature for event subscribers. May be sync or async; async rejections

--- a/packages/plugin-sdk/src/context.ts
+++ b/packages/plugin-sdk/src/context.ts
@@ -42,7 +42,12 @@ export interface ServerConfig {
   skipRootAutostart?: boolean;
 }
 
-/** Event types emitted by the domain event bus. */
+/**
+ * All domain event types emitted by the event bus.
+ *
+ * This is the single source of truth. `@grackle-ai/core` re-exports these
+ * types from here; do not redefine them elsewhere.
+ */
 export type GrackleEventType =
   | "task.created"
   | "task.updated"
@@ -70,18 +75,40 @@ export type GrackleEventType =
   | "agent.created"
   | "agent.updated"
   | "agent.deleted"
+  // Heartbeat schedule for an Agent's root task was created/updated/paused (#1438).
+  // payload: { agentId }
   | "agent.heartbeat.updated"
+  // Heartbeat schedule for an Agent was deleted via SetAgentHeartbeat({ cadence: "" }).
+  // payload: { agentId }
   | "agent.heartbeat.cleared"
   | "notification.escalated"
   | "plugin.changed"
   | "github_account.changed"
-  // Keep in sync with the same union in @grackle-ai/core event-bus.ts.
+  // A workspace's promoted-component set changed (promote/demote, or a promoted
+  // component edited) — the MCP server pushes tools/list_changed to that
+  // workspace's sessions so dynamic render_<name> tools refresh (#1297). payload: { workspaceId }
   | "component.changed"
+  // A watched resource (file/dir) changed on an environment's PowerLine-owned
+  // worktree (#1395). Forwarded from the AHP resource-watch channel; the web
+  // `useResources` hook re-reads the affected URIs. payload:
+  // { environmentId, uri, changes: [{ uri, type }] }
   | "resource.changed"
+  // IPC stream (room) lifecycle (#1309). Emitted from the stream registry for
+  // observable (non-reserved) rooms so the Coordination roster updates live as
+  // streams are created/joined/left/closed by either agents or the operator.
+  // payloads:
+  //   stream.created  { streamId, name, selfEcho }
+  //   stream.attached { streamId, name, sessionId, permission, deliveryMode }
+  //   stream.detached { streamId, name, sessionId }
+  //   stream.closed   { streamId, name }
   | "stream.created"
   | "stream.attached"
   | "stream.detached"
   | "stream.closed"
+  // An agent asked the UI to open a read-only live view of a file (#1396 live
+  // docs v0). Emitted when the `show_file` MCP tool's result carries a document
+  // descriptor; the web `useDocuments` hook opens a tab bound to the URI
+  // reference (NOT baked content). payload: { environmentId, uri, sessionId }
   | "document.show";
 
 /** A domain event from the event bus. */


### PR DESCRIPTION
## Summary

- `GrackleEventType` and `GrackleEvent` were defined identically in both `@grackle-ai/core` and `@grackle-ai/plugin-sdk`, guarded only by a manual "Keep in sync" comment
- `plugin-sdk` is now the single source of truth (following the precedent set in #1463 for `PluginContext`/`Disposable`)
- `core` re-exports both types from `plugin-sdk` so all existing `import { GrackleEvent } from "@grackle-ai/core"` statements continue to work unchanged
- No new package needed — `core` already depends on `plugin-sdk` (the dependency runs that direction, not the other way)

## Test plan

- [x] `rush build -t @grackle-ai/core` — clean, no warnings
- [x] `rush build -t @grackle-ai/plugin-core -t @grackle-ai/plugin-scheduling -t @grackle-ai/plugin-knowledge` — all downstream consumers build cleanly
- [x] `rushx test` in `packages/core` — 666/666 tests pass
- [x] `grep -rn "Keep in sync" packages/plugin-sdk packages/core` — returns nothing

Closes #1517