### PR TITLE
DI: Migrate remaining plugins and server to store registry

### DIFF
--- a/common/changes/@grackle-ai/cli/nick-pape-1551-di-stores-migration_2026-06-11-06-48-32.json
+++ b/common/changes/@grackle-ai/cli/nick-pape-1551-di-stores-migration_2026-06-11-06-48-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Migrate plugin-scheduling, plugin-orchestration, plugin-knowledge, and server to getDatabaseStores() registry (DI migration #1551)",
+      "type": "patch",
+      "packageName": "@grackle-ai/cli"
+    }
+  ],
+  "packageName": "@grackle-ai/cli",
+  "email": "5674316+nick-pape@users.noreply.github.com"
+}

--- a/packages/plugin-knowledge/src/entity-sync.test.ts
+++ b/packages/plugin-knowledge/src/entity-sync.test.ts
@@ -18,11 +18,18 @@ const stores = vi.hoisted(() => ({
   getWorkspace: vi.fn(),
   getPersona: vi.fn(),
 }));
-vi.mock("@grackle-ai/database", () => ({
-  taskStore: { getTask: stores.getTask },
-  workspaceStore: { getWorkspace: stores.getWorkspace },
-  personaStore: { getPersona: stores.getPersona },
-}));
+vi.mock("@grackle-ai/database", () => {
+  const taskStore = { getTask: stores.getTask };
+  const workspaceStore = { getWorkspace: stores.getWorkspace };
+  const personaStore = { getPersona: stores.getPersona };
+  const registry = { taskStore, workspaceStore, personaStore };
+  return {
+    taskStore,
+    workspaceStore,
+    personaStore,
+    getDatabaseStores: () => registry,
+  };
+});
 
 const gates = vi.hoisted(() => ({
   getEmbedder: vi.fn(() => ({}) as unknown),

--- a/packages/plugin-knowledge/src/entity-sync.ts
+++ b/packages/plugin-knowledge/src/entity-sync.ts
@@ -14,7 +14,7 @@
  */
 
 import type { GrackleEvent, PluginContext, Disposable } from "@grackle-ai/plugin-sdk";
-import { taskStore, workspaceStore, personaStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { logger } from "./logger.js";
 import { getKnowledgeEmbedder } from "./knowledge-init.js";
 import { isNeo4jHealthy } from "./knowledge-health.js";
@@ -52,7 +52,7 @@ async function handleEvent(event: GrackleEvent): Promise<void> {
       if (!taskId) {
         return;
       }
-      const task = taskStore.getTask(taskId);
+      const task = getDatabaseStores().taskStore.getTask(taskId);
       if (task) {
         await projectTask(task);
       }
@@ -74,7 +74,7 @@ async function handleEvent(event: GrackleEvent): Promise<void> {
       if (!workspaceId) {
         return;
       }
-      const workspace = workspaceStore.getWorkspace(workspaceId);
+      const workspace = getDatabaseStores().workspaceStore.getWorkspace(workspaceId);
       if (workspace) {
         await projectWorkspace(workspace);
       }
@@ -86,7 +86,7 @@ async function handleEvent(event: GrackleEvent): Promise<void> {
       if (!personaId) {
         return;
       }
-      const persona = personaStore.getPersona(personaId);
+      const persona = getDatabaseStores().personaStore.getPersona(personaId);
       if (persona) {
         await projectPersona(persona);
       }

--- a/packages/plugin-knowledge/src/knowledge-projection-phase.test.ts
+++ b/packages/plugin-knowledge/src/knowledge-projection-phase.test.ts
@@ -3,14 +3,31 @@ import type { Embedder } from "@grackle-ai/knowledge";
 
 // ── Mocks (all module-load deps of the phase) ───────────────
 
-vi.mock("@grackle-ai/database", () => ({
-  sessionStore: { listSessions: vi.fn(() => []) },
-  taskStore: { listTasks: vi.fn(() => []), getTask: vi.fn() },
-  workspaceStore: { listWorkspaces: vi.fn(() => []) },
-  personaStore: { listPersonas: vi.fn(() => []) },
-  envRegistry: { listEnvironments: vi.fn(() => []) },
-  workspaceEnvironmentLinkStore: { getLinkedEnvironmentIds: vi.fn(() => []) },
-}));
+vi.mock("@grackle-ai/database", () => {
+  const sessionStore = { listSessions: vi.fn(() => []) };
+  const taskStore = { listTasks: vi.fn(() => []), getTask: vi.fn() };
+  const workspaceStore = { listWorkspaces: vi.fn(() => []) };
+  const personaStore = { listPersonas: vi.fn(() => []) };
+  const envRegistry = { listEnvironments: vi.fn(() => []) };
+  const workspaceEnvironmentLinkStore = { getLinkedEnvironmentIds: vi.fn(() => []) };
+  const registry = {
+    sessionStore,
+    taskStore,
+    workspaceStore,
+    personaStore,
+    envRegistry,
+    workspaceEnvironmentLinkStore,
+  };
+  return {
+    sessionStore,
+    taskStore,
+    workspaceStore,
+    personaStore,
+    envRegistry,
+    workspaceEnvironmentLinkStore,
+    getDatabaseStores: () => registry,
+  };
+});
 
 const kg = vi.hoisted(() => ({
   getReferenceNodeProps: vi.fn(),

--- a/packages/plugin-knowledge/src/knowledge-projection-phase.ts
+++ b/packages/plugin-knowledge/src/knowledge-projection-phase.ts
@@ -25,14 +25,7 @@
  */
 
 import type { ReconciliationPhase } from "@grackle-ai/plugin-sdk";
-import {
-  sessionStore,
-  taskStore,
-  workspaceStore,
-  personaStore,
-  envRegistry,
-  workspaceEnvironmentLinkStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   getReferenceNodeProps,
   listReferenceSourceIds,
@@ -93,10 +86,11 @@ function resolveSessionWorkspaceId(taskId: string): string {
   if (!taskId) {
     return "";
   }
-  return taskStore.getTask(taskId)?.workspaceId ?? "";
+  return getDatabaseStores().taskStore.getTask(taskId)?.workspaceId ?? "";
 }
 
 async function syncSessions(embedder: Embedder): Promise<void> {
+  const { sessionStore } = getDatabaseStores();
   const sessions = sessionStore.listSessions();
   const liveSessionIds = new Set<string>();
 
@@ -198,6 +192,13 @@ export function createKnowledgeProjectionPhase(
       if (!embedder || !deps.isHealthy()) {
         return;
       }
+      const {
+        taskStore,
+        workspaceStore,
+        personaStore,
+        envRegistry,
+        workspaceEnvironmentLinkStore,
+      } = getDatabaseStores();
       // Entity backbone (hash-gated): converges the mirror even if the
       // low-latency event subscriber missed events (e.g. while Neo4j was down).
       // Endpoints (env/persona/workspace) before tasks/sessions so edges resolve.

--- a/packages/plugin-knowledge/src/projection/project-entity.ts
+++ b/packages/plugin-knowledge/src/projection/project-entity.ts
@@ -18,7 +18,7 @@ import {
   type UpsertReferenceNodeInput,
   type EdgeType,
 } from "@grackle-ai/knowledge";
-import { workspaceEnvironmentLinkStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import type {
   TaskRow,
   WorkspaceRow,
@@ -110,8 +110,8 @@ async function reconcileEdges(
 
 /** Resolve a workspace's LINKED_TO edge specs from the junction table. */
 function workspaceLinkEdges(workspaceId: string): EdgeSpec[] {
-  return workspaceEnvironmentLinkStore
-    .getLinkedEnvironmentIds(workspaceId)
+  return getDatabaseStores()
+    .workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(workspaceId)
     .map((environmentId) => workspaceLinkEdge(workspaceId, environmentId));
 }
 
@@ -128,7 +128,7 @@ export async function projectWorkspace(workspace: WorkspaceRow): Promise<void> {
   const nodeId = await upsertEntityNode(
     workspaceToNodeInput(
       workspace,
-      workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(workspace.id),
+      getDatabaseStores().workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(workspace.id),
     ),
   );
   await reconcileEdges(nodeId, WORKSPACE_EDGE_TYPES, workspaceLinkEdges(workspace.id), true);

--- a/packages/plugin-knowledge/src/projection/rebuild.ts
+++ b/packages/plugin-knowledge/src/projection/rebuild.ts
@@ -9,13 +9,7 @@
  * @module
  */
 
-import {
-  taskStore,
-  sessionStore,
-  workspaceStore,
-  personaStore,
-  envRegistry,
-} from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   REFERENCE_SOURCE,
   listReferenceSourceIds,
@@ -54,6 +48,8 @@ export interface RebuildResult {
  *   backfilled off the write path by the reconciliation phase).
  */
 export async function rebuild(embedder: Embedder): Promise<RebuildResult> {
+  const { taskStore, sessionStore, workspaceStore, personaStore, envRegistry } =
+    getDatabaseStores();
   const environments = envRegistry.listEnvironments();
   const personas = personaStore.listPersonas();
   const workspaces = workspaceStore.listWorkspaces();

--- a/packages/plugin-orchestration/src/orchestration-plugin.test.ts
+++ b/packages/plugin-orchestration/src/orchestration-plugin.test.ts
@@ -22,12 +22,17 @@ vi.mock("@grackle-ai/common", () => ({
   })),
 }));
 
-vi.mock("@grackle-ai/database", () => ({
-  taskStore: {
+vi.mock("@grackle-ai/database", () => {
+  const taskStore = {
     listTasks: vi.fn(() => []),
     reparentTask: vi.fn(),
-  },
-}));
+  };
+  const stores = { taskStore };
+  return {
+    taskStore,
+    getDatabaseStores: () => stores,
+  };
+});
 
 vi.mock("@grackle-ai/plugin-core", () => ({
   // Orchestration collector — returns handlers with representative methods

--- a/packages/plugin-orchestration/src/orchestration-plugin.ts
+++ b/packages/plugin-orchestration/src/orchestration-plugin.ts
@@ -16,7 +16,7 @@ import {
   createEscalationAutoSubscriber,
   createOrphanReparentSubscriber,
 } from "@grackle-ai/plugin-core";
-import { taskStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { taskService } from "@grackle-ai/core";
 
 /**
@@ -54,7 +54,7 @@ export function createOrchestrationPlugin(): GracklePlugin {
 
     reconciliationPhases: (ctx) => [
       createOrphanPhase({
-        listAllTasks: () => taskStore.listTasks(),
+        listAllTasks: () => getDatabaseStores().taskStore.listTasks(),
         reparentTask: (taskId: string, newParentTaskId: string): void => {
           taskService.reparentTask(taskId, newParentTaskId);
         },

--- a/packages/plugin-scheduling/src/schedule-handlers.test.ts
+++ b/packages/plugin-scheduling/src/schedule-handlers.test.ts
@@ -3,18 +3,22 @@ import { ConnectError, Code } from "@connectrpc/connect";
 import { grackle } from "@grackle-ai/common";
 
 // Mock database stores
-vi.mock("@grackle-ai/database", () => ({
-  personaStore: {
-    getPersona: vi.fn(),
-  },
-  scheduleStore: {
+vi.mock("@grackle-ai/database", () => {
+  const personaStore = { getPersona: vi.fn() };
+  const scheduleStore = {
     createSchedule: vi.fn(),
     getSchedule: vi.fn(),
     listSchedules: vi.fn(),
     updateSchedule: vi.fn(),
     deleteSchedule: vi.fn(),
-  },
-}));
+  };
+  const stores = { personaStore, scheduleStore };
+  return {
+    personaStore,
+    scheduleStore,
+    getDatabaseStores: () => stores,
+  };
+});
 
 import { personaStore, scheduleStore } from "@grackle-ai/database";
 import { createScheduleHandlers } from "./schedule-handlers.js";

--- a/packages/plugin-scheduling/src/schedule-handlers.ts
+++ b/packages/plugin-scheduling/src/schedule-handlers.ts
@@ -10,7 +10,8 @@
 import { ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { grackle } from "@grackle-ai/common";
-import { personaStore, scheduleStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
+import type { ScheduleUpdate } from "@grackle-ai/database";
 import { v4 as uuid } from "uuid";
 import type { PluginContext } from "@grackle-ai/plugin-sdk";
 import { scheduleRowToProto } from "@grackle-ai/common";
@@ -31,6 +32,7 @@ export function createScheduleHandlers(emit: PluginContext["emit"]): {
 } {
   /** Create a new schedule. */
   async function createSchedule(req: grackle.CreateScheduleRequest): Promise<grackle.Schedule> {
+    const { personaStore, scheduleStore } = getDatabaseStores();
     const title = req.title.trim();
     const expr = req.scheduleExpression.trim();
     const personaId = req.personaId.trim();
@@ -76,6 +78,7 @@ export function createScheduleHandlers(emit: PluginContext["emit"]): {
 
   /** List all schedules, optionally filtered by workspace. */
   async function listSchedules(req: grackle.ListSchedulesRequest): Promise<grackle.ScheduleList> {
+    const { scheduleStore } = getDatabaseStores();
     const rows = scheduleStore.listSchedules(req.workspaceId || undefined);
     return create(grackle.ScheduleListSchema, {
       schedules: rows.map(scheduleRowToProto),
@@ -84,6 +87,7 @@ export function createScheduleHandlers(emit: PluginContext["emit"]): {
 
   /** Get a schedule by ID. */
   async function getSchedule(req: grackle.ScheduleId): Promise<grackle.Schedule> {
+    const { scheduleStore } = getDatabaseStores();
     const row = scheduleStore.getSchedule(req.id);
     if (!row) {
       throw new ConnectError(`Schedule not found: ${req.id}`, Code.NotFound);
@@ -93,12 +97,13 @@ export function createScheduleHandlers(emit: PluginContext["emit"]): {
 
   /** Update an existing schedule. */
   async function updateSchedule(req: grackle.UpdateScheduleRequest): Promise<grackle.Schedule> {
+    const { personaStore, scheduleStore } = getDatabaseStores();
     const existing = scheduleStore.getSchedule(req.id);
     if (!existing) {
       throw new ConnectError(`Schedule not found: ${req.id}`, Code.NotFound);
     }
 
-    const update: scheduleStore.ScheduleUpdate = {};
+    const update: ScheduleUpdate = {};
     if (req.title !== undefined && req.title.trim() !== "") {
       update.title = req.title.trim();
     }
@@ -153,6 +158,7 @@ export function createScheduleHandlers(emit: PluginContext["emit"]): {
 
   /** Delete a schedule by ID. */
   async function deleteSchedule(req: grackle.ScheduleId): Promise<grackle.Empty> {
+    const { scheduleStore } = getDatabaseStores();
     scheduleStore.deleteSchedule(req.id);
     emit("schedule.deleted", { scheduleId: req.id });
     return create(grackle.EmptySchema, {});

--- a/packages/plugin-scheduling/src/scheduling-plugin.test.ts
+++ b/packages/plugin-scheduling/src/scheduling-plugin.test.ts
@@ -2,30 +2,39 @@ import { describe, it, expect, vi } from "vitest";
 import type { PluginContext } from "@grackle-ai/plugin-sdk";
 import type { Logger } from "pino";
 
-// Mock database stores (scheduling plugin reads from them directly)
-vi.mock("@grackle-ai/database", () => ({
-  scheduleStore: {
+// Mock database stores (scheduling plugin reads via getDatabaseStores())
+vi.mock("@grackle-ai/database", () => {
+  const scheduleStore = {
     getDueSchedules: vi.fn(),
     advanceSchedule: vi.fn(),
     setScheduleEnabled: vi.fn(),
-  },
-  taskStore: {
+  };
+  const taskStore = {
     setTaskScheduleId: vi.fn(),
     getTask: vi.fn(),
-  },
-  personaStore: {
-    getPersona: vi.fn(),
-  },
-  agentStore: {
-    getAgent: vi.fn(),
-  },
-  sessionStore: {
-    getLatestSessionForTask: vi.fn(),
-  },
-  dispatchQueueStore: {
-    enqueue: vi.fn(),
-  },
-}));
+  };
+  const personaStore = { getPersona: vi.fn() };
+  const agentStore = { getAgent: vi.fn() };
+  const sessionStore = { getLatestSessionForTask: vi.fn() };
+  const dispatchQueueStore = { enqueue: vi.fn() };
+  const stores = {
+    scheduleStore,
+    taskStore,
+    personaStore,
+    agentStore,
+    sessionStore,
+    dispatchQueueStore,
+  };
+  return {
+    scheduleStore,
+    taskStore,
+    personaStore,
+    agentStore,
+    sessionStore,
+    dispatchQueueStore,
+    getDatabaseStores: () => stores,
+  };
+});
 
 // The heartbeat branch (#1438) reads core helpers (reanimate, stdin, spawn,
 // env resolver). Mock the surface to avoid pulling in the real event-bus,

--- a/packages/plugin-scheduling/src/scheduling-plugin.ts
+++ b/packages/plugin-scheduling/src/scheduling-plugin.ts
@@ -71,34 +71,34 @@ export function createSchedulingPlugin(): GracklePlugin {
       },
     ],
 
-    reconciliationPhases: (ctx: PluginContext) => [
-      createCronPhase({
-        getDueSchedules: () => getDatabaseStores().scheduleStore.getDueSchedules(),
-        advanceSchedule: (id, lastRunAt, nextRunAt) =>
-          getDatabaseStores().scheduleStore.advanceSchedule(id, lastRunAt, nextRunAt),
-        createTask: taskService.createTask,
-        setTaskScheduleId: (taskId, scheduleId) =>
-          getDatabaseStores().taskStore.setTaskScheduleId(taskId, scheduleId),
-        enqueueForDispatch: (entry) => getDatabaseStores().dispatchQueueStore.enqueue(entry),
-        emit: ctx.emit,
-        getPersona: (id) => getDatabaseStores().personaStore.getPersona(id),
-        setScheduleEnabled: (id, enabled, nextRunAt) =>
-          getDatabaseStores().scheduleStore.setScheduleEnabled(id, enabled, nextRunAt),
-        // Heartbeat branch wiring (#1438). `reanimateAgent` is sync (returns
-        // SessionRow); the CronPhaseDep type accepts `unknown` so it can be
-        // passed directly without an async wrapper.
-        getTask: (id: string) => {
-          const row = getDatabaseStores().taskStore.getTask(id);
-          return row ? toTaskModel(row) : undefined;
-        },
-        getLatestSessionForTask: (taskId) =>
-          getDatabaseStores().sessionStore.getLatestSessionForTask(taskId),
-        reanimateAgent,
-        publishToStdin,
-        startTaskSession,
-        resolveEnvironment: resolveEnvironmentForHeartbeat,
-        logger: ctx.logger,
-      }),
-    ],
+    reconciliationPhases: (ctx: PluginContext) => {
+      const { scheduleStore, taskStore, personaStore, dispatchQueueStore, sessionStore } =
+        getDatabaseStores();
+      return [
+        createCronPhase({
+          getDueSchedules: scheduleStore.getDueSchedules,
+          advanceSchedule: scheduleStore.advanceSchedule,
+          createTask: taskService.createTask,
+          setTaskScheduleId: taskStore.setTaskScheduleId,
+          enqueueForDispatch: dispatchQueueStore.enqueue,
+          emit: ctx.emit,
+          getPersona: personaStore.getPersona,
+          setScheduleEnabled: scheduleStore.setScheduleEnabled,
+          // Heartbeat branch wiring (#1438). `reanimateAgent` is sync (returns
+          // SessionRow); the CronPhaseDep type accepts `unknown` so it can be
+          // passed directly without an async wrapper.
+          getTask: (id: string) => {
+            const row = taskStore.getTask(id);
+            return row ? toTaskModel(row) : undefined;
+          },
+          getLatestSessionForTask: sessionStore.getLatestSessionForTask,
+          reanimateAgent,
+          publishToStdin,
+          startTaskSession,
+          resolveEnvironment: resolveEnvironmentForHeartbeat,
+          logger: ctx.logger,
+        }),
+      ];
+    },
   };
 }

--- a/packages/plugin-scheduling/src/scheduling-plugin.ts
+++ b/packages/plugin-scheduling/src/scheduling-plugin.ts
@@ -10,14 +10,7 @@
 import type { GracklePlugin, PluginContext } from "@grackle-ai/plugin-sdk";
 import { registerPlugin } from "@grackle-ai/plugin-sdk";
 import { grackle } from "@grackle-ai/common";
-import {
-  scheduleStore,
-  taskStore,
-  personaStore,
-  agentStore,
-  sessionStore,
-  dispatchQueueStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import {
   findFirstConnectedEnvironment,
   reanimateAgent,
@@ -43,6 +36,7 @@ import { createCronPhase } from "./cron-phase.js";
  */
 export function resolveEnvironmentForHeartbeat(task: TaskModel): string | undefined {
   if (task.agentId) {
+    const { agentStore } = getDatabaseStores();
     const agent = agentStore.getAgent(task.agentId);
     if (agent?.environmentId) {
       return agent.environmentId;
@@ -79,22 +73,26 @@ export function createSchedulingPlugin(): GracklePlugin {
 
     reconciliationPhases: (ctx: PluginContext) => [
       createCronPhase({
-        getDueSchedules: scheduleStore.getDueSchedules,
-        advanceSchedule: scheduleStore.advanceSchedule,
+        getDueSchedules: () => getDatabaseStores().scheduleStore.getDueSchedules(),
+        advanceSchedule: (id, lastRunAt, nextRunAt) =>
+          getDatabaseStores().scheduleStore.advanceSchedule(id, lastRunAt, nextRunAt),
         createTask: taskService.createTask,
-        setTaskScheduleId: taskStore.setTaskScheduleId,
-        enqueueForDispatch: dispatchQueueStore.enqueue,
+        setTaskScheduleId: (taskId, scheduleId) =>
+          getDatabaseStores().taskStore.setTaskScheduleId(taskId, scheduleId),
+        enqueueForDispatch: (entry) => getDatabaseStores().dispatchQueueStore.enqueue(entry),
         emit: ctx.emit,
-        getPersona: personaStore.getPersona,
-        setScheduleEnabled: scheduleStore.setScheduleEnabled,
+        getPersona: (id) => getDatabaseStores().personaStore.getPersona(id),
+        setScheduleEnabled: (id, enabled, nextRunAt) =>
+          getDatabaseStores().scheduleStore.setScheduleEnabled(id, enabled, nextRunAt),
         // Heartbeat branch wiring (#1438). `reanimateAgent` is sync (returns
         // SessionRow); the CronPhaseDep type accepts `unknown` so it can be
         // passed directly without an async wrapper.
         getTask: (id: string) => {
-          const row = taskStore.getTask(id);
+          const row = getDatabaseStores().taskStore.getTask(id);
           return row ? toTaskModel(row) : undefined;
         },
-        getLatestSessionForTask: sessionStore.getLatestSessionForTask,
+        getLatestSessionForTask: (taskId) =>
+          getDatabaseStores().sessionStore.getLatestSessionForTask(taskId),
         reanimateAgent,
         publishToStdin,
         startTaskSession,

--- a/packages/server/src/adapter-registry.test.ts
+++ b/packages/server/src/adapter-registry.test.ts
@@ -13,11 +13,19 @@ vi.mock("@grackle-ai/core", () => ({
   },
 }));
 
-vi.mock("@grackle-ai/database", () => ({
-  credentialProviders: {
+vi.mock("@grackle-ai/database", () => {
+  const credentialProviders = {
     getCredentialProviders: vi.fn(() => ({ github: "oauth" })),
-  },
-}));
+  };
+  const githubAccountStore = {
+    resolveStoredGitHubToken: vi.fn(),
+  };
+  const stores = { credentialProviders, githubAccountStore };
+  return {
+    credentialProviders,
+    getDatabaseStores: () => stores,
+  };
+});
 
 vi.mock("@grackle-ai/adapter-docker", () => ({
   DockerAdapter: vi.fn(),

--- a/packages/server/src/adapter-registry.ts
+++ b/packages/server/src/adapter-registry.ts
@@ -1,5 +1,5 @@
 import { registerAdapter, exec, logger } from "@grackle-ai/core";
-import { credentialProviders, githubAccountStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { TunnelRegistry } from "@grackle-ai/adapter-sdk";
 import { DockerAdapter } from "@grackle-ai/adapter-docker";
 import { LocalAdapter } from "@grackle-ai/adapter-local";
@@ -19,9 +19,9 @@ export function registerAllAdapters(): TunnelRegistry {
     logger,
     tunnelRegistry,
     isGitHubProviderEnabled: (): boolean =>
-      credentialProviders.getCredentialProviders().github !== "off",
+      getDatabaseStores().credentialProviders.getCredentialProviders().github !== "off",
     resolveGitHubToken: (accountId?: string): string | undefined =>
-      githubAccountStore.resolveStoredGitHubToken(accountId),
+      getDatabaseStores().githubAccountStore.resolveStoredGitHubToken(accountId),
   };
 
   registerAdapter(new DockerAdapter(adapterDeps));

--- a/packages/server/src/event-subscribers.ts
+++ b/packages/server/src/event-subscribers.ts
@@ -11,7 +11,7 @@ import {
   createRootTaskBootSubscriber,
   createAgentRootTaskSubscriber,
 } from "@grackle-ai/plugin-core";
-import { agentStore, taskStore, sessionStore, settingsStore } from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 import { randomUUID } from "node:crypto";
 
 /**
@@ -31,16 +31,19 @@ export function createEventSubscribers(ctx: PluginContext): Disposable[] {
     factories.push((pluginCtx) =>
       createRootTaskBootSubscriber(pluginCtx, {
         getTask: (id: string) => {
-          const row = taskStore.getTask(id);
+          const row = getDatabaseStores().taskStore.getTask(id);
           return row ? toTaskModel(row) : undefined;
         },
-        listSessionsForTask: sessionStore.listSessionsForTask,
-        getLatestSessionForTask: sessionStore.getLatestSessionForTask,
+        listSessionsForTask: (taskId) =>
+          getDatabaseStores().sessionStore.listSessionsForTask(taskId),
+        getLatestSessionForTask: (taskId) =>
+          getDatabaseStores().sessionStore.getLatestSessionForTask(taskId),
         computeTaskStatus,
         findFirstConnectedEnvironment,
         startTaskSession,
         reanimateAgent,
-        isOnboarded: () => settingsStore.getSetting("onboarding_completed") === "true",
+        isOnboarded: () =>
+          getDatabaseStores().settingsStore.getSetting("onboarding_completed") === "true",
       }),
     );
   }
@@ -49,9 +52,9 @@ export function createEventSubscribers(ctx: PluginContext): Disposable[] {
   // root-task autostart flag above (which gates the *system* root task).
   factories.push((pluginCtx) =>
     createAgentRootTaskSubscriber(pluginCtx, {
-      getAgent: agentStore.getAgent,
-      getRootTaskForAgent: taskStore.getRootTaskForAgent,
-      insertTask: taskStore.insertTask,
+      getAgent: (id) => getDatabaseStores().agentStore.getAgent(id),
+      getRootTaskForAgent: (agentId) => getDatabaseStores().taskStore.getRootTaskForAgent(agentId),
+      insertTask: (task) => getDatabaseStores().taskStore.insertTask(task),
       newId: () => randomUUID(),
     }),
   );

--- a/packages/server/src/reconciliation-setup.test.ts
+++ b/packages/server/src/reconciliation-setup.test.ts
@@ -56,46 +56,61 @@ vi.mock("@grackle-ai/common", () => ({
   })),
 }));
 
-vi.mock("@grackle-ai/database", () => ({
-  taskStore: {
+vi.mock("@grackle-ai/database", () => {
+  const taskStore = {
     createTask: vi.fn(),
     setTaskScheduleId: vi.fn(),
     getTask: vi.fn(),
     listTasks: vi.fn(() => []),
     areDependenciesMet: vi.fn(() => true),
     reparentTask: vi.fn(),
-  },
-  workspaceStore: {
+  };
+  const workspaceStore = {
     listWorkspaces: vi.fn(() => []),
     getWorkspace: vi.fn(),
-  },
-  personaStore: {
-    getPersona: vi.fn(),
-  },
-  envRegistry: {
+  };
+  const personaStore = { getPersona: vi.fn() };
+  const envRegistry = {
     getEnvironment: vi.fn(),
     listEnvironments: vi.fn(() => []),
     updateEnvironmentStatus: vi.fn(),
-  },
-  sessionStore: {
+  };
+  const sessionStore = {
     countActiveForEnvironment: vi.fn(() => 0),
     getActiveSessionsForTask: vi.fn(() => []),
     listSessionsForTask: vi.fn(() => []),
     listRunningSubagentChildren: vi.fn(() => []),
     getSession: vi.fn(),
-  },
-  settingsStore: {
-    getSetting: vi.fn(),
-  },
-  dispatchQueueStore: {
+  };
+  const settingsStore = { getSetting: vi.fn() };
+  const dispatchQueueStore = {
     listPending: vi.fn(() => []),
     dequeue: vi.fn(),
     enqueue: vi.fn(),
-  },
-  workspaceEnvironmentLinkStore: {
-    getLinkedEnvironmentIds: vi.fn(() => []),
-  },
-}));
+  };
+  const workspaceEnvironmentLinkStore = { getLinkedEnvironmentIds: vi.fn(() => []) };
+  const stores = {
+    taskStore,
+    workspaceStore,
+    personaStore,
+    envRegistry,
+    sessionStore,
+    settingsStore,
+    dispatchQueueStore,
+    workspaceEnvironmentLinkStore,
+  };
+  return {
+    taskStore,
+    workspaceStore,
+    personaStore,
+    envRegistry,
+    sessionStore,
+    settingsStore,
+    dispatchQueueStore,
+    workspaceEnvironmentLinkStore,
+    getDatabaseStores: () => stores,
+  };
+});
 
 import { createCoreReconciliationPhases } from "./reconciliation-setup.js";
 

--- a/packages/server/src/reconciliation-setup.ts
+++ b/packages/server/src/reconciliation-setup.ts
@@ -50,13 +50,14 @@ export function createCoreReconciliationPhases(): ReconciliationPhase[] {
       const row = getDatabaseStores().taskStore.getTask(id);
       return row ? toTaskModel(row) : undefined;
     },
-    hasCapacity: (environmentId: string): boolean =>
-      hasCapacity(environmentId, {
-        countActiveForEnvironment: (envId) =>
-          getDatabaseStores().sessionStore.countActiveForEnvironment(envId),
-        getEnvironment: (id) => getDatabaseStores().envRegistry.getEnvironment(id),
-        getSetting: (key) => getDatabaseStores().settingsStore.getSetting(key),
-      }),
+    hasCapacity: (environmentId: string): boolean => {
+      const { sessionStore, envRegistry, settingsStore } = getDatabaseStores();
+      return hasCapacity(environmentId, {
+        countActiveForEnvironment: (envId) => sessionStore.countActiveForEnvironment(envId),
+        getEnvironment: (id) => envRegistry.getEnvironment(id),
+        getSetting: (key) => settingsStore.getSetting(key),
+      });
+    },
     environmentExists: (id: string): boolean =>
       getDatabaseStores().envRegistry.getEnvironment(id) !== undefined,
     isTaskEligible: (taskId: string): boolean => {

--- a/packages/server/src/reconciliation-setup.ts
+++ b/packages/server/src/reconciliation-setup.ts
@@ -21,14 +21,7 @@ import {
   createSubagentReconciliationPhase,
 } from "@grackle-ai/plugin-core";
 import { TASK_STATUS, ROOT_TASK_ID } from "@grackle-ai/common";
-import {
-  taskStore,
-  envRegistry,
-  sessionStore,
-  settingsStore,
-  dispatchQueueStore,
-  workspaceEnvironmentLinkStore,
-} from "@grackle-ai/database";
+import { getDatabaseStores } from "@grackle-ai/database";
 
 /**
  * Assemble the ordered list of core reconciliation phases for the server.
@@ -42,31 +35,35 @@ import {
  */
 export function createCoreReconciliationPhases(): ReconciliationPhase[] {
   const environmentReconciliationPhase = createEnvironmentReconciliationPhase({
-    listEnvironments: envRegistry.listEnvironments,
+    listEnvironments: () => getDatabaseStores().envRegistry.listEnvironments(),
     listConnectionIds: () => new Set(listConnections().keys()),
-    updateEnvironmentStatus: envRegistry.updateEnvironmentStatus,
+    updateEnvironmentStatus: (id, status) =>
+      getDatabaseStores().envRegistry.updateEnvironmentStatus(id, status),
     removeConnection,
     emit,
   });
 
   const dispatchPhase = createDispatchPhase({
-    listPendingEntries: dispatchQueueStore.listPending,
-    dequeueEntry: dispatchQueueStore.dequeue,
+    listPendingEntries: () => getDatabaseStores().dispatchQueueStore.listPending(),
+    dequeueEntry: (id) => getDatabaseStores().dispatchQueueStore.dequeue(id),
     getTask: (id: string) => {
-      const row = taskStore.getTask(id);
+      const row = getDatabaseStores().taskStore.getTask(id);
       return row ? toTaskModel(row) : undefined;
     },
     hasCapacity: (environmentId: string): boolean =>
       hasCapacity(environmentId, {
-        countActiveForEnvironment: sessionStore.countActiveForEnvironment,
-        getEnvironment: (id) => envRegistry.getEnvironment(id),
-        getSetting: settingsStore.getSetting,
+        countActiveForEnvironment: (envId) =>
+          getDatabaseStores().sessionStore.countActiveForEnvironment(envId),
+        getEnvironment: (id) => getDatabaseStores().envRegistry.getEnvironment(id),
+        getSetting: (key) => getDatabaseStores().settingsStore.getSetting(key),
       }),
-    environmentExists: (id: string): boolean => envRegistry.getEnvironment(id) !== undefined,
+    environmentExists: (id: string): boolean =>
+      getDatabaseStores().envRegistry.getEnvironment(id) !== undefined,
     isTaskEligible: (taskId: string): boolean => {
       if (!taskService.areDependenciesMet(taskId)) {
         return false;
       }
+      const { taskStore, sessionStore } = getDatabaseStores();
       const task = taskStore.getTask(taskId);
       if (!task) {
         return false;
@@ -83,15 +80,18 @@ export function createCoreReconciliationPhases(): ReconciliationPhase[] {
     },
     startTaskSession,
     isEnvironmentConnected: (id: string): boolean => {
-      const env = envRegistry.getEnvironment(id);
+      const env = getDatabaseStores().envRegistry.getEnvironment(id);
       return env?.status === "connected";
     },
     resolveEnvironment: (task) => {
       const resolved = resolveDispatchEnvironment(task, {
         resolveAncestorEnvironmentId,
-        getLinkedEnvironmentIds: workspaceEnvironmentLinkStore.getLinkedEnvironmentIds,
-        isEnvironmentConnected: (id) => envRegistry.getEnvironment(id)?.status === "connected",
-        countActiveForEnvironment: sessionStore.countActiveForEnvironment,
+        getLinkedEnvironmentIds: (wsId) =>
+          getDatabaseStores().workspaceEnvironmentLinkStore.getLinkedEnvironmentIds(wsId),
+        isEnvironmentConnected: (id) =>
+          getDatabaseStores().envRegistry.getEnvironment(id)?.status === "connected",
+        countActiveForEnvironment: (envId) =>
+          getDatabaseStores().sessionStore.countActiveForEnvironment(envId),
         findFirstConnectedEnvironment,
       });
       if (resolved) {
@@ -105,8 +105,9 @@ export function createCoreReconciliationPhases(): ReconciliationPhase[] {
   });
 
   const subagentReconciliationPhase = createSubagentReconciliationPhase({
-    listRunningSubagentChildren: sessionStore.listRunningSubagentChildren,
-    getSession: sessionStore.getSession,
+    listRunningSubagentChildren: () =>
+      getDatabaseStores().sessionStore.listRunningSubagentChildren(),
+    getSession: (id) => getDatabaseStores().sessionStore.getSession(id),
     interruptChildSession,
   });
 

--- a/packages/server/src/scheduling-plugin.test.ts
+++ b/packages/server/src/scheduling-plugin.test.ts
@@ -5,18 +5,35 @@ import type { Logger } from "pino";
 // ── Mock external dependencies used by the real scheduling plugin ─────────────
 // (The real createSchedulingPlugin() is imported below — no mock of the plugin itself)
 
-vi.mock("@grackle-ai/database", () => ({
-  scheduleStore: {
+vi.mock("@grackle-ai/database", () => {
+  const scheduleStore = {
     getDueSchedules: vi.fn(),
     advanceSchedule: vi.fn(),
     setScheduleEnabled: vi.fn(),
-  },
-  taskStore: { createTask: vi.fn(), setTaskScheduleId: vi.fn(), getTask: vi.fn() },
-  personaStore: { getPersona: vi.fn() },
-  agentStore: { getAgent: vi.fn() },
-  sessionStore: { getLatestSessionForTask: vi.fn() },
-  dispatchQueueStore: { enqueue: vi.fn() },
-}));
+  };
+  const taskStore = { createTask: vi.fn(), setTaskScheduleId: vi.fn(), getTask: vi.fn() };
+  const personaStore = { getPersona: vi.fn() };
+  const agentStore = { getAgent: vi.fn() };
+  const sessionStore = { getLatestSessionForTask: vi.fn() };
+  const dispatchQueueStore = { enqueue: vi.fn() };
+  const stores = {
+    scheduleStore,
+    taskStore,
+    personaStore,
+    agentStore,
+    sessionStore,
+    dispatchQueueStore,
+  };
+  return {
+    scheduleStore,
+    taskStore,
+    personaStore,
+    agentStore,
+    sessionStore,
+    dispatchQueueStore,
+    getDatabaseStores: () => stores,
+  };
+});
 
 // Heartbeat branch (#1438) pulls in core helpers. Mock the surface to avoid
 // loading the real event-bus, which imports SequencedLog from common.


### PR DESCRIPTION
## Summary
- Replaces direct `import { storeX } from "@grackle-ai/database"` singleton imports with `getDatabaseStores()` registry calls across the four remaining store-consuming packages: `plugin-scheduling`, `plugin-orchestration`, `plugin-knowledge`, and `server`
- Updates 10 production files and 7 test files; test mocks converted to factory-function pattern that exports `getDatabaseStores: () => stores` alongside named mocks for `vi.mocked()` compatibility
- `database-init.ts`, `index.ts`, and `local-environment.ts` intentionally left untouched (ordering constraint: `database-init` runs before `setDatabaseStores()`, `index.ts` is the composition root, `local-environment.ts` already uses constructor DI)

## Test plan
- [x] `rush test -t @grackle-ai/plugin-scheduling` — 76 passed (5 files)
- [x] `rush test -t @grackle-ai/plugin-orchestration` — 5 passed (1 file)
- [x] `rush test -t @grackle-ai/plugin-knowledge` — 98 passed, 2 skipped (12 files)
- [x] `rush test -t @grackle-ai/server` — 156 passed (15 files)
- [x] `rush build -t @grackle-ai/server` — SUCCESS (no warnings)
- [ ] CI green

Closes #1551